### PR TITLE
Add global Cmd+K / Ctrl+K command palette

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { CampaignProvider } from "./campaignContext";
 import { AuthProvider, DisplayNameGate } from "./auth";
 import { useCampaignStatus, useKinds } from "./hooks";
@@ -6,6 +6,7 @@ import { Icon } from "./icons";
 import { Sidebar, Topbar } from "./components";
 import { NoticeBoard, KindList } from "./board";
 import { DetailSheet } from "./detail";
+import { CommandPalette, useCommandPaletteHotkey } from "./commandPalette";
 
 function LoadingSheet() {
   return (
@@ -57,6 +58,10 @@ function AppLoaded() {
   const [openId, setOpenId] = useState<string | null>(null);
   const [tweaksOpen, setTweaksOpen] = useState(false);
   const [shareToast, setShareToast] = useState(false);
+  const [paletteOpen, setPaletteOpen] = useState(false);
+
+  const togglePalette = useCallback(() => setPaletteOpen((o) => !o), []);
+  useCommandPaletteHotkey(togglePalette);
 
   useEffect(() => {
     document.documentElement.setAttribute("data-theme", theme);
@@ -108,6 +113,12 @@ function AppLoaded() {
           onOpen={(id) => setOpenId(id)}
         />
       )}
+
+      <CommandPalette
+        open={paletteOpen}
+        onClose={() => setPaletteOpen(false)}
+        onOpenEntity={(id) => { setOpenId(id); setPaletteOpen(false); }}
+      />
 
       {shareToast && (
         <div style={{

--- a/src/board.tsx
+++ b/src/board.tsx
@@ -52,7 +52,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
     });
     return f;
   });
-  const [scale, setScale] = useState(0.7);
+  const [scale, setScale] = useState(0.9);
   const [pan, setPan] = useState({ x: 0, y: 0 });
   const [panning, setPanning] = useState(false);
   const [connectMode, setConnectMode] = useState(false);
@@ -391,7 +391,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
           <button onClick={() => zoomBy(0.1)} title="Zoom in">+</button>
           <div className="zoom-val">{Math.round(scale * 100)}%</div>
           <button onClick={() => zoomBy(-0.1)} title="Zoom out">−</button>
-          <button onClick={() => { setScale(0.7); setPan({ x: 0, y: 0 }); }} title="Reset view" style={{ fontSize: 11, fontFamily: "var(--font-fell-sc)" }}>⟲</button>
+          <button onClick={() => { setScale(0.9); setPan({ x: 0, y: 0 }); }} title="Reset view" style={{ fontSize: 11, fontFamily: "var(--font-fell-sc)" }}>⟲</button>
         </div>
       </div>
     </>

--- a/src/commandPalette.tsx
+++ b/src/commandPalette.tsx
@@ -1,0 +1,336 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCampaign } from "./hooks";
+import { entityLabel, type Campaign, type KindKey } from "./data";
+import { Icon } from "./icons";
+
+type MatchSource = "primary" | "secondary" | "note";
+
+interface PaletteHit {
+  id: string;
+  kind: KindKey;
+  label: string;
+  snippet?: string;
+  matchSource: MatchSource;
+  rank: 0 | 1 | 2 | 3;
+}
+
+const KIND_ICON: Record<KindKey, "people" | "location" | "quest" | "goal" | "faction" | "item" | "lore" | "session"> = {
+  people: "people",
+  locations: "location",
+  quests: "quest",
+  goals: "goal",
+  factions: "faction",
+  items: "item",
+  lore: "lore",
+  sessions: "session",
+};
+
+const KIND_LABEL: Record<KindKey, string> = {
+  people: "Person",
+  locations: "Location",
+  quests: "Quest",
+  goals: "Goal",
+  factions: "Faction",
+  items: "Item",
+  lore: "Lore",
+  sessions: "Session",
+};
+
+interface Indexed {
+  id: string;
+  kind: KindKey;
+  label: string;
+  primary: string;
+  secondary: string;
+}
+
+function joinFields(...parts: Array<string | number | null | undefined>): string {
+  return parts.filter((p) => p !== undefined && p !== null && p !== "").join(" · ");
+}
+
+function buildIndex(campaign: Campaign): Indexed[] {
+  const out: Indexed[] = [];
+  for (const p of campaign.people) {
+    out.push({
+      id: p.id,
+      kind: "people",
+      label: entityLabel(p),
+      primary: p.name ?? "",
+      secondary: joinFields(p.epithet, p.race, p.role, p.disposition, p.alignment, p.notes),
+    });
+  }
+  for (const l of campaign.locations) {
+    out.push({
+      id: l.id,
+      kind: "locations",
+      label: entityLabel(l),
+      primary: l.name ?? "",
+      secondary: joinFields(l.kind, l.region, l.ruler, l.desc, l.notes),
+    });
+  }
+  for (const q of campaign.quests) {
+    out.push({
+      id: q.id,
+      kind: "quests",
+      label: entityLabel(q),
+      primary: q.title ?? "",
+      secondary: joinFields(q.status, q.reward, q.desc, q.hooks),
+    });
+  }
+  for (const g of campaign.goals) {
+    out.push({
+      id: g.id,
+      kind: "goals",
+      label: entityLabel(g),
+      primary: g.text ?? "",
+      secondary: joinFields(g.owner, g.kind, g.status),
+    });
+  }
+  for (const f of campaign.factions) {
+    out.push({
+      id: f.id,
+      kind: "factions",
+      label: entityLabel(f),
+      primary: f.name ?? "",
+      secondary: joinFields(f.sigil, f.desc, f.allegiance),
+    });
+  }
+  for (const i of campaign.items) {
+    out.push({
+      id: i.id,
+      kind: "items",
+      label: entityLabel(i),
+      primary: i.name ?? "",
+      secondary: joinFields(i.kind, i.desc),
+    });
+  }
+  for (const lo of campaign.lore) {
+    out.push({
+      id: lo.id,
+      kind: "lore",
+      label: entityLabel(lo),
+      primary: lo.title ?? "",
+      secondary: lo.text ?? "",
+    });
+  }
+  for (const s of campaign.sessions) {
+    out.push({
+      id: s.id,
+      kind: "sessions",
+      label: entityLabel(s),
+      primary: s.title ?? "",
+      secondary: joinFields(s.date, `Session ${s.num}`),
+    });
+  }
+  return out;
+}
+
+function makeSnippet(source: string, queryLower: string): string {
+  const idx = source.toLowerCase().indexOf(queryLower);
+  if (idx < 0) return source.slice(0, 90);
+  const start = Math.max(0, idx - 30);
+  const end = Math.min(source.length, idx + queryLower.length + 40);
+  const prefix = start > 0 ? "…" : "";
+  const suffix = end < source.length ? "…" : "";
+  const core = source.slice(start, end);
+  const snippet = `${prefix}${core}${suffix}`;
+  return snippet.length > 100 ? `${snippet.slice(0, 97)}…` : snippet;
+}
+
+function searchHits(index: Indexed[], campaign: Campaign, query: string): PaletteHit[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+
+  const best = new Map<string, PaletteHit>();
+  const keepBest = (hit: PaletteHit) => {
+    const prev = best.get(hit.id);
+    if (!prev || hit.rank < prev.rank) best.set(hit.id, hit);
+  };
+
+  for (const e of index) {
+    const primary = e.primary.toLowerCase();
+    if (primary.startsWith(q)) {
+      keepBest({ id: e.id, kind: e.kind, label: e.label, matchSource: "primary", rank: 0 });
+      continue;
+    }
+    if (primary.includes(q)) {
+      keepBest({ id: e.id, kind: e.kind, label: e.label, matchSource: "primary", rank: 1 });
+      continue;
+    }
+    const secondary = e.secondary.toLowerCase();
+    if (secondary.includes(q)) {
+      keepBest({
+        id: e.id,
+        kind: e.kind,
+        label: e.label,
+        snippet: makeSnippet(e.secondary, q),
+        matchSource: "secondary",
+        rank: 2,
+      });
+    }
+  }
+
+  const indexById = new Map(index.map((e) => [e.id, e] as const));
+  for (const [entityId, notes] of Object.entries(campaign.notes)) {
+    const parent = indexById.get(entityId);
+    if (!parent) continue;
+    for (const note of notes) {
+      if (note.text.toLowerCase().includes(q)) {
+        keepBest({
+          id: entityId,
+          kind: parent.kind,
+          label: parent.label,
+          snippet: `${note.author}: ${makeSnippet(note.text, q)}`,
+          matchSource: "note",
+          rank: 3,
+        });
+        break;
+      }
+    }
+  }
+
+  return Array.from(best.values())
+    .sort((a, b) => a.rank - b.rank || a.label.localeCompare(b.label))
+    .slice(0, 30);
+}
+
+export function useCommandPaletteHotkey(onToggle: () => void) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
+        e.preventDefault();
+        onToggle();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onToggle]);
+}
+
+interface CommandPaletteProps {
+  open: boolean;
+  onClose: () => void;
+  onOpenEntity: (id: string) => void;
+}
+
+export function CommandPalette({ open, onClose, onOpenEntity }: CommandPaletteProps) {
+  const campaign = useCampaign();
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState(0);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+
+  const index = useMemo(() => buildIndex(campaign), [campaign]);
+  const results = useMemo(() => searchHits(index, campaign, query), [index, campaign, query]);
+
+  useEffect(() => { setSelected(0); }, [query]);
+
+  useEffect(() => {
+    if (!open) return;
+    previouslyFocused.current = document.activeElement as HTMLElement | null;
+    setQuery("");
+    setSelected(0);
+    const t = window.setTimeout(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }, 0);
+    return () => {
+      window.clearTimeout(t);
+      previouslyFocused.current?.focus?.();
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !listRef.current) return;
+    const active = listRef.current.querySelector<HTMLElement>(`[data-idx="${selected}"]`);
+    active?.scrollIntoView({ block: "nearest" });
+  }, [selected, open, results.length]);
+
+  const choose = useCallback((hit: PaletteHit | undefined) => {
+    if (!hit) return;
+    onOpenEntity(hit.id);
+  }, [onOpenEntity]);
+
+  if (!open) return null;
+
+  const handleKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
+    if (e.nativeEvent.isComposing || e.keyCode === 229) return;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (results.length === 0) return;
+      setSelected((i) => (i + 1) % results.length);
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (results.length === 0) return;
+      setSelected((i) => (i - 1 + results.length) % results.length);
+      return;
+    }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      choose(results[selected]);
+    }
+  };
+
+  return (
+    <div className="cmdk-overlay" onMouseDown={onClose} role="dialog" aria-label="Search">
+      <div className="cmdk-panel" onMouseDown={(e) => e.stopPropagation()}>
+        <div className="cmdk-input-row">
+          <Icon name="search" size={16} />
+          <input
+            ref={inputRef}
+            className="cmdk-input"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Search the codex…"
+            spellCheck={false}
+            autoComplete="off"
+          />
+        </div>
+        <div className="cmdk-list" ref={listRef}>
+          {query.trim() === "" && (
+            <div className="cmdk-empty">Type to search people, places, quests, goals, factions, items, lore, sessions, and party notes.</div>
+          )}
+          {query.trim() !== "" && results.length === 0 && (
+            <div className="cmdk-empty">Nothing in the codex matches "{query}".</div>
+          )}
+          {results.map((hit, i) => (
+            <button
+              key={`${hit.id}:${hit.matchSource}`}
+              data-idx={i}
+              className={`cmdk-row${i === selected ? " active" : ""}`}
+              onMouseEnter={() => setSelected(i)}
+              onClick={() => choose(hit)}
+              type="button"
+            >
+              <Icon name={KIND_ICON[hit.kind]} size={16} />
+              <div className="cmdk-row-text">
+                <div className="cmdk-row-label">{hit.label}</div>
+                {hit.snippet && (
+                  <div className="cmdk-snippet">
+                    {hit.matchSource === "note" ? <span className="cmdk-snippet-tag">note · </span> : null}
+                    {hit.snippet}
+                  </div>
+                )}
+              </div>
+              <span className="cmdk-kind">{KIND_LABEL[hit.kind]}</span>
+            </button>
+          ))}
+        </div>
+        <div className="cmdk-hint">
+          <span>↑↓ navigate</span>
+          <span>↵ open</span>
+          <span>esc close</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1392,3 +1392,118 @@ body {
 .mt-8 { margin-top: 8px; }
 .mt-12 { margin-top: 12px; }
 .center { display: grid; place-items: center; }
+
+/* Command palette (Cmd+K / Ctrl+K) */
+.cmdk-overlay {
+  position: fixed; inset: 0;
+  background: rgba(40, 20, 5, .35);
+  backdrop-filter: blur(2px);
+  display: grid; place-items: start center;
+  padding-top: 14vh;
+  z-index: 80;
+}
+.cmdk-panel {
+  width: min(640px, 92vw);
+  max-height: 66vh;
+  display: flex; flex-direction: column;
+  background: var(--vellum-light);
+  border: 1px solid var(--ink-ghost);
+  border-radius: 2px;
+  box-shadow: var(--shadow-deep);
+  overflow: hidden;
+}
+.cmdk-input-row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 12px 16px;
+  color: var(--ink-faded);
+  border-bottom: 1px dashed var(--ink-ghost);
+}
+.cmdk-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-family: var(--font-fell);
+  font-style: italic;
+  font-size: 17px;
+  color: var(--ink);
+  padding: 2px 0;
+}
+.cmdk-input::placeholder {
+  color: var(--ink-ghost);
+  font-style: italic;
+}
+.cmdk-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 6px 0;
+}
+.cmdk-empty {
+  padding: 18px 20px;
+  font-family: var(--font-fell);
+  font-style: italic;
+  font-size: 14px;
+  color: var(--ink-faded);
+}
+.cmdk-row {
+  width: 100%;
+  display: flex; align-items: center; gap: 12px;
+  padding: 8px 16px;
+  background: transparent;
+  border: none;
+  border-left: 2px solid transparent;
+  text-align: left;
+  cursor: pointer;
+  color: var(--ink);
+  font-family: var(--font-fell);
+  font-size: 15px;
+}
+.cmdk-row.active {
+  background: var(--paper-cream);
+  border-left-color: var(--bloodred);
+}
+.cmdk-row > svg {
+  flex-shrink: 0;
+  color: var(--ink-faded);
+}
+.cmdk-row-text {
+  flex: 1;
+  min-width: 0;
+  display: flex; flex-direction: column; gap: 2px;
+}
+.cmdk-row-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cmdk-snippet {
+  font-size: 12px;
+  color: var(--ink-faded);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-style: italic;
+}
+.cmdk-snippet-tag {
+  font-family: var(--font-fell-sc);
+  font-style: normal;
+  letter-spacing: .15em;
+  color: var(--bloodred);
+  font-size: 10px;
+}
+.cmdk-kind {
+  flex-shrink: 0;
+  font-family: var(--font-fell-sc);
+  letter-spacing: .2em;
+  font-size: 10px;
+  color: var(--ink-faded);
+}
+.cmdk-hint {
+  display: flex; gap: 16px; justify-content: flex-end;
+  padding: 8px 16px;
+  border-top: 1px dashed var(--ink-ghost);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  color: var(--ink-ghost);
+  letter-spacing: .05em;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -76,6 +76,7 @@
   --board-bg:      #1a1120;
   --teal-oxidized: #6bb5a5;
   --bloodred:      #c63d2f;
+  --bloodred-deep: #e05a4a;
   --mustard:       #d4a728;
 }
 [data-theme="modern"] {
@@ -104,7 +105,7 @@ body {
   color: var(--ink-body);
   background: var(--vellum);
   overflow: hidden;
-  font-size: 14px;
+  font-size: 15px;
   line-height: 1.5;
 }
 
@@ -238,7 +239,7 @@ body {
 .logo-sub {
   font-family: var(--font-fell);
   font-style: italic;
-  font-size: 11px;
+  font-size: 12px;
   color: var(--ink-faded);
   margin-top: -2px;
   letter-spacing: .02em;
@@ -259,7 +260,7 @@ body {
   border: 1px solid var(--vellum-deep);
   border-radius: 20px;
   font-family: var(--font-fell);
-  font-size: 13px;
+  font-size: 14px;
   color: var(--ink);
   box-shadow: 0 1px 2px rgba(40,20,5,.12);
   white-space: nowrap;
@@ -303,7 +304,7 @@ body {
 
 .btn {
   font-family: var(--font-ui);
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 500;
   padding: 7px 14px;
   border-radius: 4px;
@@ -347,8 +348,8 @@ body {
 }
 .sidebar-label {
   font-family: var(--font-fell-sc);
-  font-size: 10px;
-  letter-spacing: .18em;
+  font-size: 11px;
+  letter-spacing: .16em;
   color: var(--ink-faded);
   padding: 8px 16px 4px;
   display: flex; align-items: center; justify-content: space-between;
@@ -403,14 +404,14 @@ body {
   display: flex; align-items: center; gap: 8px;
   padding: 6px 16px 6px 20px;
   font-family: var(--font-fell);
-  font-size: 13px;
+  font-size: 14px;
   color: var(--ink-faded);
   cursor: pointer;
 }
 .session-chip:hover { background: rgba(139,94,40,.06); }
 .session-chip .num {
   font-family: var(--font-fell-sc);
-  font-size: 10px;
+  font-size: 11px;
   background: var(--paper-cream);
   border: 1px solid var(--vellum-deep);
   padding: 2px 6px;
@@ -588,8 +589,8 @@ body {
 }
 .card-poster .wanted {
   font-family: var(--font-fell-sc);
-  font-size: 11px;
-  letter-spacing: .22em;
+  font-size: 12px;
+  letter-spacing: .16em;
   color: var(--bloodred-deep);
   text-align: center;
   padding: 2px 0 6px;
@@ -604,7 +605,7 @@ body {
   display: grid; place-items: center;
   color: var(--ink-faded);
   font-family: var(--font-fell);
-  font-size: 11px;
+  font-size: 12px;
   position: relative;
 }
 .card-poster .portrait .silhouette {
@@ -627,8 +628,8 @@ body {
 }
 .card-poster .name {
   font-family: var(--font-fell-sc);
-  font-size: 14px;
-  letter-spacing: .12em;
+  font-size: 16px;
+  letter-spacing: .1em;
   text-align: center;
   margin-top: 10px;
   color: var(--ink);
@@ -646,7 +647,7 @@ body {
   padding-top: 8px;
   border-top: 1px dashed var(--ink-ghost);
   font-family: var(--font-fell);
-  font-size: 11px;
+  font-size: 12px;
   color: var(--ink-body);
   display: flex; justify-content: space-between;
 }
@@ -673,8 +674,8 @@ body {
 }
 .card-quest .quest-tag {
   font-family: var(--font-fell-sc);
-  font-size: 9px;
-  letter-spacing: .2em;
+  font-size: 11px;
+  letter-spacing: .16em;
   color: var(--bloodred-deep);
 }
 .card-quest .quest-title {
@@ -687,15 +688,15 @@ body {
 }
 .card-quest .quest-desc {
   font-family: var(--font-fell);
-  font-size: 13px;
+  font-size: 14px;
   font-style: italic;
   color: var(--ink-faded);
-  line-height: 1.3;
+  line-height: 1.35;
 }
 .card-quest .quest-meta {
   display: flex; gap: 8px; align-items: center; margin-top: 10px;
   font-family: var(--font-ui);
-  font-size: 10px;
+  font-size: 11px;
   color: var(--ink-faded);
   text-transform: uppercase;
   letter-spacing: .1em;
@@ -727,8 +728,8 @@ body {
 }
 .card-location .loc-type {
   font-family: var(--font-fell-sc);
-  font-size: 9px;
-  letter-spacing: .2em;
+  font-size: 11px;
+  letter-spacing: .16em;
   color: var(--teal-deep);
 }
 .card-location .loc-name {
@@ -741,7 +742,7 @@ body {
 .card-location .loc-desc {
   font-family: var(--font-fell);
   font-style: italic;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--ink-faded);
 }
 
@@ -757,8 +758,8 @@ body {
 }
 .card-goal .goal-kind {
   font-family: var(--font-fell-sc);
-  font-size: 9px;
-  letter-spacing: .2em;
+  font-size: 11px;
+  letter-spacing: .16em;
   color: var(--mustard);
 }
 .card-goal .goal-text {
@@ -771,7 +772,7 @@ body {
 .card-goal .goal-owner {
   font-family: var(--font-fell);
   font-style: italic;
-  font-size: 11px;
+  font-size: 12px;
   color: var(--ink-faded);
   margin-top: 8px;
 }
@@ -807,7 +808,7 @@ body {
 .card-faction .f-sub {
   font-family: var(--font-fell);
   font-style: italic;
-  font-size: 11px;
+  font-size: 12px;
   color: var(--ink-faded);
   margin-top: 3px;
 }
@@ -822,8 +823,8 @@ body {
 }
 .card-item .i-label {
   font-family: var(--font-fell-sc);
-  font-size: 9px;
-  letter-spacing: .2em;
+  font-size: 11px;
+  letter-spacing: .16em;
   color: var(--mustard);
 }
 .card-item .i-name {
@@ -836,7 +837,7 @@ body {
 .card-item .i-desc {
   font-family: var(--font-fell);
   font-style: italic;
-  font-size: 11px;
+  font-size: 12px;
   color: var(--ink-faded);
   margin-top: 3px;
 }
@@ -852,14 +853,14 @@ body {
 }
 .card-lore .l-label {
   font-family: var(--font-fell-sc);
-  font-size: 9px;
-  letter-spacing: .2em;
+  font-size: 11px;
+  letter-spacing: .16em;
   color: var(--forest);
 }
 .card-lore .l-text {
   font-family: var(--font-fell);
   font-style: italic;
-  font-size: 12.5px;
+  font-size: 13.5px;
   line-height: 1.3;
   color: var(--ink);
   margin-top: 4px;
@@ -883,7 +884,7 @@ body {
 }
 .card-note .n-author {
   font-family: var(--font-script);
-  font-size: 11px;
+  font-size: 12px;
   color: #8a7230;
   margin-top: 6px;
   text-align: right;
@@ -1033,8 +1034,8 @@ body {
 }
 .stat .stat-label {
   font-family: var(--font-fell-sc);
-  font-size: 9px;
-  letter-spacing: .18em;
+  font-size: 11px;
+  letter-spacing: .16em;
   color: var(--ink-faded);
 }
 .stat .stat-value {
@@ -1048,7 +1049,7 @@ body {
 .stat .stat-sub {
   font-family: var(--font-fell);
   font-style: italic;
-  font-size: 11px;
+  font-size: 12px;
   color: var(--ink-faded);
 }
 
@@ -1105,9 +1106,9 @@ body {
 }
 .note-scrap .meta {
   font-family: var(--font-ui);
-  font-size: 10px;
+  font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: .1em;
+  letter-spacing: .08em;
   color: var(--ink-faded);
   margin-top: 10px;
   display: flex; justify-content: space-between;
@@ -1122,7 +1123,7 @@ body {
   cursor: text;
   font-family: var(--font-fell);
   font-style: italic;
-  font-size: 13px;
+  font-size: 14px;
   color: var(--ink-ghost);
 }
 .add-note:focus {
@@ -1144,8 +1145,8 @@ body {
 .rail-section { margin-bottom: 22px; }
 .rail-section h4 {
   font-family: var(--font-fell-sc);
-  font-size: 10px;
-  letter-spacing: .2em;
+  font-size: 11px;
+  letter-spacing: .16em;
   color: var(--ink-faded);
   margin: 0 0 10px;
 }
@@ -1171,15 +1172,15 @@ body {
 }
 .rail-chip .rc-name {
   font-family: var(--font-fell);
-  font-size: 13px;
+  font-size: 14px;
   color: var(--ink);
-  line-height: 1.1;
+  line-height: 1.15;
 }
 .rail-chip .rc-rel {
   font-family: var(--font-ui);
-  font-size: 9px;
+  font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: .1em;
+  letter-spacing: .08em;
   color: var(--ink-faded);
 }
 .rail-chip.people  { border-left-color: var(--bloodred); }
@@ -1211,8 +1212,8 @@ body {
   display: inline-flex; align-items: center; gap: 6px;
   padding: 3px 9px;
   font-family: var(--font-fell-sc);
-  font-size: 10px;
-  letter-spacing: .14em;
+  font-size: 11px;
+  letter-spacing: .12em;
   border: 1px solid;
   border-radius: 2px;
   line-height: 1.3;
@@ -1251,9 +1252,9 @@ body {
 .tweaks-panel .body { padding: 14px; display: flex; flex-direction: column; gap: 14px; }
 .tweak-row label {
   display: block;
-  font-size: 10px;
+  font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: .12em;
+  letter-spacing: .1em;
   color: var(--ink-faded);
   margin-bottom: 6px;
 }
@@ -1319,7 +1320,7 @@ body {
 .board-zoom button:hover { background: var(--vellum-light); }
 .board-zoom .zoom-val {
   font-family: var(--font-ui);
-  font-size: 10px;
+  font-size: 11px;
   text-align: center;
   padding: 4px 0;
   color: var(--ink-faded);
@@ -1358,8 +1359,8 @@ body {
   background: var(--bloodred);
   color: var(--paper-cream);
   font-family: var(--font-fell-sc);
-  font-size: 10px;
-  letter-spacing: .15em;
+  font-size: 11px;
+  letter-spacing: .12em;
   clip-path: polygon(4px 0, 100% 0, calc(100% - 4px) 100%, 0 100%);
 }
 


### PR DESCRIPTION
## Summary
- Global Cmd+K / Ctrl+K opens a search palette over all 8 entity kinds plus party-note text
- Ranks by match quality (primary prefix → primary substring → secondary field → note); one hit per entity id
- Selecting a result reuses the existing `setOpenId` flow to open the detail sheet; themes automatically via CSS vars

## Test plan
- [ ] Cmd+K (mac) / Ctrl+K (win/linux) opens the palette; Esc and Cmd+K toggle closed
- [ ] Typing returns ranked results with kind badges; secondary/note matches show an ellipsized snippet
- [ ] ↑/↓ wraps, Enter opens the highlighted entity
- [ ] Cmd+K while a detail sheet is open layers the palette above; picking a hit swaps the sheet content
- [ ] Empty query shows hint; no-match shows italic "Nothing in the codex matches…"

🤖 Generated with [Claude Code](https://claude.com/claude-code)