### PR TITLE
Bump typography sizes for readability

### DIFF
--- a/src/board.tsx
+++ b/src/board.tsx
@@ -52,7 +52,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
     });
     return f;
   });
-  const [scale, setScale] = useState(0.7);
+  const [scale, setScale] = useState(0.9);
   const [pan, setPan] = useState({ x: 0, y: 0 });
   const [panning, setPanning] = useState(false);
   const [connectMode, setConnectMode] = useState(false);
@@ -391,7 +391,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
           <button onClick={() => zoomBy(0.1)} title="Zoom in">+</button>
           <div className="zoom-val">{Math.round(scale * 100)}%</div>
           <button onClick={() => zoomBy(-0.1)} title="Zoom out">−</button>
-          <button onClick={() => { setScale(0.7); setPan({ x: 0, y: 0 }); }} title="Reset view" style={{ fontSize: 11, fontFamily: "var(--font-fell-sc)" }}>⟲</button>
+          <button onClick={() => { setScale(0.9); setPan({ x: 0, y: 0 }); }} title="Reset view" style={{ fontSize: 11, fontFamily: "var(--font-fell-sc)" }}>⟲</button>
         </div>
       </div>
     </>

--- a/src/styles.css
+++ b/src/styles.css
@@ -76,6 +76,7 @@
   --board-bg:      #1a1120;
   --teal-oxidized: #6bb5a5;
   --bloodred:      #c63d2f;
