### PR TITLE
Add archive/pin entities and Tidy the Codex cleanup panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { Sidebar, Topbar } from "./components";
 import { NoticeBoard, KindList } from "./board";
 import { DetailSheet } from "./detail";
 import { CommandPalette, useCommandPaletteHotkey } from "./commandPalette";
+import { CleanupPanel } from "./cleanupPanel";
 
 function LoadingSheet() {
   return (
@@ -59,6 +60,7 @@ function AppLoaded() {
   const [tweaksOpen, setTweaksOpen] = useState(false);
   const [shareToast, setShareToast] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [cleanupOpen, setCleanupOpen] = useState(false);
 
   const togglePalette = useCallback(() => setPaletteOpen((o) => !o), []);
   useCommandPaletteHotkey(togglePalette);
@@ -85,8 +87,12 @@ function AppLoaded() {
   };
 
   const counts = useMemo(() => {
-    const c: Record<string, number> = {};
-    kinds.forEach((k) => { c[k.key] = k.list().length; });
+    const c: Record<string, { active: number; archived: number }> = {};
+    kinds.forEach((k) => {
+      const list = k.list() as any[];
+      const archived = list.filter((e) => e.archived).length;
+      c[k.key] = { active: list.length - archived, archived };
+    });
     return c;
   }, [kinds]);
 
@@ -99,7 +105,7 @@ function AppLoaded() {
     <>
       <div className="app">
         <Topbar onShare={onShare} />
-        <Sidebar active={view} onSelect={setView} onOpenEntity={setOpenId} counts={counts} />
+        <Sidebar active={view} onSelect={setView} onOpenEntity={setOpenId} onOpenCleanup={() => setCleanupOpen(true)} counts={counts} />
         <main className="main">
           {view === "board" && <NoticeBoard onOpenEntity={setOpenId} />}
           {view !== "board" && <KindList kind={view} onOpenEntity={setOpenId} />}
@@ -119,6 +125,13 @@ function AppLoaded() {
         onClose={() => setPaletteOpen(false)}
         onOpenEntity={(id) => { setOpenId(id); setPaletteOpen(false); }}
       />
+
+      {cleanupOpen && (
+        <CleanupPanel
+          onClose={() => setCleanupOpen(false)}
+          onOpenEntity={(id) => { setOpenId(id); setCleanupOpen(false); }}
+        />
+      )}
 
       {shareToast && (
         <div style={{

--- a/src/board.tsx
+++ b/src/board.tsx
@@ -1,6 +1,8 @@
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import {
   type KindKey,
+  sortForDisplay,
+  isArchivableKind,
 } from "./data";
 import { CompassRose, Icon, kindIcon } from "./icons";
 import { useCampaign, useFindEntity, useKinds } from "./hooks";
@@ -52,6 +54,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
     });
     return f;
   });
+  const [showArchived, setShowArchived] = useState(false);
   const [scale, setScale] = useState(0.9);
   const [pan, setPan] = useState({ x: 0, y: 0 });
   const [panning, setPanning] = useState(false);
@@ -64,6 +67,9 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
     const pos = positions[id];
     if (!pos) return false;
     if (!(filters as any)[pos.kind]) return false;
+    const ent = findEntity(id);
+    if (!ent) return false;
+    if (!showArchived && (ent as any).archived) return false;
     return true;
   };
 
@@ -188,6 +194,16 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
               {k.label}
             </span>
           ))}
+        </div>
+
+        <div className="filter-group">
+          <span
+            className={`filter-pill ${showArchived ? "active" : ""}`}
+            onClick={() => setShowArchived((v) => !v)}
+            title="Include archived cards on the board"
+          >
+            {showArchived ? "✓ Archived" : "Show archived"}
+          </span>
         </div>
 
         <div className="filter-group">
@@ -344,6 +360,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
             if (!(filters as any)[pos.kind]) return null;
             const entity = findEntity(id);
             if (!entity) return null;
+            if (!showArchived && (entity as any).archived) return null;
             return (
               <PinnedCard
                 key={id}
@@ -400,29 +417,56 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
 
 export function KindList({ kind, onOpenEntity }: { kind: string; onOpenEntity: (id: string) => void }) {
   const kinds = useKinds();
+  const [showArchived, setShowArchived] = useState(false);
   const k = kinds.find((x) => x.key === kind);
   if (!k) return null;
-  const items = k.list();
+
+  const archivable = isArchivableKind(k.key);
+  const all = k.list() as any[];
+  const { archivedCount, sorted } = useMemo(() => {
+    if (!archivable) return { archivedCount: 0, sorted: all };
+    const archived = all.filter((e) => e.archived).length;
+    const visible = showArchived ? all : all.filter((e) => !e.archived);
+    return { archivedCount: archived, sorted: sortForDisplay(visible) };
+  }, [all, archivable, showArchived]);
+
   return (
     <div style={{ flex: 1, overflow: "auto", padding: "28px 40px 60px", background: "var(--vellum)", position: "relative" }} className="tex-vellum">
       <div style={{ position: "relative", zIndex: 1 }}>
-        <div style={{ display: "flex", alignItems: "baseline", gap: 16, marginBottom: 8 }}>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 16, marginBottom: 8, flexWrap: "wrap" }}>
           <h1 style={{ margin: 0, fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 40, color: "var(--ink)", letterSpacing: ".01em" }}>{k.label}</h1>
           <span style={{ fontFamily: "var(--font-fell)", fontStyle: "italic", fontSize: 16, color: "var(--ink-faded)" }}>
-            {items.length} {k.plural} of note
+            {sorted.length} {k.plural} of note
           </span>
+          {archivable && archivedCount > 0 && (
+            <button
+              onClick={() => setShowArchived((v) => !v)}
+              className="cleanup-link-btn"
+              style={{ marginLeft: "auto" }}
+            >
+              {showArchived ? `hide ${archivedCount} archived` : `show ${archivedCount} archived`}
+            </button>
+          )}
         </div>
         <div className="scratch-divider"><em>✦ ✦ ✦</em></div>
 
         <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(260px, 1fr))", gap: 20, marginTop: 24 }}>
-          {items.map((e: any) => (
-            <div key={e.id}
-                 onClick={() => onOpenEntity(e.id)}
-                 style={{ cursor: "pointer", transform: `rotate(${(e.id.charCodeAt(1) % 5 - 2) * 0.6}deg)` }}
-            >
-              <CardBody entity={e} kind={k.key as KindKey} />
-            </div>
-          ))}
+          {sorted.map((e: any) => {
+            const classes = [
+              "kind-card",
+              e.archived ? "archived" : "",
+              e.pinned ? "is-pinned" : "",
+            ].filter(Boolean).join(" ");
+            return (
+              <div key={e.id}
+                   onClick={() => onOpenEntity(e.id)}
+                   className={classes}
+                   style={{ transform: `rotate(${(e.id.charCodeAt(1) % 5 - 2) * 0.6}deg)` }}
+              >
+                <CardBody entity={e} kind={k.key as KindKey} />
+              </div>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/src/campaignContext.tsx
+++ b/src/campaignContext.tsx
@@ -23,6 +23,12 @@ export const CampaignContext = createContext<CampaignContextValue>({
 });
 
 // Map a DB row (snake_case, `desc`) to the app's object shape (camelCase).
+const archiveFields = (r: any) => ({
+  archived: !!r.archived,
+  pinned: !!r.pinned,
+  updatedAt: r.updated_at ?? undefined,
+});
+
 const mapPerson = (r: any) => ({
   id: r.id,
   name: r.name,
@@ -36,6 +42,7 @@ const mapPerson = (r: any) => ({
   lastSeen: r.last_seen_session_id ?? undefined,
   imageUrl: r.image_url ?? undefined,
   notes: r.notes ?? undefined,
+  ...archiveFields(r),
 });
 
 const mapLocation = (r: any) => ({
@@ -47,6 +54,7 @@ const mapLocation = (r: any) => ({
   ruler: r.ruler ?? undefined,
   imageUrl: r.image_url ?? undefined,
   notes: r.notes ?? undefined,
+  ...archiveFields(r),
 });
 
 const mapQuest = (r: any) => ({
@@ -58,6 +66,7 @@ const mapQuest = (r: any) => ({
   session: r.session_id ?? undefined,
   desc: r.desc ?? undefined,
   hooks: r.hooks ?? undefined,
+  ...archiveFields(r),
 });
 
 const mapGoal = (r: any) => ({
@@ -66,6 +75,7 @@ const mapGoal = (r: any) => ({
   owner: r.owner,
   kind: r.kind,
   status: r.status ?? undefined,
+  ...archiveFields(r),
 });
 
 const mapFaction = (r: any) => ({
@@ -75,6 +85,7 @@ const mapFaction = (r: any) => ({
   desc: r.desc ?? undefined,
   allegiance: r.allegiance ?? undefined,
   imageUrl: r.image_url ?? undefined,
+  ...archiveFields(r),
 });
 
 const mapItem = (r: any) => ({
@@ -83,12 +94,14 @@ const mapItem = (r: any) => ({
   kind: r.kind,
   desc: r.desc ?? undefined,
   imageUrl: r.image_url ?? undefined,
+  ...archiveFields(r),
 });
 
 const mapLore = (r: any) => ({
   id: r.id,
   title: r.title,
   text: r.text,
+  ...archiveFields(r),
 });
 
 const mapSession = (r: any) => ({

--- a/src/cleanupPanel.tsx
+++ b/src/cleanupPanel.tsx
@@ -1,0 +1,247 @@
+import { useMemo, useState } from "react";
+import { useCampaign, useKinds } from "./hooks";
+import {
+  type Campaign,
+  type KindKey,
+  ARCHIVABLE_KINDS,
+  entityLabel,
+  isArchived,
+  isPinned,
+} from "./data";
+import { Icon } from "./icons";
+import { bulkArchive } from "./mutations";
+
+interface Suggestion {
+  kind: KindKey;
+  id: string;
+  label: string;
+  reason: string;
+}
+
+function computeSuggestions(campaign: Campaign, n: number): Suggestion[] {
+  const sessionsByNum = [...campaign.sessions].sort((a, b) => a.num - b.num);
+  const recentSessionIds = new Set(sessionsByNum.slice(-n).map((s) => s.id));
+  const lastTwoSessionIds = new Set(sessionsByNum.slice(-2).map((s) => s.id));
+
+  const touchedByRecent = new Set<string>();
+  for (const p of campaign.people) {
+    if (p.lastSeen && recentSessionIds.has(p.lastSeen)) touchedByRecent.add(p.id);
+  }
+  for (const q of campaign.quests) {
+    if (q.session && recentSessionIds.has(q.session)) touchedByRecent.add(q.id);
+  }
+
+  const connectionNeighbours = new Map<string, Set<string>>();
+  for (const [a, b] of campaign.connections) {
+    if (!connectionNeighbours.has(a)) connectionNeighbours.set(a, new Set());
+    if (!connectionNeighbours.has(b)) connectionNeighbours.set(b, new Set());
+    connectionNeighbours.get(a)!.add(b);
+    connectionNeighbours.get(b)!.add(a);
+  }
+  const activeByConnection = new Set<string>();
+  for (const id of touchedByRecent) {
+    activeByConnection.add(id);
+    const neighbours = connectionNeighbours.get(id);
+    if (neighbours) for (const n2 of neighbours) activeByConnection.add(n2);
+  }
+
+  const out: Suggestion[] = [];
+  const skip = (e: any) => isArchived(e) || isPinned(e);
+
+  for (const p of campaign.people) {
+    if (skip(p)) continue;
+    if (p.lastSeen && !recentSessionIds.has(p.lastSeen)) {
+      const sess = sessionsByNum.find((s) => s.id === p.lastSeen);
+      out.push({
+        kind: "people",
+        id: p.id,
+        label: entityLabel(p),
+        reason: sess ? `last seen session ${sess.num}` : "not seen recently",
+      });
+    } else if (!p.lastSeen && !activeByConnection.has(p.id)) {
+      out.push({ kind: "people", id: p.id, label: entityLabel(p), reason: "no session link" });
+    }
+  }
+
+  for (const q of campaign.quests) {
+    if (skip(q)) continue;
+    if (q.status !== "resolved" && q.status !== "lost") continue;
+    if (q.session && lastTwoSessionIds.has(q.session)) continue;
+    out.push({ kind: "quests", id: q.id, label: entityLabel(q), reason: q.status });
+  }
+
+  for (const g of campaign.goals) {
+    if (skip(g)) continue;
+    if (g.status !== "resolved" && g.status !== "lost") continue;
+    out.push({ kind: "goals", id: g.id, label: entityLabel(g), reason: g.status });
+  }
+
+  const connectionStaleKinds: Array<[KindKey, any[]]> = [
+    ["locations", campaign.locations],
+    ["factions", campaign.factions],
+    ["items", campaign.items],
+    ["lore", campaign.lore],
+  ];
+  for (const [kind, list] of connectionStaleKinds) {
+    for (const e of list) {
+      if (skip(e)) continue;
+      if (activeByConnection.has(e.id)) continue;
+      out.push({ kind, id: e.id, label: entityLabel(e), reason: "no recent connection" });
+    }
+  }
+
+  return out;
+}
+
+interface CleanupPanelProps {
+  onClose: () => void;
+  onOpenEntity: (id: string) => void;
+}
+
+export function CleanupPanel({ onClose, onOpenEntity }: CleanupPanelProps) {
+  const campaign = useCampaign();
+  const kinds = useKinds();
+  const [n, setN] = useState(5);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [working, setWorking] = useState(false);
+
+  const kindLabel = useMemo(
+    () => Object.fromEntries(kinds.map((k) => [k.key, k.label])) as Record<KindKey, string>,
+    [kinds],
+  );
+
+  const suggestions = useMemo(() => computeSuggestions(campaign, n), [campaign, n]);
+
+  const grouped = useMemo(() => {
+    const g: Partial<Record<KindKey, Suggestion[]>> = {};
+    for (const s of suggestions) {
+      (g[s.kind] = g[s.kind] || []).push(s);
+    }
+    return g;
+  }, [suggestions]);
+
+  const keyOf = (s: Suggestion) => `${s.kind}:${s.id}`;
+  const toggle = (s: Suggestion) => {
+    const k = keyOf(s);
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(k)) next.delete(k); else next.add(k);
+      return next;
+    });
+  };
+  const selectGroup = (kind: KindKey, items: Suggestion[]) => {
+    const allSelected = items.every((s) => selected.has(keyOf(s)));
+    setSelected((prev) => {
+      const next = new Set(prev);
+      for (const s of items) {
+        if (allSelected) next.delete(keyOf(s));
+        else next.add(keyOf(s));
+      }
+      return next;
+    });
+  };
+  const selectAll = () => {
+    setSelected(new Set(suggestions.map(keyOf)));
+  };
+
+  const archiveSelected = async () => {
+    if (selected.size === 0 || working) return;
+    setWorking(true);
+    const entries = suggestions
+      .filter((s) => selected.has(keyOf(s)))
+      .map(({ kind, id }) => ({ kind, id }));
+    try {
+      await bulkArchive(entries);
+      setSelected(new Set());
+    } catch (e) {
+      console.error("bulkArchive failed", e);
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  return (
+    <div className="cleanup-overlay" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="cleanup-panel" onMouseDown={(e) => e.stopPropagation()}>
+        <div className="cleanup-header">
+          <button className="cleanup-close" onClick={onClose}><Icon name="close" size={16} /></button>
+          <h2>Tidy the Codex</h2>
+          <p>
+            Suggestions — nothing is archived until you act. Pinned entries are never suggested.
+          </p>
+        </div>
+        <div className="cleanup-controls">
+          <span>Fresh window:</span>
+          <input
+            type="range"
+            min={1}
+            max={Math.max(10, campaign.sessions.length)}
+            value={n}
+            onChange={(e) => setN(Number(e.target.value))}
+          />
+          <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".16em", fontSize: 11, color: "var(--ink-faded)" }}>
+            LAST {n} SESSIONS
+          </span>
+          <button className="cleanup-link-btn" onClick={selectAll}>select all</button>
+        </div>
+        <div className="cleanup-body">
+          {suggestions.length === 0 && (
+            <div className="cleanup-empty">
+              ✦ Nothing stale — the Codex is tidy. ✦
+            </div>
+          )}
+          {ARCHIVABLE_KINDS.map((kind) => {
+            const items = grouped[kind];
+            if (!items || items.length === 0) return null;
+            const allSelected = items.every((s) => selected.has(keyOf(s)));
+            return (
+              <div className="cleanup-group" key={kind}>
+                <div className="cleanup-group-head">
+                  <span className="cleanup-group-title">
+                    {kindLabel[kind]} · {items.length}
+                  </span>
+                  <button className="cleanup-link-btn" onClick={() => selectGroup(kind, items)}>
+                    {allSelected ? "deselect group" : "select group"}
+                  </button>
+                </div>
+                {items.map((s) => (
+                  <label className="cleanup-row" key={keyOf(s)}>
+                    <input
+                      type="checkbox"
+                      checked={selected.has(keyOf(s))}
+                      onChange={() => toggle(s)}
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                    <span
+                      style={{ cursor: "pointer", color: "var(--ink)" }}
+                      onClick={(e) => { e.preventDefault(); onOpenEntity(s.id); }}
+                    >
+                      {s.label}
+                    </span>
+                    <span className="cleanup-reason">{s.reason}</span>
+                  </label>
+                ))}
+              </div>
+            );
+          })}
+        </div>
+        <div className="cleanup-footer">
+          <span className="cleanup-selected">
+            {selected.size} selected · {suggestions.length} suggested
+          </span>
+          <div style={{ display: "flex", gap: 8 }}>
+            <button className="btn" onClick={onClose}>Close</button>
+            <button
+              className="btn btn-primary"
+              onClick={archiveSelected}
+              disabled={selected.size === 0 || working}
+              style={{ opacity: selected.size === 0 || working ? 0.5 : 1 }}
+            >
+              {working ? "Archiving…" : `Archive ${selected.size}`}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/cleanupPanel.tsx
+++ b/src/cleanupPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useCampaign, useKinds } from "./hooks";
 import {
   type Campaign,
@@ -50,6 +50,7 @@ function computeSuggestions(campaign: Campaign, n: number): Suggestion[] {
 
   for (const p of campaign.people) {
     if (skip(p)) continue;
+    if (activeByConnection.has(p.id)) continue;
     if (p.lastSeen && !recentSessionIds.has(p.lastSeen)) {
       const sess = sessionsByNum.find((s) => s.id === p.lastSeen);
       out.push({
@@ -58,7 +59,7 @@ function computeSuggestions(campaign: Campaign, n: number): Suggestion[] {
         label: entityLabel(p),
         reason: sess ? `last seen session ${sess.num}` : "not seen recently",
       });
-    } else if (!p.lastSeen && !activeByConnection.has(p.id)) {
+    } else if (!p.lastSeen) {
       out.push({ kind: "people", id: p.id, label: entityLabel(p), reason: "no session link" });
     }
   }
@@ -111,6 +112,16 @@ export function CleanupPanel({ onClose, onOpenEntity }: CleanupPanelProps) {
   );
 
   const suggestions = useMemo(() => computeSuggestions(campaign, n), [campaign, n]);
+
+  useEffect(() => {
+    setSelected((prev) => {
+      if (prev.size === 0) return prev;
+      const valid = new Set(suggestions.map((s) => `${s.kind}:${s.id}`));
+      const next = new Set<string>();
+      for (const k of prev) if (valid.has(k)) next.add(k);
+      return next.size === prev.size ? prev : next;
+    });
+  }, [suggestions]);
 
   const grouped = useMemo(() => {
     const g: Partial<Record<KindKey, Suggestion[]>> = {};

--- a/src/commandPalette.tsx
+++ b/src/commandPalette.tsx
@@ -12,6 +12,7 @@ interface PaletteHit {
   snippet?: string;
   matchSource: MatchSource;
   rank: 0 | 1 | 2 | 3;
+  archived?: boolean;
 }
 
 const KIND_ICON: Record<KindKey, "people" | "location" | "quest" | "goal" | "faction" | "item" | "lore" | "session"> = {
@@ -42,6 +43,7 @@ interface Indexed {
   label: string;
   primary: string;
   secondary: string;
+  archived?: boolean;
 }
 
 function joinFields(...parts: Array<string | number | null | undefined>): string {
@@ -57,6 +59,7 @@ function buildIndex(campaign: Campaign): Indexed[] {
       label: entityLabel(p),
       primary: p.name ?? "",
       secondary: joinFields(p.epithet, p.race, p.role, p.disposition, p.alignment, p.notes),
+      archived: p.archived,
     });
   }
   for (const l of campaign.locations) {
@@ -66,6 +69,7 @@ function buildIndex(campaign: Campaign): Indexed[] {
       label: entityLabel(l),
       primary: l.name ?? "",
       secondary: joinFields(l.kind, l.region, l.ruler, l.desc, l.notes),
+      archived: l.archived,
     });
   }
   for (const q of campaign.quests) {
@@ -75,6 +79,7 @@ function buildIndex(campaign: Campaign): Indexed[] {
       label: entityLabel(q),
       primary: q.title ?? "",
       secondary: joinFields(q.status, q.reward, q.desc, q.hooks),
+      archived: q.archived,
     });
   }
   for (const g of campaign.goals) {
@@ -84,6 +89,7 @@ function buildIndex(campaign: Campaign): Indexed[] {
       label: entityLabel(g),
       primary: g.text ?? "",
       secondary: joinFields(g.owner, g.kind, g.status),
+      archived: g.archived,
     });
   }
   for (const f of campaign.factions) {
@@ -93,6 +99,7 @@ function buildIndex(campaign: Campaign): Indexed[] {
       label: entityLabel(f),
       primary: f.name ?? "",
       secondary: joinFields(f.sigil, f.desc, f.allegiance),
+      archived: f.archived,
     });
   }
   for (const i of campaign.items) {
@@ -102,6 +109,7 @@ function buildIndex(campaign: Campaign): Indexed[] {
       label: entityLabel(i),
       primary: i.name ?? "",
       secondary: joinFields(i.kind, i.desc),
+      archived: i.archived,
     });
   }
   for (const lo of campaign.lore) {
@@ -111,6 +119,7 @@ function buildIndex(campaign: Campaign): Indexed[] {
       label: entityLabel(lo),
       primary: lo.title ?? "",
       secondary: lo.text ?? "",
+      archived: lo.archived,
     });
   }
   for (const s of campaign.sessions) {
@@ -150,11 +159,11 @@ function searchHits(index: Indexed[], campaign: Campaign, query: string): Palett
   for (const e of index) {
     const primary = e.primary.toLowerCase();
     if (primary.startsWith(q)) {
-      keepBest({ id: e.id, kind: e.kind, label: e.label, matchSource: "primary", rank: 0 });
+      keepBest({ id: e.id, kind: e.kind, label: e.label, matchSource: "primary", rank: 0, archived: e.archived });
       continue;
     }
     if (primary.includes(q)) {
-      keepBest({ id: e.id, kind: e.kind, label: e.label, matchSource: "primary", rank: 1 });
+      keepBest({ id: e.id, kind: e.kind, label: e.label, matchSource: "primary", rank: 1, archived: e.archived });
       continue;
     }
     const secondary = e.secondary.toLowerCase();
@@ -166,6 +175,7 @@ function searchHits(index: Indexed[], campaign: Campaign, query: string): Palett
         snippet: makeSnippet(e.secondary, q),
         matchSource: "secondary",
         rank: 2,
+        archived: e.archived,
       });
     }
   }
@@ -183,6 +193,7 @@ function searchHits(index: Indexed[], campaign: Campaign, query: string): Palett
           snippet: `${note.author}: ${makeSnippet(note.text, q)}`,
           matchSource: "note",
           rank: 3,
+          archived: parent.archived,
         });
         break;
       }
@@ -313,7 +324,7 @@ export function CommandPalette({ open, onClose, onOpenEntity }: CommandPalettePr
             >
               <Icon name={KIND_ICON[hit.kind]} size={16} />
               <div className="cmdk-row-text">
-                <div className="cmdk-row-label">{hit.label}</div>
+                <div className={`cmdk-row-label ${hit.archived ? "archived" : ""}`}>{hit.label}</div>
                 {hit.snippet && (
                   <div className="cmdk-snippet">
                     {hit.matchSource === "note" ? <span className="cmdk-snippet-tag">note · </span> : null}
@@ -322,6 +333,7 @@ export function CommandPalette({ open, onClose, onOpenEntity }: CommandPalettePr
                 )}
               </div>
               <span className="cmdk-kind">{KIND_LABEL[hit.kind]}</span>
+              {hit.archived && <span className="cmdk-kind-archived">archived</span>}
             </button>
           ))}
         </div>

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -73,10 +73,13 @@ export function PinnedCard({
   const effective = drag || pos;
   const pinClass = pos.kind === "quests" ? "brass" : pos.kind === "lore" ? "iron" : "";
 
+  const archived = !!entity.archived;
+  const pinnedFlag = !!entity.pinned;
+
   return (
     <div
       ref={ref}
-      className={`pinned ${dragging ? "dragging" : ""}`}
+      className={`pinned ${dragging ? "dragging" : ""} ${archived ? "archived" : ""} ${pinnedFlag ? "is-pinned" : ""}`}
       data-kind={pos.kind}
       data-id={entity.id}
       style={{
@@ -88,7 +91,7 @@ export function PinnedCard({
       }}
       onMouseDown={onMouseDown}
     >
-      <span className={`pin-head ${pinClass}`} />
+      <span className={`pin-head ${pinnedFlag ? "brass" : pinClass}`} />
       <CardBody entity={entity} kind={pos.kind} />
     </div>
   );
@@ -245,12 +248,14 @@ interface SidebarProps {
   active: string;
   onSelect: (v: string) => void;
   onOpenEntity: (id: string) => void;
-  counts: Record<string, number>;
+  onOpenCleanup: () => void;
+  counts: Record<string, { active: number; archived: number }>;
 }
 
-export function Sidebar({ active, onSelect, onOpenEntity, counts }: SidebarProps) {
+export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts }: SidebarProps) {
   const campaign = useCampaign();
   const kinds = useKinds();
+  const totalArchived = kinds.reduce((sum, k) => sum + (counts[k.key]?.archived ?? 0), 0);
   return (
     <aside className="sidebar">
       <div className="sidebar-label"><span>The Board</span></div>
@@ -260,17 +265,33 @@ export function Sidebar({ active, onSelect, onOpenEntity, counts }: SidebarProps
       </div>
 
       <div className="sidebar-label"><span>Codex</span></div>
-      {kinds.map((k) => (
-        <div
-          key={k.key}
-          className={`nav-item ${active === k.key ? "active" : ""}`}
-          onClick={() => onSelect(k.key)}
-        >
-          <span className="icon"><Icon name={kindIcon[k.key]} /></span>
-          {k.label}
-          <span className="count">{counts[k.key]}</span>
-        </div>
-      ))}
+      {kinds.map((k) => {
+        const c = counts[k.key] ?? { active: 0, archived: 0 };
+        return (
+          <div
+            key={k.key}
+            className={`nav-item ${active === k.key ? "active" : ""}`}
+            onClick={() => onSelect(k.key)}
+          >
+            <span className="icon"><Icon name={kindIcon[k.key]} /></span>
+            {k.label}
+            <span className="count">{c.active}</span>
+            {c.archived > 0 && (
+              <span className="count-archived" title={`${c.archived} archived`}>+{c.archived}</span>
+            )}
+          </div>
+        );
+      })}
+      <div
+        className="nav-item"
+        onClick={onOpenCleanup}
+        style={{ marginTop: 4, fontStyle: "italic", color: "var(--ink-faded)" }}
+        title="Review stale entities and archive in bulk"
+      >
+        <span className="icon"><Icon name="scroll" /></span>
+        Tidy the Codex
+        {totalArchived > 0 && <span className="count-archived">{totalArchived} archived</span>}
+      </div>
 
       <div className="sidebar-label"><span>Sessions</span></div>
       {campaign.sessions.slice().reverse().map((s) => (

--- a/src/data.ts
+++ b/src/data.ts
@@ -16,7 +16,13 @@ export interface Session {
   date: string;
 }
 
-export interface Person {
+export interface ArchivableFields {
+  archived?: boolean;
+  pinned?: boolean;
+  updatedAt?: string;
+}
+
+export interface Person extends ArchivableFields {
   id: string;
   name: string;
   epithet?: string;
@@ -31,7 +37,7 @@ export interface Person {
   notes?: string;
 }
 
-export interface Location {
+export interface Location extends ArchivableFields {
   id: string;
   name: string;
   kind: string;
@@ -42,7 +48,7 @@ export interface Location {
   notes?: string;
 }
 
-export interface Quest {
+export interface Quest extends ArchivableFields {
   id: string;
   title: string;
   status?: Status;
@@ -53,7 +59,7 @@ export interface Quest {
   hooks?: string;
 }
 
-export interface Goal {
+export interface Goal extends ArchivableFields {
   id: string;
   text: string;
   owner: string;
@@ -61,7 +67,7 @@ export interface Goal {
   status?: Status;
 }
 
-export interface Faction {
+export interface Faction extends ArchivableFields {
   id: string;
   name: string;
   sigil: string;
@@ -70,7 +76,7 @@ export interface Faction {
   imageUrl?: string;
 }
 
-export interface Item {
+export interface Item extends ArchivableFields {
   id: string;
   name: string;
   kind: string;
@@ -78,10 +84,18 @@ export interface Item {
   imageUrl?: string;
 }
 
-export interface Lore {
+export interface Lore extends ArchivableFields {
   id: string;
   title: string;
   text: string;
+}
+
+export const ARCHIVABLE_KINDS: ReadonlyArray<KindKey> = [
+  "people", "locations", "quests", "goals", "factions", "items", "lore",
+];
+
+export function isArchivableKind(k: KindKey): boolean {
+  return ARCHIVABLE_KINDS.includes(k);
 }
 
 export type BoardPosition = { x: number; y: number; rot: number; kind: KindKey };
@@ -164,4 +178,29 @@ export function findEntity(
 
 export function entityLabel(e: any): string {
   return e?.name || e?.title || e?.text || "—";
+}
+
+export function isArchived(e: any): boolean {
+  return !!(e && e.archived);
+}
+
+export function isPinned(e: any): boolean {
+  return !!(e && e.pinned);
+}
+
+// Sort: pinned first, then active by most recently updated, then archived at the bottom.
+export function sortForDisplay<T extends { id: string; updatedAt?: string; archived?: boolean; pinned?: boolean }>(
+  items: T[],
+): T[] {
+  return items.slice().sort((a, b) => {
+    const pa = a.pinned ? 1 : 0;
+    const pb = b.pinned ? 1 : 0;
+    if (pa !== pb) return pb - pa;
+    const aa = a.archived ? 1 : 0;
+    const ab = b.archived ? 1 : 0;
+    if (aa !== ab) return aa - ab;
+    const ta = a.updatedAt ? Date.parse(a.updatedAt) : 0;
+    const tb = b.updatedAt ? Date.parse(b.updatedAt) : 0;
+    return tb - ta;
+  });
 }

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from "react";
-import { type KindKey, entityLabel } from "./data";
+import { type KindKey, entityLabel, isArchivableKind, isArchived, isPinned } from "./data";
 import { Icon, kindIcon } from "./icons";
 import { StatusChip, EditableText, EnumSelect } from "./components";
 import { useCampaign, useFindEntity } from "./hooks";
@@ -331,21 +331,38 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
 
   return (
     <div className="detail-overlay" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}>
-      <div className="detail-sheet tex-vellum">
+      <div className={`detail-sheet tex-vellum ${isArchived(entity) ? "is-archived" : ""}`}>
         <button className="detail-close" onClick={onClose}><Icon name="close" size={16} /></button>
-        <button
-          onClick={onDelete}
-          title="Strike from the codex"
-          style={{
-            position: "absolute", top: 14, right: 54,
-            background: "transparent", border: "1px solid var(--ink-faded)",
-            color: "var(--bloodred)", padding: "4px 8px",
-            fontFamily: "var(--font-fell-sc)", letterSpacing: ".16em", fontSize: 11,
-            cursor: "pointer",
-          }}
-        >
-          ✕ STRIKE
-        </button>
+        <div style={{ position: "absolute", top: 14, right: 54, display: "flex", gap: 6, zIndex: 2 }}>
+          {isArchivableKind(kind) && (
+            <>
+              <button
+                onClick={() => patch({ pinned: !isPinned(entity) })}
+                title={isPinned(entity) ? "Unpin from top of lists" : "Pin to top of lists"}
+                className="detail-action-btn"
+                style={isPinned(entity) ? { borderColor: "var(--mustard)", color: "#6e5018" } : undefined}
+              >
+                {isPinned(entity) ? "★ PINNED" : "☆ PIN"}
+              </button>
+              <button
+                onClick={() => patch({ archived: !isArchived(entity) })}
+                title={isArchived(entity) ? "Restore to active codex" : "Hide from default view"}
+                className="detail-action-btn"
+                style={isArchived(entity) ? { borderColor: "var(--ink)", color: "var(--ink)" } : undefined}
+              >
+                {isArchived(entity) ? "⤴ UNARCHIVE" : "⤵ ARCHIVE"}
+              </button>
+            </>
+          )}
+          <button
+            onClick={onDelete}
+            title="Strike from the codex"
+            className="detail-action-btn"
+            style={{ color: "var(--bloodred)" }}
+          >
+            ✕ STRIKE
+          </button>
+        </div>
         <div className="detail-sheet-inner">
 
           <div className="statblock">

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -6,37 +6,30 @@ import { CURRENT_CAMPAIGN_ID, type KindKey, type PartyNote, type BoardPosition }
 
 // UI field → DB column for each kind. Only renamed fields are listed;
 // others pass through unchanged (name, title, text, desc, hooks, status, kind, etc.).
+// updated_at is server-managed by the touch_updated_at trigger
+// (supabase/migrations/0005_archive_and_pin.sql) — never write it from the client.
 const fieldAlias: Record<KindKey, Record<string, string>> = {
   people: {
     location: "location_id",
     faction: "faction_id",
     lastSeen: "last_seen_session_id",
     imageUrl: "image_url",
-    updatedAt: "updated_at",
   },
   quests: {
     giver: "giver_id",
     session: "session_id",
-    updatedAt: "updated_at",
   },
   locations: {
     imageUrl: "image_url",
-    updatedAt: "updated_at",
   },
-  goals: {
-    updatedAt: "updated_at",
-  },
+  goals: {},
   factions: {
     imageUrl: "image_url",
-    updatedAt: "updated_at",
   },
   items: {
     imageUrl: "image_url",
-    updatedAt: "updated_at",
   },
-  lore: {
-    updatedAt: "updated_at",
-  },
+  lore: {},
   sessions: {},
 };
 

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -12,22 +12,31 @@ const fieldAlias: Record<KindKey, Record<string, string>> = {
     faction: "faction_id",
     lastSeen: "last_seen_session_id",
     imageUrl: "image_url",
+    updatedAt: "updated_at",
   },
   quests: {
     giver: "giver_id",
     session: "session_id",
+    updatedAt: "updated_at",
   },
   locations: {
     imageUrl: "image_url",
+    updatedAt: "updated_at",
   },
-  goals: {},
+  goals: {
+    updatedAt: "updated_at",
+  },
   factions: {
     imageUrl: "image_url",
+    updatedAt: "updated_at",
   },
   items: {
     imageUrl: "image_url",
+    updatedAt: "updated_at",
   },
-  lore: {},
+  lore: {
+    updatedAt: "updated_at",
+  },
   sessions: {},
 };
 
@@ -148,6 +157,14 @@ async function deletePartyNotesFor(entityId: string) {
     .eq("campaign_id", CURRENT_CAMPAIGN_ID)
     .eq("entity_id", entityId);
   if (error) throw error;
+}
+
+export async function bulkArchive(entries: Array<{ kind: KindKey; id: string }>) {
+  // Fire in parallel; each goes through updateEntity so realtime reflects it
+  // the same way as any other edit.
+  await Promise.all(
+    entries.map(({ kind, id }) => updateEntity(kind, id, { archived: true })),
+  );
 }
 
 export async function deleteEntity(kind: KindKey, id: string) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1534,6 +1534,279 @@ body {
   font-size: 10px;
   color: var(--ink-faded);
 }
+/* ── Archive / Pin ──────────────────────── */
+.detail-action-btn {
+  background: transparent;
+  border: 1px solid var(--ink-faded);
+  color: var(--ink-faded);
+  padding: 4px 8px;
+  font-family: var(--font-fell-sc);
+  letter-spacing: .16em;
+  font-size: 11px;
+  cursor: pointer;
+  border-radius: 2px;
+}
+.detail-action-btn:hover {
+  background: var(--paper-cream);
+  color: var(--ink);
+}
+
+.detail-sheet.is-archived .statblock::after {
+  content: "ARCHIVED";
+  display: block;
+  position: absolute;
+  top: 14px; left: 50%;
+  bottom: auto;
+  transform: translate(-50%, 0);
+  background: var(--ink);
+  color: var(--vellum-light);
+  font-family: var(--font-fell-sc);
+  letter-spacing: .3em;
+  font-size: 10px;
+  padding: 2px 12px;
+  border-radius: 2px;
+  opacity: .7;
+  pointer-events: none;
+}
+
+/* Dim archived cards wherever they render on the Board/KindList */
+.pinned.archived,
+.kind-card.archived {
+  opacity: .55;
+  filter: saturate(.5);
+}
+.pinned.archived::before,
+.kind-card.archived::before {
+  content: "ARCHIVED";
+  position: absolute;
+  top: -10px; left: 8px;
+  background: var(--ink);
+  color: var(--vellum-light);
+  font-family: var(--font-fell-sc);
+  letter-spacing: .2em;
+  font-size: 9px;
+  padding: 2px 6px;
+  z-index: 5;
+  pointer-events: none;
+}
+
+.pinned.is-pinned .pin-head {
+  background: radial-gradient(circle at 35% 30%, #f5d68a 0%, #b08228 55%, #6a4d14 100%);
+  box-shadow: 0 2px 3px rgba(0,0,0,.5), 0 4px 10px rgba(176,130,40,.6), 0 0 0 3px rgba(176,130,40,.25);
+}
+
+/* Wrapper hugs the card so the pinned badge docks at the real corner
+   instead of floating out in the grid gap. */
+.kind-card {
+  position: relative;
+  cursor: pointer;
+  width: fit-content;
+  max-width: 100%;
+}
+
+/* Pinned: a struck-brass rosette — a medal of particular favor, rim-beveled
+   like a hand-punched coin, with an embossed 5-pointed star pressed into the
+   face. Slight rotation so it reads as hand-placed. */
+.kind-card.is-pinned::before {
+  content: "";
+  position: absolute;
+  top: -14px; right: -14px;
+  width: 44px; height: 44px;
+  border-radius: 50%;
+  z-index: 5;
+  background:
+    radial-gradient(circle at 34% 28%, rgba(255, 245, 205, .92) 0%, rgba(255, 245, 205, 0) 40%),
+    radial-gradient(circle at 68% 78%, rgba(80, 52, 10, .55) 0%, rgba(80, 52, 10, 0) 50%),
+    radial-gradient(circle at 50% 50%, #f3d27a 0%, #d0a138 36%, #8c6413 72%, #4f360a 100%);
+  box-shadow:
+    /* rim bevel */
+    inset 0 1.5px 1px rgba(255, 240, 185, .78),
+    inset 0 -1.5px 2px rgba(40, 25, 5, .7),
+    inset 0 0 0 1px rgba(60, 40, 8, .55),
+    /* inner groove, slight recessed field around the star */
+    inset 0 0 0 5px rgba(255, 235, 170, .12),
+    inset 0 0 0 6px rgba(60, 40, 8, .28),
+    /* cast shadow onto the card */
+    0 3px 5px rgba(20, 12, 4, .55),
+    0 1px 1.5px rgba(0, 0, 0, .7),
+    /* warm ambient glow */
+    0 0 18px rgba(212, 167, 40, .28);
+  transform: rotate(-9deg);
+  pointer-events: none;
+}
+
+.kind-card.is-pinned::after {
+  content: "";
+  position: absolute;
+  top: -10px; right: -10px;
+  width: 34px; height: 34px;
+  z-index: 6;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none'><path d='M12 2.6 L14.72 9.24 L21.84 9.84 L16.44 14.58 L18.12 21.36 L12 17.7 L5.88 21.36 L7.56 14.58 L2.16 9.84 L9.28 9.24 Z' fill='%234a2a06' stroke='%23271802' stroke-width='0.7' stroke-linejoin='round'/></svg>");
+  background-size: 60% 60%;
+  background-position: center;
+  background-repeat: no-repeat;
+  transform: rotate(-9deg);
+  filter: drop-shadow(0 0.8px 0 rgba(255, 238, 180, .55));
+  pointer-events: none;
+}
+
+/* Sidebar archived count */
+.nav-item .count-archived {
+  margin-left: 4px;
+  font-family: var(--font-ui);
+  font-size: 10px;
+  color: var(--ink-ghost);
+  font-style: italic;
+}
+
+/* Command palette archived tag */
+.cmdk-kind-archived {
+  margin-left: 6px;
+  font-family: var(--font-fell-sc);
+  letter-spacing: .2em;
+  font-size: 9px;
+  color: var(--ink);
+  background: var(--vellum-dark);
+  padding: 1px 5px;
+  border-radius: 2px;
+}
+.cmdk-row .cmdk-row-label.archived {
+  opacity: .6;
+}
+
+/* ── Cleanup panel (Tidy the Codex) ─────── */
+.cleanup-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(20,12,5,.55);
+  backdrop-filter: blur(2px);
+  z-index: 65;
+  display: grid;
+  place-items: start center;
+  padding: 8vh 20px 40px;
+  overflow-y: auto;
+}
+.cleanup-panel {
+  width: min(720px, 96vw);
+  background: var(--vellum);
+  border: 2px solid var(--vellum-deep);
+  box-shadow: var(--shadow-deep);
+  color: var(--ink-body);
+  display: flex; flex-direction: column;
+  max-height: calc(100vh - 16vh);
+}
+.cleanup-header {
+  padding: 20px 24px 16px;
+  background: var(--vellum-light);
+  border-bottom: 2px double var(--ink-faded);
+  position: relative;
+}
+.cleanup-header h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 26px;
+  color: var(--ink);
+}
+.cleanup-header p {
+  margin: 4px 0 0;
+  font-family: var(--font-fell);
+  font-style: italic;
+  font-size: 14px;
+  color: var(--ink-faded);
+}
+.cleanup-close {
+  position: absolute;
+  top: 14px; right: 14px;
+  width: 32px; height: 32px;
+  border-radius: 50%;
+  background: var(--paper-cream);
+  border: 1px solid var(--vellum-deep);
+  display: grid; place-items: center;
+  cursor: pointer;
+  color: var(--ink);
+}
+.cleanup-close:hover { background: var(--bloodred); color: var(--paper-cream); }
+.cleanup-controls {
+  display: flex; align-items: center; gap: 14px;
+  padding: 12px 24px;
+  border-bottom: 1px solid var(--vellum-deep);
+  background: var(--vellum-light);
+  font-family: var(--font-fell);
+  font-size: 13px;
+  color: var(--ink);
+}
+.cleanup-controls input[type="range"] { flex: 1; }
+.cleanup-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 24px;
+}
+.cleanup-empty {
+  padding: 40px 20px;
+  text-align: center;
+  font-family: var(--font-fell);
+  font-style: italic;
+  font-size: 15px;
+  color: var(--ink-faded);
+}
+.cleanup-group {
+  margin-bottom: 18px;
+}
+.cleanup-group-head {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 10px;
+  padding: 6px 0;
+  border-bottom: 1px dashed var(--ink-ghost);
+  margin-bottom: 8px;
+}
+.cleanup-group-title {
+  font-family: var(--font-fell-sc);
+  font-size: 12px;
+  letter-spacing: .2em;
+  color: var(--ink-faded);
+}
+.cleanup-row {
+  display: flex; align-items: center; gap: 12px;
+  padding: 7px 6px;
+  border-bottom: 1px solid rgba(139,94,40,.15);
+  cursor: pointer;
+  font-family: var(--font-fell);
+  font-size: 14px;
+}
+.cleanup-row:hover { background: rgba(139,94,40,.06); }
+.cleanup-row input[type="checkbox"] { accent-color: var(--bloodred); }
+.cleanup-row .cleanup-reason {
+  margin-left: auto;
+  font-style: italic;
+  font-size: 12px;
+  color: var(--ink-faded);
+}
+.cleanup-footer {
+  display: flex; justify-content: space-between; align-items: center;
+  gap: 12px;
+  padding: 12px 24px;
+  border-top: 1px solid var(--vellum-deep);
+  background: var(--vellum-light);
+}
+.cleanup-footer .cleanup-selected {
+  font-family: var(--font-fell-sc);
+  font-size: 11px;
+  letter-spacing: .16em;
+  color: var(--ink-faded);
+}
+.cleanup-link-btn {
+  background: transparent;
+  border: none;
+  color: var(--ink);
+  font-family: var(--font-fell);
+  font-style: italic;
+  font-size: 13px;
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0;
+}
+
 .cmdk-hint {
   display: flex; gap: 16px; justify-content: flex-end;
   padding: 8px 16px;

--- a/supabase/migrations/0005_archive_and_pin.sql
+++ b/supabase/migrations/0005_archive_and_pin.sql
@@ -1,0 +1,84 @@
+-- Clutter management for large campaigns.
+-- Adds archived/pinned flags and a tracked updated_at to every mutable entity
+-- table (sessions are permanent history and intentionally excluded).
+
+-- ==========================================================================
+-- Columns
+-- ==========================================================================
+
+alter table public.people
+  add column if not exists archived   boolean     not null default false,
+  add column if not exists pinned     boolean     not null default false,
+  add column if not exists updated_at timestamptz not null default now();
+
+alter table public.locations
+  add column if not exists archived   boolean     not null default false,
+  add column if not exists pinned     boolean     not null default false,
+  add column if not exists updated_at timestamptz not null default now();
+
+alter table public.factions
+  add column if not exists archived   boolean     not null default false,
+  add column if not exists pinned     boolean     not null default false,
+  add column if not exists updated_at timestamptz not null default now();
+
+alter table public.items
+  add column if not exists archived   boolean     not null default false,
+  add column if not exists pinned     boolean     not null default false,
+  add column if not exists updated_at timestamptz not null default now();
+
+alter table public.quests
+  add column if not exists archived   boolean     not null default false,
+  add column if not exists pinned     boolean     not null default false,
+  add column if not exists updated_at timestamptz not null default now();
+
+alter table public.goals
+  add column if not exists archived   boolean     not null default false,
+  add column if not exists pinned     boolean     not null default false,
+  add column if not exists updated_at timestamptz not null default now();
+
+alter table public.lore
+  add column if not exists archived   boolean     not null default false,
+  add column if not exists pinned     boolean     not null default false,
+  add column if not exists updated_at timestamptz not null default now();
+
+-- ==========================================================================
+-- updated_at trigger
+-- ==========================================================================
+
+create or replace function public.touch_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists tg_people_touch    on public.people;
+drop trigger if exists tg_locations_touch on public.locations;
+drop trigger if exists tg_factions_touch  on public.factions;
+drop trigger if exists tg_items_touch     on public.items;
+drop trigger if exists tg_quests_touch    on public.quests;
+drop trigger if exists tg_goals_touch     on public.goals;
+drop trigger if exists tg_lore_touch      on public.lore;
+
+create trigger tg_people_touch    before update on public.people    for each row execute function public.touch_updated_at();
+create trigger tg_locations_touch before update on public.locations for each row execute function public.touch_updated_at();
+create trigger tg_factions_touch  before update on public.factions  for each row execute function public.touch_updated_at();
+create trigger tg_items_touch     before update on public.items     for each row execute function public.touch_updated_at();
+create trigger tg_quests_touch    before update on public.quests    for each row execute function public.touch_updated_at();
+create trigger tg_goals_touch     before update on public.goals     for each row execute function public.touch_updated_at();
+create trigger tg_lore_touch      before update on public.lore      for each row execute function public.touch_updated_at();
+
+-- ==========================================================================
+-- Partial indexes on the hot "active, not archived" filter path
+-- ==========================================================================
+
+create index if not exists idx_people_active    on public.people(campaign_id)    where archived = false;
+create index if not exists idx_locations_active on public.locations(campaign_id) where archived = false;
+create index if not exists idx_factions_active  on public.factions(campaign_id)  where archived = false;
+create index if not exists idx_items_active     on public.items(campaign_id)     where archived = false;
+create index if not exists idx_quests_active    on public.quests(campaign_id)    where archived = false;
+create index if not exists idx_goals_active     on public.goals(campaign_id)     where archived = false;
+create index if not exists idx_lore_active      on public.lore(campaign_id)      where archived = false;


### PR DESCRIPTION
## Summary
- Adds `archived`, `pinned`, `updated_at` to every mutable entity table (migration `0005_archive_and_pin.sql`). Sessions are permanent history and intentionally excluded.
- Detail sheet: Pin / Archive / Strike buttons; ARCHIVED banner + dimmed body when archived.
- Board + KindList: archived hidden by default behind a "Show archived" toggle; KindList sorts pinned → active (by updatedAt) → archived.
- Pinned cards get a struck-brass rosette badge to match the wax-seal / wanted-poster aesthetic.
- Command palette keeps archived entities fully searchable with an inline `archived` tag.
- New **Tidy the Codex** panel (sidebar entry) suggests stale entities using session-linkage + connection-graph heuristics. Suggestion-only — the DM selects and confirms.

## Test plan
- [ ] Apply `supabase/migrations/0005_archive_and_pin.sql` via the Supabase dashboard SQL editor (project `nsemknuzupcnvctevgfd`).
- [ ] Open any entity's detail sheet → click Archive → entity vanishes from board/KindList; sidebar count drops; "+N archived" appears.
- [ ] Toggle "Show archived" on the board → archived card reappears, dimmed with ARCHIVED label.
- [ ] Cmd+K search for the archived entity → still listed, with `archived` tag next to the kind chip.
- [ ] Pin an entity → gold rosette badge in KindList corner, sorts to the top.
- [ ] Open Tidy the Codex → suggestions grouped by kind; select a few → Archive N → they disappear from the active list.
- [ ] Second browser tab shows all state changes live via realtime subscription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)