### PR TITLE
Add a new-session button to the Sessions sidebar

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -2,6 +2,7 @@ import { useLayoutEffect, useRef, useState } from "react";
 import { type KindKey, type PresenceUser } from "./data";
 import { Icon, MapScribble, kindIcon } from "./icons";
 import { useCampaign, useKinds } from "./hooks";
+import { createEntity } from "./mutations";
 
 interface Position {
   x: number;
@@ -293,7 +294,30 @@ export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts 
         {totalArchived > 0 && <span className="count-archived">{totalArchived} archived</span>}
       </div>
 
-      <div className="sidebar-label"><span>Sessions</span></div>
+      <div className="sidebar-label">
+        <span>Sessions</span>
+        <button
+          title="New session"
+          onClick={() => {
+            const id = crypto.randomUUID();
+            const num = Math.max(0, ...campaign.sessions.map((s) => s.num)) + 1;
+            const date = new Date().toLocaleDateString("en-GB", {
+              day: "numeric", month: "long", year: "numeric",
+            });
+            createEntity("sessions", id, { num, title: "Untitled session", date })
+              .then(() => onOpenEntity(id))
+              .catch(console.error);
+          }}
+          style={{
+            background: "transparent",
+            border: "1px dashed var(--ink-faded)",
+            color: "var(--ink-faded)",
+            width: 18, height: 18, lineHeight: "14px",
+            fontSize: 13, padding: 0, cursor: "pointer",
+            flex: "0 0 auto",
+          }}
+        >+</button>
+      </div>
       {campaign.sessions.slice().reverse().map((s) => (
         <div key={s.id} className="session-chip" onClick={() => onOpenEntity(s.id)}>
           <span className="num">SESS {String(s.num).padStart(2, "0")}</span>


### PR DESCRIPTION
## Summary
- Adds a "+" button inside the "Sessions" sidebar label (`Sidebar` in src/components.tsx) — the entry point issue #3 proposes instead of the board's "Pin new" menu
- Computes `num = Math.max(0, ...sessions.map(s => s.num)) + 1` client-side from `useCampaign()` (no extra query), inserts through `createEntity("sessions", …)` like every other kind, then opens the detail sheet via `onOpenEntity(id)`
- Defaults: `title: "Untitled session"`, `date` = today as a human-readable string ("3 July 2026"); both are inline-editable via #2's stat grid
- `NEW_ENTITY_DEFAULTS` and `buildKinds` untouched — sessions deliberately stay off the notice board

Known/accepted per the issue: two users clicking simultaneously could produce a duplicate `num` (no unique constraint) — fixable afterwards via the editable stat grid; the detail sheet renders once realtime echoes the insert (same behavior as board creates).

Stacked on #22; retargets automatically as the stack merges.

## Verification
Playwright against the dev server (test sessions STRIKE-deleted after):
- "+" → sheet opens with No. 01 / Date "3 July 2026"; sidebar chip appears via realtime
- Edited num to 5, then created again → new session got num 06 (max+1, not count)
- Bonus (deferred from #22): "abc" into the No. field → reverted, 0 write requests; valid edit → 1 write, padded display after echo
- `npm run build` passes

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)