### PR TITLE
Add image upload for visual entities

### DIFF
--- a/src/campaignContext.tsx
+++ b/src/campaignContext.tsx
@@ -45,6 +45,7 @@ const mapLocation = (r: any) => ({
   desc: r.desc ?? undefined,
   region: r.region ?? undefined,
   ruler: r.ruler ?? undefined,
+  imageUrl: r.image_url ?? undefined,
   notes: r.notes ?? undefined,
 });
 
@@ -73,6 +74,7 @@ const mapFaction = (r: any) => ({
   sigil: r.sigil,
   desc: r.desc ?? undefined,
   allegiance: r.allegiance ?? undefined,
+  imageUrl: r.image_url ?? undefined,
 });
 
 const mapItem = (r: any) => ({
@@ -80,6 +82,7 @@ const mapItem = (r: any) => ({
   name: r.name,
   kind: r.kind,
   desc: r.desc ?? undefined,
+  imageUrl: r.image_url ?? undefined,
 });
 
 const mapLore = (r: any) => ({

--- a/src/data.ts
+++ b/src/data.ts
@@ -38,6 +38,7 @@ export interface Location {
   desc?: string;
   region?: string;
   ruler?: string;
+  imageUrl?: string;
   notes?: string;
 }
 
@@ -66,6 +67,7 @@ export interface Faction {
   sigil: string;
   desc?: string;
   allegiance?: string;
+  imageUrl?: string;
 }
 
 export interface Item {
@@ -73,6 +75,7 @@ export interface Item {
   name: string;
   kind: string;
   desc?: string;
+  imageUrl?: string;
 }
 
 export interface Lore {

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -10,6 +10,112 @@ import {
   deleteEntity,
   insertConnection,
 } from "./mutations";
+import { uploadEntityImage, type UploadableKind } from "./upload";
+
+const UPLOADABLE_KINDS = ["people", "locations", "factions", "items"] as const;
+const isUploadable = (k: KindKey): k is UploadableKind =>
+  (UPLOADABLE_KINDS as readonly string[]).includes(k);
+
+const chipStyle: React.CSSProperties = {
+  background: "var(--vellum-light)",
+  color: "var(--ink)",
+  border: "1px solid var(--ink)",
+  fontFamily: "var(--font-fell-sc)",
+  letterSpacing: ".1em",
+  fontSize: 11,
+  lineHeight: 1.2,
+  padding: "4px 9px",
+  boxShadow: "0 1px 2px rgba(0,0,0,.35)",
+  cursor: "pointer",
+};
+
+function PortraitFallback({ kind }: { kind: KindKey }) {
+  if (kind === "people") return <span className="silhouette" />;
+  return (
+    <div style={{ position: "absolute", inset: 6, border: "1px solid var(--ink-faded)", display: "grid", placeItems: "center", color: "var(--ink)" }}>
+      <Icon name={kindIcon[kind]} size={48} strokeWidth={1.2} />
+    </div>
+  );
+}
+
+function EntityPortrait({
+  kind,
+  entityId,
+  imageUrl,
+  label,
+  onSave,
+}: {
+  kind: UploadableKind;
+  entityId: string;
+  imageUrl: string | undefined;
+  label: string;
+  onSave: (url: string | null) => void;
+}) {
+  const fileRef = useRef<HTMLInputElement | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const pick = () => fileRef.current?.click();
+
+  const onFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+    setUploading(true);
+    try {
+      const url = await uploadEntityImage(file, kind, entityId);
+      onSave(url);
+    } catch (err: any) {
+      console.error("uploadEntityImage failed", err);
+      window.alert(err?.message || "Upload failed.");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const clear = () => {
+    if (!window.confirm("Remove this image?")) return;
+    onSave(null);
+  };
+
+  const hiddenInput = (
+    <input ref={fileRef} type="file" accept="image/*" onChange={onFile} style={{ display: "none" }} />
+  );
+
+  if (!imageUrl) {
+    return (
+      <button
+        type="button"
+        onClick={pick}
+        disabled={uploading}
+        className="sb-portrait portrait-empty"
+        style={{ background: "var(--paper-tan)", padding: 0, cursor: uploading ? "wait" : "pointer" }}
+      >
+        <PortraitFallback kind={kind} />
+        <div className="portrait-caption">
+          {uploading ? "Uploading…" : "Click to add portrait"}
+        </div>
+        {hiddenInput}
+      </button>
+    );
+  }
+
+  return (
+    <div className="sb-portrait">
+      <img src={imageUrl} alt={label} className="sb-portrait-img" />
+      {hiddenInput}
+      <div className={uploading ? "portrait-chips is-uploading" : "portrait-chips"}>
+        <button onClick={pick} disabled={uploading} style={chipStyle}>
+          {uploading ? "Uploading…" : "Replace"}
+        </button>
+        {!uploading && (
+          <button onClick={clear} title="Remove image" style={{ ...chipStyle, padding: "4px 8px", fontSize: 12 }}>
+            ✕
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
 
 const STATUS_OPTIONS = ["whispered", "pursuing", "resolved", "lost"] as const;
 const DISPOSITION_OPTIONS = ["ally", "neutral", "wary", "hostile"] as const;
@@ -243,19 +349,17 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
         <div className="detail-sheet-inner">
 
           <div className="statblock">
-            {kind === "people" ? (
-              <div className="sb-portrait">
-                {(entity as any).imageUrl
-                  ? <img src={(entity as any).imageUrl} alt={entityLabel(entity)} className="sb-portrait-img" />
-                  : <span className="silhouette" />}
-              </div>
+            {isUploadable(kind) ? (
+              <EntityPortrait
+                kind={kind}
+                entityId={entityId}
+                imageUrl={(entity as any).imageUrl}
+                label={entityLabel(entity)}
+                onSave={(url) => patch({ imageUrl: url })}
+              />
             ) : (
               <div className="sb-portrait" style={{ background: "var(--paper-tan)" }}>
-                <div style={{ position: "absolute", inset: 6, border: "1px solid var(--ink-faded)", display: "grid", placeItems: "center" }}>
-                  <div style={{ color: "var(--ink)", textAlign: "center" }}>
-                    <Icon name={kindIcon[kind]} size={48} strokeWidth={1.2} />
-                  </div>
-                </div>
+                <PortraitFallback kind={kind} />
               </div>
             )}
             <div className="sb-meta">

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -17,10 +17,16 @@ const fieldAlias: Record<KindKey, Record<string, string>> = {
     giver: "giver_id",
     session: "session_id",
   },
-  locations: {},
+  locations: {
+    imageUrl: "image_url",
+  },
   goals: {},
-  factions: {},
-  items: {},
+  factions: {
+    imageUrl: "image_url",
+  },
+  items: {
+    imageUrl: "image_url",
+  },
   lore: {},
   sessions: {},
 };

--- a/src/styles.css
+++ b/src/styles.css
@@ -999,6 +999,42 @@ body {
                 radial-gradient(ellipse 60% 80% at 50% 90%, #000 55%, transparent 56%) no-repeat;
 }
 
+.portrait-caption {
+  position: absolute;
+  left: 6px; right: 6px; bottom: 6px;
+  background: var(--vellum-light);
+  border-top: 1px solid var(--ink-faded);
+  color: var(--ink);
+  font-family: var(--font-fell-sc);
+  letter-spacing: .12em;
+  font-size: 11px;
+  padding: 4px 0;
+  text-align: center;
+  opacity: .82;
+  transition: opacity .15s;
+}
+.sb-portrait.portrait-empty:hover .portrait-caption,
+.sb-portrait.portrait-empty:focus-visible .portrait-caption {
+  opacity: 1;
+}
+
+.portrait-chips {
+  position: absolute;
+  left: 6px; right: 6px; bottom: 6px;
+  display: flex;
+  gap: 4px;
+  justify-content: flex-end;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .15s;
+}
+.sb-portrait:hover .portrait-chips,
+.sb-portrait:focus-within .portrait-chips,
+.portrait-chips.is-uploading {
+  opacity: 1;
+  pointer-events: auto;
+}
+
 .sb-meta .sb-kind {
   font-family: var(--font-fell-sc);
   font-size: 11px;

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -1,0 +1,31 @@
+import { supabase } from "./utils/supabase";
+
+const BUCKET = "entity-images";
+const MAX_BYTES = 5 * 1024 * 1024;
+
+export type UploadableKind = "people" | "locations" | "factions" | "items";
+
+export async function uploadEntityImage(
+  file: File,
+  kind: UploadableKind,
+  entityId: string,
+): Promise<string> {
+  if (!file.type.startsWith("image/")) {
+    throw new Error("Only image files are allowed.");
+  }
+  if (file.size > MAX_BYTES) {
+    throw new Error("Image must be 5 MB or smaller.");
+  }
+
+  const match = file.name.match(/\.([a-zA-Z0-9]+)$/);
+  const ext = match ? match[1].toLowerCase() : "bin";
+  const path = `${kind}/${entityId}-${Date.now()}.${ext}`;
+
+  const { error } = await supabase.storage
+    .from(BUCKET)
+    .upload(path, file, { upsert: false, contentType: file.type });
+  if (error) throw error;
+
+  const { data } = supabase.storage.from(BUCKET).getPublicUrl(path);
+  return data.publicUrl;
+}

--- a/supabase/migrations/0004_entity_images.sql
+++ b/supabase/migrations/0004_entity_images.sql
@@ -1,0 +1,31 @@
+-- Add image_url to visual entity tables
+alter table public.people    add column if not exists image_url text;
+alter table public.locations add column if not exists image_url text;
+alter table public.factions  add column if not exists image_url text;
+alter table public.items     add column if not exists image_url text;
+
+-- Public bucket for entity images
+insert into storage.buckets (id, name, public)
+values ('entity-images', 'entity-images', true)
+on conflict (id) do nothing;
+
+-- Storage RLS: anyone reads, authenticated writes (mirrors 0003_enable_writes.sql)
+create policy "anon read entity-images"
+  on storage.objects for select
+  to anon, authenticated
+  using (bucket_id = 'entity-images');
+
+create policy "auth write entity-images"
+  on storage.objects for insert
+  to authenticated
+  with check (bucket_id = 'entity-images');
+
+create policy "auth update entity-images"
+  on storage.objects for update
+  to authenticated
+  using (bucket_id = 'entity-images');
+
+create policy "auth delete entity-images"
+  on storage.objects for delete
+  to authenticated
+  using (bucket_id = 'entity-images');


### PR DESCRIPTION
## Summary
- Adds a single-image portrait upload flow for **people, locations, factions, and items**. Quests, goals, lore, and sessions keep the existing icon fallback.
- Images upload to a new public Supabase Storage bucket (`entity-images`); the public URL is persisted in a new `image_url` column on each of the four tables. Writes go through the existing `updateEntity` path so realtime replays the change back into every open client.
- The detail sheet `.sb-portrait` frame doubles as the upload target: empty frames show a "Click to add portrait" caption, filled frames reveal **Replace** / **✕** chips on hover (CSS `:hover`, no React state).
- New migration `supabase/migrations/0004_entity_images.sql` adds the columns, creates the bucket, and installs storage RLS policies (anon read, authenticated write) that mirror the existing per-table policies in `0003_enable_writes.sql`.

## Apply the migration
The MCP rejected `apply_migration` with a permission error. Run via the Supabase dashboard SQL editor **or** `supabase db push` after `supabase link --project-ref nsemknuzupcnvctevgfd`. Uploads will fail with "Bucket not found" until the migration runs.

## Test plan
- [ ] Apply `0004_entity_images.sql` in the target project
- [ ] `npm run build` passes (verified locally)
- [ ] Open a person / location / faction / item, click the empty portrait, pick a PNG or JPG under 5 MB — image appears in the sepia frame
- [ ] Open the same entity in a second browser tab — image appears within ~1s via realtime
- [ ] Hover a filled portrait → Replace / ✕ chips appear; Replace uploads a new file, ✕ clears the URL
- [ ] Try an oversized or non-image file → error alert, no write
- [ ] Open a quest / goal / lore / session → no upload button, icon fallback only

🤖 Generated with [Claude Code](https://claude.com/claude-code)