+  --bloodred-deep: #e05a4a;
   --mustard:       #d4a728;
 }
 [data-theme="modern"] {
@@ -104,7 +105,7 @@ body {
   color: var(--ink-body);
   background: var(--vellum);
   overflow: hidden;
-  font-size: 14px;
+  font-size: 15px;
   line-height: 1.5;
 }
 
@@ -238,7 +239,7 @@ body {
 .logo-sub {
   font-family: var(--font-fell);
   font-style: italic;
-  font-size: 11px;
+  font-size: 12px;
   color: var(--ink-faded);
   margin-top: -2px;
   letter-spacing: .02em;
@@ -259,7 +260,7 @@ body {
   border: 1px solid var(--vellum-deep);
   border-radius: 20px;
   font-family: var(--font-fell);
-  font-size: 13px;
+  font-size: 14px;
   color: var(--ink);
   box-shadow: 0 1px 2px rgba(40,20,5,.12);
   white-space: nowrap;
@@ -303,7 +304,7 @@ body {
 
 .btn {
   font-family: var(--font-ui);
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 500;
   padding: 7px 14px;
   border-radius: 4px;
@@ -347,8 +348,8 @@ body {
 }
 .sidebar-label {
   font-family: var(--font-fell-sc);
-  font-size: 10px;
-  letter-spacing: .18em;
+  font-size: 11px;
+  letter-spacing: .16em;
   color: var(--ink-faded);
   padding: 8px 16px 4px;
   display: flex; align-items: center; justify-content: space-between;
@@ -403,14 +404,14 @@ body {
   display: flex; align-items: center; gap: 8px;
   padding: 6px 16px 6px 20px;
   font-family: var(--font-fell);
-  font-size: 13px;
+  font-size: 14px;
   color: var(--ink-faded);
   cursor: pointer;
 }
 .session-chip:hover { background: rgba(139,94,40,.06); }
 .session-chip .num {
   font-family: var(--font-fell-sc);
-  font-size: 10px;
+  font-size: 11px;
   background: var(--paper-cream);
   border: 1px solid var(--vellum-deep);
   padding: 2px 6px;
@@ -588,8 +589,8 @@ body {
 }
 .card-poster .wanted {
   font-family: var(--font-fell-sc);
-  font-size: 11px;
-  letter-spacing: .22em;
+  font-size: 12px;
+  letter-spacing: .16em;
   color: var(--bloodred-deep);
   text-align: center;
   padding: 2px 0 6px;
@@ -604,7 +605,7 @@ body {
   display: grid; place-items: center;
   color: var(--ink-faded);
   font-family: var(--font-fell);
-  font-size: 11px;
+  font-size: 12px;
   position: relative;
 }
 .card-poster .portrait .silhouette {
@@ -627,8 +628,8 @@ body {
 }
 .card-poster .name {
   font-family: var(--font-fell-sc);
-  font-size: 14px;
-  letter-spacing: .12em;
+  font-size: 16px;
+  letter-spacing: .1em;
   text-align: center;
   margin-top: 10px;
   color: var(--ink);
@@ -646,7 +647,7 @@ body {
   padding-top: 8px;
   border-top: 1px dashed var(--ink-ghost);
   font-family: var(--font-fell);
-  font-size: 11px;
+  font-size: 12px;
   color: var(--ink-body);
   display: flex; justify-content: space-between;
 }
@@ -673,8 +674,8 @@ body {
 }
 .card-quest .quest-tag {
   font-family: var(--font-fell-sc);
-  font-size: 9px;
-  letter-spacing: .2em;
+  font-size: 11px;
+  letter-spacing: .16em;
   color: var(--bloodred-deep);
 }
 .card-quest .quest-title {
@@ -687,15 +688,15 @@ body {
 }
 .card-quest .quest-desc {
   font-family: var(--font-fell);
-  font-size: 13px;
+  font-size: 14px;
   font-style: italic;
   color: var(--ink-faded);
-  line-height: 1.3;
+  line-height: 1.35;
 }
 .card-quest .quest-meta {
   display: flex; gap: 8px; align-items: center; margin-top: 10px;
   font-family: var(--font-ui);
-  font-size: 10px;
+  font-size: 11px;
   color: var(--ink-faded);
   text-transform: uppercase;
   letter-spacing: .1em;
@@ -727,8 +728,8 @@ body {
 }
 .card-location .loc-type {
   font-family: var(--font-fell-sc);
-  font-size: 9px;
-  letter-spacing: .2em;
+  font-size: 11px;
+  letter-spacing: .16em;
   color: var(--teal-deep);
 }
 .card-location .loc-name {
@@ -741,7 +742,7 @@ body {
 .card-location .loc-desc {
   font-family: var(--font-fell);
   font-style: italic;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--ink-faded);
 }
 
@@ -757,8 +758,8 @@ body {
 }
 .card-goal .goal-kind {
   font-family: var(--font-fell-sc);
-  font-size: 9px;
-  letter-spacing: .2em;
+  font-size: 11px;
+  letter-spacing: .16em;
   color: var(--mustard);
 }
 .card-goal .goal-text {
@@ -771,7 +772,7 @@ body {
 .card-goal .goal-owner {
   font-family: var(--font-fell);
   font-style: italic;
-  font-size: 11px;
+  font-size: 12px;
   color: var(--ink-faded);
   margin-top: 8px;
 }
@@ -807,7 +808,7 @@ body {
 .card-faction .f-sub {
   font-family: var(--font-fell);
   font-style: italic;
-  font-size: 11px;
+  font-size: 12px;
   color: var(--ink-faded);
   margin-top: 3px;
 }
@@ -822,8 +823,8 @@ body {
 }
 .card-item .i-label {
   font-family: var(--font-fell-sc);
-  font-size: 9px;
-  letter-spacing: .2em;
+  font-size: 11px;
+  letter-spacing: .16em;
   color: var(--mustard);
 }
 .card-item .i-name {
@@ -836,7 +837,7 @@ body {
 .card-item .i-desc {
   font-family: var(--font-fell);
   font-style: italic;
-  font-size: 11px;
+  font-size: 12px;
   color: var(--ink-faded);
   margin-top: 3px;
 }
@@ -852,14 +853,14 @@ body {
 }
 .card-lore .l-label {
   font-family: var(--font-fell-sc);
-  font-size: 9px;
-  letter-spacing: .2em;
+  font-size: 11px;
+  letter-spacing: .16em;
   color: var(--forest);
 }
 .card-lore .l-text {
   font-family: var(--font-fell);
   font-style: italic;
-  font-size: 12.5px;
+  font-size: 13.5px;
   line-height: 1.3;
   color: var(--ink);
   margin-top: 4px;
@@ -883,7 +884,7 @@ body {
 }
 .card-note .n-author {
   font-family: var(--font-script);
-  font-size: 11px;
+  font-size: 12px;
   color: #8a7230;
   margin-top: 6px;
   text-align: right;
@@ -1033,8 +1034,8 @@ body {
 }
 .stat .stat-label {
   font-family: var(--font-fell-sc);
-  font-size: 9px;
-  letter-spacing: .18em;
+  font-size: 11px;
+  letter-spacing: .16em;
   color: var(--ink-faded);
 }
 .stat .stat-value {
@@ -1048,7 +1049,7 @@ body {
 .stat .stat-sub {
   font-family: var(--font-fell);
   font-style: italic;
-  font-size: 11px;
+  font-size: 12px;
   color: var(--ink-faded);
 }
 
@@ -1105,9 +1106,9 @@ body {
 }
 .note-scrap .meta {
   font-family: var(--font-ui);
-  font-size: 10px;
+  font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: .1em;
+  letter-spacing: .08em;
   color: var(--ink-faded);
   margin-top: 10px;
   display: flex; justify-content: space-between;
@@ -1122,7 +1123,7 @@ body {
   cursor: text;
   font-family: var(--font-fell);
   font-style: italic;
-  font-size: 13px;
+  font-size: 14px;
   color: var(--ink-ghost);
 }
 .add-note:focus {
@@ -1144,8 +1145,8 @@ body {
 .rail-section { margin-bottom: 22px; }
 .rail-section h4 {
   font-family: var(--font-fell-sc);
-  font-size: 10px;
-  letter-spacing: .2em;
+  font-size: 11px;
+  letter-spacing: .16em;
   color: var(--ink-faded);
   margin: 0 0 10px;
 }
@@ -1171,15 +1172,15 @@ body {
 }
 .rail-chip .rc-name {
   font-family: var(--font-fell);
-  font-size: 13px;
+  font-size: 14px;
   color: var(--ink);
-  line-height: 1.1;
+  line-height: 1.15;
 }
 .rail-chip .rc-rel {
   font-family: var(--font-ui);
-  font-size: 9px;
+  font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: .1em;
+  letter-spacing: .08em;
   color: var(--ink-faded);
 }
 .rail-chip.people  { border-left-color: var(--bloodred); }
@@ -1211,8 +1212,8 @@ body {
   display: inline-flex; align-items: center; gap: 6px;
   padding: 3px 9px;
   font-family: var(--font-fell-sc);
-  font-size: 10px;
-  letter-spacing: .14em;
+  font-size: 11px;
+  letter-spacing: .12em;
   border: 1px solid;
   border-radius: 2px;
   line-height: 1.3;
@@ -1251,9 +1252,9 @@ body {
 .tweaks-panel .body { padding: 14px; display: flex; flex-direction: column; gap: 14px; }
 .tweak-row label {
   display: block;
-  font-size: 10px;
+  font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: .12em;
+  letter-spacing: .1em;
   color: var(--ink-faded);
   margin-bottom: 6px;
 }
@@ -1319,7 +1320,7 @@ body {
 .board-zoom button:hover { background: var(--vellum-light); }
 .board-zoom .zoom-val {
   font-family: var(--font-ui);
-  font-size: 10px;
+  font-size: 11px;
   text-align: center;
   padding: 4px 0;
   color: var(--ink-faded);
@@ -1358,8 +1359,8 @@ body {
   background: var(--bloodred);
   color: var(--paper-cream);
   font-family: var(--font-fell-sc);
-  font-size: 10px;
-  letter-spacing: .15em;
+  font-size: 11px;
+  letter-spacing: .12em;
   clip-path: polygon(4px 0, 100% 0, calc(100% - 4px) 100%, 0 100%);
 }
 


### PR DESCRIPTION
## Summary
- Bump body base 14→15px; raise 9–10px labels to 11px (with tighter tracking) and 11–13px body copy up a notch so descriptions, relation names, and chronicle text read comfortably.
- Override \`--bloodred-deep\` in the grimoire dark theme (\`#6a1e16\` → \`#e05a4a\`) — the old deep red had almost no contrast on dark cards, making the "Of Note" / "Wanted" banner unreadable. Also enlarges the banner itself (11→12px, looser→tighter tracking) and the card name (14→16px).
- Raise notice-board default zoom from 0.7 to 0.9 so card text isn't rendered 30% smaller than its CSS value.

## Test plan
- [ ] Open the Notice Board — confirm default zoom is 90% and card titles/descriptions read clearly
- [ ] Open Known People list — "Of Note" / "Wanted" / "Known Ally" banner visible in orange on dark cards; names read larger
- [ ] Open a person detail sheet — stat labels, relation chips, and chronicle body sized comfortably
- [ ] Toggle to modern theme — no regression (grimoire-only override doesn't leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)