### PR TITLE
Reject anonymous writes: RLS lockdown + magic-link sign-in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,18 @@ Practical implication: if you find yourself adding `useState` to mirror DB state
 
 ### Auth
 
-[src/auth.tsx](src/auth.tsx) runs `signInAnonymously()` on first load if there's no session, then gates the app on a display name (stored in `user_metadata.display_name`, used as the `author` on `party_notes`). RLS (migration [0003_enable_writes.sql](supabase/migrations/0003_enable_writes.sql)) requires `authenticated` — anonymous JWTs satisfy this. Reads remain open to `anon`.
+**Two tiers** (issue #4): anonymous sessions are read-only **viewers**; email magic-link sessions are **editors**.
 
-Anonymous sign-ins must be enabled in the Supabase dashboard (Authentication → Providers), otherwise `AuthProvider` surfaces a gate-barred error screen.
+[src/auth.tsx](src/auth.tsx) runs `signInAnonymously()` on first load if there's no session — every visitor always has a session. Anonymous users skip the display-name gate and land straight in the journal read-only. "Sign in to edit" in the Topbar opens `SignInDialog` → `signInWithOtp` (magic link, `emailRedirectTo: window.location.origin`; the client's default `detectSessionInUrl` consumes the link token). Editors' display name comes from `user_metadata.display_name`, falling back to their email prefix; it signs `party_notes`. `signOut` drops back to a fresh anonymous session, not a blank screen.
+
+`useAuth().canEdit` (`!!user && !user.is_anonymous`) is the single gate for edit affordances — `EditableText`/`EnumSelect` check it themselves and render plain text when false; buttons that mutate (Pin new, Draw string, sidebar `+`, PIN/ARCHIVE/STRIKE, note composer, Add Relation, portrait upload, bulk archive) are hidden behind it. Gate any new edit surface the same way.
+
+RLS (migration [0006_reject_anonymous_writes.sql](supabase/migrations/0006_reject_anonymous_writes.sql)) keeps reads open to `anon` but write policies require `(auth.jwt() ->> 'is_anonymous')::boolean is not true` — anonymous JWTs hold the `authenticated` *role*, so the claim is the only reliable gate. Storage (`entity-images`) writes are gated the same way. Advisors may still flag the policies as claim-based rather than row-based; per-campaign membership is issue #18.
+
+Dashboard config this depends on (Authentication → …):
+- Providers: **Anonymous ON** (viewer JWTs) and **Email ON** (magic link).
+- **Sign-ups disabled** — editors are invite-only, added manually via the dashboard.
+- URL Configuration: Site URL = production URL; `http://localhost:5173` in Redirect URLs for dev.
 
 ### Entity model
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ The app supports an "edit mode" handshake with a parent window via `window.__TWE
 
 ## Conventions
 
-- **Route everything campaign-scoped through `CURRENT_CAMPAIGN_ID`**; never query without the `campaign_id` filter. RLS doesn't enforce per-campaign access today ([issue #4](https://github.com/Kminkjan/the-codex/issues/4)).
+- **Route everything campaign-scoped through `CURRENT_CAMPAIGN_ID`**; never query without the `campaign_id` filter. RLS doesn't enforce per-campaign access today ([issue #18](https://github.com/Kminkjan/the-codex/issues/18)).
 - **New entity IDs are `crypto.randomUUID()` strings** generated client-side. All PKs are `text` except `connections.id` (bigserial) and `party_notes.id` (bigserial).
 - **Styling is inline style objects + a few CSS classes** in [src/styles.css](src/styles.css). CSS variables (`--ink`, `--vellum`, `--bloodred`, `--font-fell-sc`, etc.) carry the parchment aesthetic — reach for those before inventing colors.
 - **Committed `.js` / `.d.ts` siblings of the `.tsx` files are gitignored** (`src/**/*.js`, `src/**/*.d.ts` except `global.d.ts`). They're `tsc` outputs — ignore them.

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import { createContext, useContext, useEffect, useRef, useState, type ReactNode } from "react";
 import type { Session, User } from "@supabase/supabase-js";
 import { supabase } from "./utils/supabase";
 
@@ -18,6 +18,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
   const [ready, setReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const signingOutRef = useRef(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -48,6 +49,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     })();
 
     const { data: listener } = supabase.auth.onAuthStateChange((_event, s) => {
+      // During signOut the SIGNED_OUT event would blank the app (null user
+      // unmounts everything behind DisplayNameGate) before the replacement
+      // anonymous session lands — signOut() sets the session itself.
+      if (signingOutRef.current) return;
       setSession(s);
     });
 
@@ -81,11 +86,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const signOut = async () => {
-    await supabase.auth.signOut();
     // Drop back to read-only viewing instead of a blank screen: the app
     // always expects a session (anonymous = viewer).
-    const { data } = await supabase.auth.signInAnonymously();
-    setSession(data.session ?? null);
+    signingOutRef.current = true;
+    try {
+      await supabase.auth.signOut();
+      const { data, error: signInErr } = await supabase.auth.signInAnonymously();
+      if (signInErr) {
+        setError(signInErr.message);
+        setSession(null);
+        return;
+      }
+      setSession(data.session ?? null);
+    } finally {
+      signingOutRef.current = false;
+    }
   };
 
   if (!ready) return null;
@@ -129,15 +144,18 @@ function AuthError({ message }: { message: string }) {
 }
 
 export function DisplayNameGate({ children }: { children: ReactNode }) {
-  const { user, displayName, setDisplayName } = useAuth();
+  const { user, setDisplayName } = useAuth();
   const [draft, setDraft] = useState("");
   const [saving, setSaving] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
   if (!user) return null;
   // Anonymous visitors are read-only viewers — the name only signs party
-  // notes, which they can't write, so skip the gate for them.
-  if (user.is_anonymous || displayName) return <>{children}</>;
+  // notes, which they can't write, so skip the gate for them. Editors are
+  // gated on the metadata name specifically (not the email-prefix fallback
+  // in displayName), so a first-time editor still gets to pick a name.
+  const metadataName = (user.user_metadata?.display_name as string | undefined)?.trim();
+  if (user.is_anonymous || metadataName) return <>{children}</>;
 
   const submit = async () => {
     if (!draft.trim() || saving) return;

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -5,7 +5,10 @@ import { supabase } from "./utils/supabase";
 type AuthState = {
   user: User | null;
   displayName: string | null;
+  /** True for non-anonymous (magic-link) sessions; RLS rejects anonymous writes. */
+  canEdit: boolean;
   setDisplayName: (name: string) => Promise<void>;
+  signInWithEmail: (email: string) => Promise<void>;
   signOut: () => Promise<void>;
 };
 
@@ -55,8 +58,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const user = session?.user ?? null;
+  const canEdit = !!user && !user.is_anonymous;
   const displayName =
-    (user?.user_metadata?.display_name as string | undefined)?.trim() || null;
+    (user?.user_metadata?.display_name as string | undefined)?.trim() ||
+    (user?.email ? user.email.split("@")[0] : null);
 
   const setDisplayName = async (name: string) => {
     const trimmed = name.trim();
@@ -67,16 +72,29 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (updateErr) throw updateErr;
   };
 
+  const signInWithEmail = async (email: string) => {
+    const { error: otpErr } = await supabase.auth.signInWithOtp({
+      email: email.trim(),
+      options: { emailRedirectTo: window.location.origin },
+    });
+    if (otpErr) throw otpErr;
+  };
+
   const signOut = async () => {
     await supabase.auth.signOut();
-    setSession(null);
+    // Drop back to read-only viewing instead of a blank screen: the app
+    // always expects a session (anonymous = viewer).
+    const { data } = await supabase.auth.signInAnonymously();
+    setSession(data.session ?? null);
   };
 
   if (!ready) return null;
   if (error) return <AuthError message={error} />;
 
   return (
-    <AuthContext.Provider value={{ user, displayName, setDisplayName, signOut }}>
+    <AuthContext.Provider
+      value={{ user, displayName, canEdit, setDisplayName, signInWithEmail, signOut }}
+    >
       {children}
     </AuthContext.Provider>
   );
@@ -117,7 +135,9 @@ export function DisplayNameGate({ children }: { children: ReactNode }) {
   const [err, setErr] = useState<string | null>(null);
 
   if (!user) return null;
-  if (displayName) return <>{children}</>;
+  // Anonymous visitors are read-only viewers — the name only signs party
+  // notes, which they can't write, so skip the gate for them.
+  if (user.is_anonymous || displayName) return <>{children}</>;
 
   const submit = async () => {
     if (!draft.trim() || saving) return;
@@ -176,6 +196,98 @@ export function DisplayNameGate({ children }: { children: ReactNode }) {
         >
           {saving ? "Signing the page…" : "Enter the journal"}
         </button>
+        {err && (
+          <div style={{ marginTop: 14, color: "var(--bloodred)", fontSize: 12, fontStyle: "italic" }}>
+            {err}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function SignInDialog({ onClose }: { onClose: () => void }) {
+  const { signInWithEmail } = useAuth();
+  const [email, setEmail] = useState("");
+  const [sending, setSending] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const submit = async () => {
+    if (!email.trim() || sending) return;
+    setSending(true);
+    setErr(null);
+    try {
+      await signInWithEmail(email);
+      setSent(true);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: "fixed", inset: 0, display: "grid", placeItems: "center",
+        background: "rgba(40,20,5,.45)", zIndex: 100,
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          maxWidth: 440, width: "90%", textAlign: "center",
+          padding: "36px 32px",
+          background: "var(--vellum-light)",
+          boxShadow: "0 10px 40px rgba(40,20,5,.25)",
+          fontFamily: "var(--font-fell)",
+        }}
+      >
+        <div style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".3em", fontSize: 11, color: "var(--ink-faded)", marginBottom: 10 }}>
+          ✦ PROVE YOUR MEMBERSHIP ✦
+        </div>
+        {sent ? (
+          <div style={{ fontStyle: "italic", fontSize: 15, color: "var(--ink)" }}>
+            A sign-in link has been sent to <strong>{email.trim()}</strong>.
+            <br />Check your email, then return here.
+          </div>
+        ) : (
+          <>
+            <div style={{ fontStyle: "italic", fontSize: 15, marginBottom: 22, color: "var(--ink)" }}>
+              Members of the party sign in by email to edit the codex.
+            </div>
+            <input
+              autoFocus
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter") submit(); }}
+              placeholder="you@example.com"
+              style={{
+                width: "100%", padding: "10px 12px", marginBottom: 14,
+                background: "transparent",
+                border: "1px solid var(--ink-faded)",
+                fontFamily: "var(--font-fell)", fontSize: 15, color: "var(--ink)",
+                textAlign: "center",
+              }}
+            />
+            <button
+              onClick={submit}
+              disabled={!email.trim() || sending}
+              style={{
+                width: "100%", padding: "10px 16px",
+                background: "var(--ink)", color: "var(--vellum-light)",
+                fontFamily: "var(--font-fell-sc)", letterSpacing: ".2em", fontSize: 12,
+                border: "none", cursor: email.trim() ? "pointer" : "not-allowed",
+                opacity: email.trim() ? 1 : 0.5,
+              }}
+            >
+              {sending ? "Sending the raven…" : "Send sign-in link"}
+            </button>
+          </>
+        )}
         {err && (
           <div style={{ marginTop: 14, color: "var(--bloodred)", fontSize: 12, fontStyle: "italic" }}>
             {err}

--- a/src/board.tsx
+++ b/src/board.tsx
@@ -6,6 +6,7 @@ import {
 } from "./data";
 import { CompassRose, Icon, kindIcon } from "./icons";
 import { useCampaign, useFindEntity, useKinds } from "./hooks";
+import { useAuth } from "./auth";
 import { CardBody, PinnedCard } from "./components";
 import { entityLabel } from "./data";
 import {
@@ -43,6 +44,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
   const campaign = useCampaign();
   const findEntity = useFindEntity();
   const kinds = useKinds();
+  const { canEdit } = useAuth();
 
   const positions = campaign.board;
   const connections = campaign.connections;
@@ -78,6 +80,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
   const toggleKind = (k: KindKey) => setFilters((f) => ({ ...f, [k]: !(f as any)[k] }));
 
   const onDragEnd = (id: string, newPos: { x: number; y: number }) => {
+    if (!canEdit) return; // read-only: card snaps back on next render
     const base = positions[id];
     if (!base) return;
     upsertBoardPosition(id, { ...base, ...newPos }).catch((e) =>
@@ -225,15 +228,15 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
           ))}
         </div>
 
-        <button
+        {canEdit && <button
           className={`btn ${connectMode ? "btn-primary" : ""}`}
           onClick={() => { setConnectMode((m) => !m); setConnectSource(null); }}
           title="Draw a connection between two cards"
         >
           <Icon name="link" size={14} /> {connectMode ? "Cancel string" : "Draw string"}
-        </button>
+        </button>}
 
-        <div style={{ position: "relative" }}>
+        {canEdit && <div style={{ position: "relative" }}>
           <button
             className="btn btn-primary"
             onClick={() => setAddMenuOpen((o) => !o)}
@@ -277,7 +280,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
               </div>
             </>
           )}
-        </div>
+        </div>}
       </div>
 
       <div
@@ -341,7 +344,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
                     </text>
                   )}
                   <path id={`yp${i}`} d={pathD} fill="none" stroke="none" />
-                  {isHover && (
+                  {isHover && canEdit && (
                     <g
                       transform={`translate(${midX} ${midY})`}
                       style={{ cursor: "pointer", pointerEvents: "all" }}

--- a/src/cleanupPanel.tsx
+++ b/src/cleanupPanel.tsx
@@ -10,6 +10,7 @@ import {
 } from "./data";
 import { Icon } from "./icons";
 import { bulkArchive } from "./mutations";
+import { useAuth } from "./auth";
 
 interface Suggestion {
   kind: KindKey;
@@ -102,6 +103,7 @@ interface CleanupPanelProps {
 export function CleanupPanel({ onClose, onOpenEntity }: CleanupPanelProps) {
   const campaign = useCampaign();
   const kinds = useKinds();
+  const { canEdit } = useAuth();
   const [n, setN] = useState(5);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [working, setWorking] = useState(false);
@@ -242,14 +244,14 @@ export function CleanupPanel({ onClose, onOpenEntity }: CleanupPanelProps) {
           </span>
           <div style={{ display: "flex", gap: 8 }}>
             <button className="btn" onClick={onClose}>Close</button>
-            <button
+            {canEdit && <button
               className="btn btn-primary"
               onClick={archiveSelected}
               disabled={selected.size === 0 || working}
               style={{ opacity: selected.size === 0 || working ? 0.5 : 1 }}
             >
               {working ? "Archiving…" : `Archive ${selected.size}`}
-            </button>
+            </button>}
           </div>
         </div>
       </div>

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -3,6 +3,7 @@ import { type KindKey, type PresenceUser } from "./data";
 import { Icon, MapScribble, kindIcon } from "./icons";
 import { useCampaign, useKinds } from "./hooks";
 import { createEntity } from "./mutations";
+import { SignInDialog, useAuth } from "./auth";
 
 interface Position {
   x: number;
@@ -256,6 +257,7 @@ interface SidebarProps {
 export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts }: SidebarProps) {
   const campaign = useCampaign();
   const kinds = useKinds();
+  const { canEdit } = useAuth();
   const totalArchived = kinds.reduce((sum, k) => sum + (counts[k.key]?.archived ?? 0), 0);
   return (
     <aside className="sidebar">
@@ -296,7 +298,7 @@ export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts 
 
       <div className="sidebar-label">
         <span>Sessions</span>
-        <button
+        {canEdit && <button
           title="New session"
           onClick={() => {
             const id = crypto.randomUUID();
@@ -316,7 +318,7 @@ export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts 
             fontSize: 13, padding: 0, cursor: "pointer",
             flex: "0 0 auto",
           }}
-        >+</button>
+        >+</button>}
       </div>
       {campaign.sessions.slice().reverse().map((s) => (
         <div key={s.id} className="session-chip" onClick={() => onOpenEntity(s.id)}>
@@ -338,6 +340,8 @@ export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts 
 
 export function Topbar({ onShare }: { onShare: () => void }) {
   const campaign = useCampaign();
+  const { canEdit, displayName, signOut } = useAuth();
+  const [signingIn, setSigningIn] = useState(false);
   return (
     <header className="topbar">
       <div className="logo">
@@ -359,8 +363,38 @@ export function Topbar({ onShare }: { onShare: () => void }) {
       <div className="topbar-right">
         <Presence users={campaign.presence} />
         <button className="btn" onClick={onShare}><Icon name="share" size={14} /> Share link</button>
-        <button className="btn btn-primary"><Icon name="plus" size={14} /> New entry</button>
+        {canEdit ? (
+          <>
+            <span style={{
+              fontFamily: "var(--font-fell)", fontStyle: "italic",
+              fontSize: 12, color: "var(--ink-faded)",
+            }}>
+              {displayName}
+            </span>
+            <button
+              className="btn"
+              onClick={() => { signOut().catch(console.error); }}
+              title="Sign out and return to read-only viewing"
+            >
+              Sign out
+            </button>
+          </>
+        ) : (
+          <>
+            <span style={{
+              fontFamily: "var(--font-fell-sc)", letterSpacing: ".14em",
+              fontSize: 10, color: "var(--ink-faded)",
+              border: "1px dashed var(--ink-faded)", padding: "3px 8px",
+            }}>
+              READ-ONLY
+            </span>
+            <button className="btn btn-primary" onClick={() => setSigningIn(true)}>
+              Sign in to edit
+            </button>
+          </>
+        )}
       </div>
+      {signingIn && <SignInDialog onClose={() => setSigningIn(false)} />}
     </header>
   );
 }
@@ -388,6 +422,7 @@ export function EditableText({
   className,
   style,
 }: EditableTextProps) {
+  const { canEdit } = useAuth();
   const ref = useRef<HTMLDivElement>(null);
   const cancelledRef = useRef(false);
   const [editing, setEditing] = useState(false);
@@ -437,6 +472,27 @@ export function EditableText({
   };
 
   const showPlaceholder = !editing && !(display ?? "").trim();
+
+  // Read-only viewers get plain text: no affordance, no handlers. The
+  // default "Click to edit…" placeholder is edit language, so only an
+  // explicit placeholder (e.g. "Unclaimed") is shown for empty values.
+  if (!canEdit) {
+    const empty = !(value ?? "").trim();
+    return (
+      <div
+        className={className}
+        style={{
+          minHeight: "1em",
+          whiteSpace: multiline ? "pre-wrap" : "normal",
+          opacity: empty ? 0.55 : 1,
+          fontStyle: empty ? "italic" : undefined,
+          ...style,
+        }}
+      >
+        {empty ? placeholder ?? "" : value}
+      </div>
+    );
+  }
 
   return (
     <div
@@ -495,6 +551,14 @@ export function EnumSelect<T extends string>({
   className,
   style,
 }: EnumSelectProps<T>) {
+  const { canEdit } = useAuth();
+  if (!canEdit) {
+    return (
+      <span className={className} style={{ fontFamily: "var(--font-fell)", ...style }}>
+        {value ?? "—"}
+      </span>
+    );
+  }
   return (
     <select
       className={className}

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -51,6 +51,7 @@ function EntityPortrait({
   label: string;
   onSave: (url: string | null) => void;
 }) {
+  const { canEdit } = useAuth();
   const fileRef = useRef<HTMLInputElement | null>(null);
   const [uploading, setUploading] = useState(false);
 
@@ -82,6 +83,13 @@ function EntityPortrait({
   );
 
   if (!imageUrl) {
+    if (!canEdit) {
+      return (
+        <div className="sb-portrait" style={{ background: "var(--paper-tan)" }}>
+          <PortraitFallback kind={kind} />
+        </div>
+      );
+    }
     return (
       <button
         type="button"
@@ -102,17 +110,21 @@ function EntityPortrait({
   return (
     <div className="sb-portrait">
       <img src={imageUrl} alt={label} className="sb-portrait-img" />
-      {hiddenInput}
-      <div className={uploading ? "portrait-chips is-uploading" : "portrait-chips"}>
-        <button onClick={pick} disabled={uploading} style={chipStyle}>
-          {uploading ? "Uploading…" : "Replace"}
-        </button>
-        {!uploading && (
-          <button onClick={clear} title="Remove image" style={{ ...chipStyle, padding: "4px 8px", fontSize: 12 }}>
-            ✕
-          </button>
-        )}
-      </div>
+      {canEdit && (
+        <>
+          {hiddenInput}
+          <div className={uploading ? "portrait-chips is-uploading" : "portrait-chips"}>
+            <button onClick={pick} disabled={uploading} style={chipStyle}>
+              {uploading ? "Uploading…" : "Replace"}
+            </button>
+            {!uploading && (
+              <button onClick={clear} title="Remove image" style={{ ...chipStyle, padding: "4px 8px", fontSize: 12 }}>
+                ✕
+              </button>
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 }
@@ -244,7 +256,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
   const campaign = useCampaign();
   const findEntity = useFindEntity();
   const entity = findEntity(entityId);
-  const { displayName } = useAuth();
+  const { displayName, canEdit } = useAuth();
 
   const notes = campaign.notes[entityId] || [];
 
@@ -350,7 +362,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
     <div className="detail-overlay" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}>
       <div className={`detail-sheet tex-vellum ${isArchived(entity) ? "is-archived" : ""}`}>
         <button className="detail-close" onClick={onClose}><Icon name="close" size={16} /></button>
-        <div style={{ position: "absolute", top: 14, right: 54, display: "flex", gap: 6, zIndex: 2 }}>
+        {canEdit && <div style={{ position: "absolute", top: 14, right: 54, display: "flex", gap: 6, zIndex: 2 }}>
           {isArchivableKind(kind) && (
             <>
               <button
@@ -379,7 +391,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
           >
             ✕ STRIKE
           </button>
-        </div>
+        </div>}
         <div className="detail-sheet-inner">
 
           <div className="statblock">
@@ -585,7 +597,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                 ))}
               </div>
 
-              <div
+              {canEdit && <div
                 className="add-note"
                 contentEditable
                 suppressContentEditableWarning
@@ -601,7 +613,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                 }}
               >
                 {draft ? null : "Leave a note in the margin… (⌘↵ to pin)"}
-              </div>
+              </div>}
             </div>
 
             <div className="detail-rail">
@@ -634,10 +646,10 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                 );
               })}
 
-              <div className="rail-section">
+              {canEdit && <div className="rail-section">
                 <h4>Add Relation</h4>
                 <AddRelationForm fromId={entityId} />
-              </div>
+              </div>}
             </div>
           </div>
 

--- a/supabase/migrations/0006_reject_anonymous_writes.sql
+++ b/supabase/migrations/0006_reject_anonymous_writes.sql
@@ -1,0 +1,134 @@
+-- ===========================================================================
+-- Reject anonymous WRITES (issue #4, option 3).
+--
+-- Anonymous sign-in users hold the `authenticated` role — only the
+-- `is_anonymous` JWT claim distinguishes them — so the 0003/0004 policies
+-- (`to authenticated using (true)`) effectively let anyone who loads the
+-- site mutate every row. This migration replaces every write policy with a
+-- claim-gated version: reads stay open to `anon` (shared links keep working,
+-- and the anonymous provider stays enabled for read-only JWTs); writes
+-- require a non-anonymous session (email magic link).
+--
+-- The gate passes for real users (`is_anonymous` = false) and for any legacy
+-- token missing the claim (null), and fails only for anonymous JWTs (true).
+--
+-- Advisor note: `rls_policy_always_true` may still flag these policies —
+-- they are claim-based, not row-based, by design. Per-campaign membership
+-- (`campaign_members`) is tracked separately in issue #18.
+--
+-- Rollout order matters: apply this only after the app ships the sign-in
+-- flow and the Supabase dashboard has Email (magic link) enabled, otherwise
+-- every current user becomes read-only with no way to sign in.
+-- ===========================================================================
+
+-- Table write policies (replacing 0003_enable_writes.sql)
+
+drop policy "auth write campaigns"       on public.campaigns;
+drop policy "auth write sessions"        on public.sessions;
+drop policy "auth write locations"       on public.locations;
+drop policy "auth write factions"        on public.factions;
+drop policy "auth write people"          on public.people;
+drop policy "auth write quests"          on public.quests;
+drop policy "auth write goals"           on public.goals;
+drop policy "auth write items"           on public.items;
+drop policy "auth write lore"            on public.lore;
+drop policy "auth write connections"     on public.connections;
+drop policy "auth write board_positions" on public.board_positions;
+drop policy "auth write presence_users"  on public.presence_users;
+drop policy "auth write party_notes"     on public.party_notes;
+
+create policy "member write campaigns" on public.campaigns
+  for all to authenticated
+  using      ((auth.jwt() ->> 'is_anonymous')::boolean is not true)
+  with check ((auth.jwt() ->> 'is_anonymous')::boolean is not true);
+
+create policy "member write sessions" on public.sessions
+  for all to authenticated
+  using      ((auth.jwt() ->> 'is_anonymous')::boolean is not true)
+  with check ((auth.jwt() ->> 'is_anonymous')::boolean is not true);
+
+create policy "member write locations" on public.locations
+  for all to authenticated
+  using      ((auth.jwt() ->> 'is_anonymous')::boolean is not true)
+  with check ((auth.jwt() ->> 'is_anonymous')::boolean is not true);
+
+create policy "member write factions" on public.factions
+  for all to authenticated
+  using      ((auth.jwt() ->> 'is_anonymous')::boolean is not true)
+  with check ((auth.jwt() ->> 'is_anonymous')::boolean is not true);
+
+create policy "member write people" on public.people
+  for all to authenticated
+  using      ((auth.jwt() ->> 'is_anonymous')::boolean is not true)
+  with check ((auth.jwt() ->> 'is_anonymous')::boolean is not true);
+
+create policy "member write quests" on public.quests
+  for all to authenticated
+  using      ((auth.jwt() ->> 'is_anonymous')::boolean is not true)
+  with check ((auth.jwt() ->> 'is_anonymous')::boolean is not true);
+
+create policy "member write goals" on public.goals
+  for all to authenticated
+  using      ((auth.jwt() ->> 'is_anonymous')::boolean is not true)
+  with check ((auth.jwt() ->> 'is_anonymous')::boolean is not true);
+
+create policy "member write items" on public.items
+  for all to authenticated
+  using      ((auth.jwt() ->> 'is_anonymous')::boolean is not true)
+  with check ((auth.jwt() ->> 'is_anonymous')::boolean is not true);
+
+create policy "member write lore" on public.lore
+  for all to authenticated
+  using      ((auth.jwt() ->> 'is_anonymous')::boolean is not true)
+  with check ((auth.jwt() ->> 'is_anonymous')::boolean is not true);
+
+create policy "member write connections" on public.connections
+  for all to authenticated
+  using      ((auth.jwt() ->> 'is_anonymous')::boolean is not true)
+  with check ((auth.jwt() ->> 'is_anonymous')::boolean is not true);
+
+create policy "member write board_positions" on public.board_positions
+  for all to authenticated
+  using      ((auth.jwt() ->> 'is_anonymous')::boolean is not true)
+  with check ((auth.jwt() ->> 'is_anonymous')::boolean is not true);
+
+create policy "member write presence_users" on public.presence_users
+  for all to authenticated
+  using      ((auth.jwt() ->> 'is_anonymous')::boolean is not true)
+  with check ((auth.jwt() ->> 'is_anonymous')::boolean is not true);
+
+create policy "member write party_notes" on public.party_notes
+  for all to authenticated
+  using      ((auth.jwt() ->> 'is_anonymous')::boolean is not true)
+  with check ((auth.jwt() ->> 'is_anonymous')::boolean is not true);
+
+-- Storage write policies (replacing the write half of 0004_entity_images.sql;
+-- the "anon read entity-images" select policy stays as-is)
+
+drop policy "auth write entity-images"  on storage.objects;
+drop policy "auth update entity-images" on storage.objects;
+drop policy "auth delete entity-images" on storage.objects;
+
+create policy "member write entity-images"
+  on storage.objects for insert
+  to authenticated
+  with check (
+    bucket_id = 'entity-images'
+    and (auth.jwt() ->> 'is_anonymous')::boolean is not true
+  );
+
+create policy "member update entity-images"
+  on storage.objects for update
+  to authenticated
+  using (
+    bucket_id = 'entity-images'
+    and (auth.jwt() ->> 'is_anonymous')::boolean is not true
+  );
+
+create policy "member delete entity-images"
+  on storage.objects for delete
+  to authenticated
+  using (
+    bucket_id = 'entity-images'
+    and (auth.jwt() ->> 'is_anonymous')::boolean is not true
+  );


### PR DESCRIPTION
## Summary
- **Migration [0006_reject_anonymous_writes.sql](supabase/migrations/0006_reject_anonymous_writes.sql)**: drops all 13 `auth write <table>` policies (0003) and the 3 storage write policies (0004), recreating them gated on `(auth.jwt() ->> 'is_anonymous')::boolean is not true`. Anonymous users hold the `authenticated` *role* — the claim is the only reliable gate. Reads stay open to `anon`, so shared links keep working.
- **Auth (src/auth.tsx)**: `canEdit` flag (non-anonymous session), `signInWithEmail` (magic link via `signInWithOtp`, redirect to origin — the client's default `detectSessionInUrl` consumes the token), `signOut` now re-signs-in anonymously instead of blanking the app, display name falls back to email prefix, anonymous viewers skip the name gate, new `SignInDialog`.
- **Read-only viewer UX**: `EditableText`/`EnumSelect` check `canEdit` themselves and render plain text — covering every field from #21/#22 centrally. Mutating buttons hidden: board Pin new / Draw string / connection ✕ / drag, sidebar `+`, detail-sheet PIN/ARCHIVE/STRIKE, note composer, Add Relation, portrait upload chips (existing images still shown), cleanup bulk archive.
- **Topbar**: READ-ONLY chip + "Sign in to edit" for viewers; display name + Sign out for editors. The dead "New entry" button is gone.
- **CLAUDE.md**: Auth section rewritten for the two-tier model (acceptance criterion).

## Rollout order (IMPORTANT — migration is NOT applied yet)
Applying the migration before this deploys would lock the whole group out with no sign-in path:
1. Merge + deploy this PR.
2. Supabase dashboard → Authentication: keep **Anonymous ON**, enable **Email** (magic link), **disable sign-ups** (invite-only editors), set Site URL + add `http://localhost:5173` to Redirect URLs.
3. Add the party's editor emails via the dashboard (invite or create users).
4. Apply `0006_reject_anonymous_writes.sql` via the dashboard SQL editor (the MCP connection in this session was read-only).
5. Re-run Supabase advisors; remaining claim-based-policy warnings are acknowledged in the migration header.

## Verification
Playwright against the dev server, driving the app as an anonymous session (= viewer under the new code):
- READ-ONLY chip + Sign in to edit shown; Pin new / Draw string / sidebar + / New entry all hidden
- Detail sheet: 0 editable elements, 0 selects; stats render as plain text; STRIKE/PIN/ARCHIVE, note composer, Add Relation gone; existing portraits still visible without Replace/✕
- Sign-in dialog opens/closes; fresh visitor (cleared storage) lands read-only with no name gate
- `npm run build` passes
- Not driven live: the email round-trip (needs dashboard config) and actual RLS rejection (migration deliberately unapplied) — both covered by the rollout checklist

Stacked on #23; retargets as the stack merges.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)