### PR TITLE
Group sessions and quests into arcs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { useCampaignStatus, useKinds } from "./hooks";
 import { Icon } from "./icons";
 import { Sidebar, Topbar } from "./components";
 import { NoticeBoard, KindList } from "./board";
+import { ArcsPage } from "./arcs";
 import { DetailSheet } from "./detail";
 import { CommandPalette, useCommandPaletteHotkey } from "./commandPalette";
 import { CleanupPanel } from "./cleanupPanel";
@@ -108,7 +109,8 @@ function AppLoaded() {
         <Sidebar active={view} onSelect={setView} onOpenEntity={setOpenId} onOpenCleanup={() => setCleanupOpen(true)} counts={counts} />
         <main className="main">
           {view === "board" && <NoticeBoard onOpenEntity={setOpenId} />}
-          {view !== "board" && <KindList kind={view} onOpenEntity={setOpenId} />}
+          {view === "arcs" && <ArcsPage onOpenEntity={setOpenId} />}
+          {view !== "board" && view !== "arcs" && <KindList kind={view} onOpenEntity={setOpenId} />}
         </main>
       </div>
 

--- a/src/arcs.tsx
+++ b/src/arcs.tsx
@@ -53,7 +53,8 @@ export function ArcsPage({ onOpenEntity }: { onOpenEntity: (id: string) => void 
         <div className="scratch-divider"><em>✦ ✦ ✦</em></div>
 
         {arcs.map((arc) => {
-          const assigned = campaign.sessions.filter((s) => s.arc === arc.id);
+          // Array order isn't trustworthy after realtime splices — sort by num.
+          const assigned = campaign.sessions.filter((s) => s.arc === arc.id).sort((a, b) => a.num - b.num);
           const quests = campaign.quests.filter((q) => q.arc === arc.id);
           const range = arcRange(arc, assigned, sessionsById);
           const summary = excerpt(arc.summary);

--- a/src/arcs.tsx
+++ b/src/arcs.tsx
@@ -1,0 +1,121 @@
+import { type Arc, type Session } from "./data";
+import { useCampaign } from "./hooks";
+import { useAuth } from "./auth";
+import { createEntity } from "./mutations";
+
+// Plain-text excerpt of a markdown summary for the arc list.
+function excerpt(text: string | undefined, max = 140): string {
+  if (!text) return "";
+  const plain = text.replace(/[#*_>`~\[\]]/g, "").replace(/\s+/g, " ").trim();
+  return plain.length > max ? `${plain.slice(0, max)}…` : plain;
+}
+
+// "Session 3 — 12 June 2025" style range for an arc: explicit start/end
+// sessions when set, otherwise the min/max of its assigned sessions.
+function arcRange(arc: Arc, assigned: Session[], byId: Map<string, Session>): string {
+  const first = (arc.startSession && byId.get(arc.startSession)) || assigned[0];
+  const last = (arc.endSession && byId.get(arc.endSession)) || assigned[assigned.length - 1];
+  if (!first || !last) return "";
+  if (first.id === last.id) return first.date;
+  return `${first.date} — ${last.date}`;
+}
+
+export function ArcsPage({ onOpenEntity }: { onOpenEntity: (id: string) => void }) {
+  const campaign = useCampaign();
+  const { canEdit } = useAuth();
+
+  const arcs = campaign.arcs.slice().sort((a, b) => a.orderNum - b.orderNum || a.title.localeCompare(b.title));
+  const sessionsById = new Map(campaign.sessions.map((s) => [s.id, s]));
+  const unassigned = campaign.sessions.filter((s) => !s.arc);
+
+  const onNewArc = () => {
+    const id = crypto.randomUUID();
+    const orderNum = Math.max(0, ...campaign.arcs.map((a) => a.orderNum)) + 1;
+    createEntity("arcs", id, { title: "Untitled arc", orderNum })
+      .then(() => onOpenEntity(id))
+      .catch(console.error);
+  };
+
+  return (
+    <div style={{ flex: 1, overflow: "auto", padding: "28px 40px 60px", background: "var(--vellum)", position: "relative" }} className="tex-vellum">
+      <div style={{ position: "relative", zIndex: 1, maxWidth: 860 }}>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 16, marginBottom: 8, flexWrap: "wrap" }}>
+          <h1 style={{ margin: 0, fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 40, color: "var(--ink)", letterSpacing: ".01em" }}>Story Arcs</h1>
+          <span style={{ fontFamily: "var(--font-fell)", fontStyle: "italic", fontSize: 16, color: "var(--ink-faded)" }}>
+            {arcs.length} {arcs.length === 1 ? "arc" : "arcs"} of the chronicle
+          </span>
+          {canEdit && (
+            <button onClick={onNewArc} className="cleanup-link-btn" style={{ marginLeft: "auto" }}>
+              + new arc
+            </button>
+          )}
+        </div>
+        <div className="scratch-divider"><em>✦ ✦ ✦</em></div>
+
+        {arcs.map((arc) => {
+          const assigned = campaign.sessions.filter((s) => s.arc === arc.id);
+          const quests = campaign.quests.filter((q) => q.arc === arc.id);
+          const range = arcRange(arc, assigned, sessionsById);
+          const summary = excerpt(arc.summary);
+          return (
+            <section key={arc.id} style={{ marginTop: 30 }}>
+              <div style={{ display: "flex", alignItems: "baseline", gap: 12, flexWrap: "wrap" }}>
+                <h2
+                  onClick={() => onOpenEntity(arc.id)}
+                  style={{ margin: 0, fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 24, color: "var(--ink)", cursor: "pointer" }}
+                >
+                  {arc.title}
+                </h2>
+                <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".12em", fontSize: 11, color: "var(--ink-faded)" }}>
+                  {assigned.length} {assigned.length === 1 ? "session" : "sessions"}
+                  {quests.length > 0 && ` · ${quests.length} ${quests.length === 1 ? "quest" : "quests"}`}
+                  {range && ` · ${range}`}
+                </span>
+              </div>
+              {summary && (
+                <p style={{ margin: "6px 0 0", fontFamily: "var(--font-fell)", fontStyle: "italic", fontSize: 14, color: "var(--ink-body)" }}>
+                  {summary}
+                </p>
+              )}
+              <div style={{ display: "flex", flexDirection: "column", gap: 2, marginTop: 10 }}>
+                {assigned.map((s) => (
+                  <div key={s.id} className="session-chip" onClick={() => onOpenEntity(s.id)}>
+                    <span className="num">SESS {String(s.num).padStart(2, "0")}</span>
+                    <span style={{ flex: 1 }}>{s.title}</span>
+                  </div>
+                ))}
+                {assigned.length === 0 && (
+                  <span style={{ fontFamily: "var(--font-fell)", fontStyle: "italic", fontSize: 13, color: "var(--ink-ghost)" }}>
+                    No sessions claimed by this arc yet.
+                  </span>
+                )}
+              </div>
+            </section>
+          );
+        })}
+
+        {arcs.length === 0 && (
+          <p style={{ marginTop: 30, fontFamily: "var(--font-fell)", fontStyle: "italic", fontSize: 15, color: "var(--ink-faded)" }}>
+            No arcs written yet — the chronicle is a single unbroken thread.
+          </p>
+        )}
+
+        {unassigned.length > 0 && arcs.length > 0 && (
+          <section style={{ marginTop: 34 }}>
+            <div style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".18em", fontSize: 12, color: "var(--ink-faded)" }}>
+              ✦ UNCLAIMED SESSIONS ✦
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 2, marginTop: 8 }}>
+              {unassigned.map((s) => (
+                <div key={s.id} className="session-chip" onClick={() => onOpenEntity(s.id)}>
+                  <span className="num">SESS {String(s.num).padStart(2, "0")}</span>
+                  <span style={{ flex: 1 }}>{s.title}</span>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/board.tsx
+++ b/src/board.tsx
@@ -18,7 +18,7 @@ import {
 
 // Minimum required columns by kind (NOT NULL constraints in 0001_init.sql).
 // createEntity injects id + campaign_id, so only the per-kind required fields go here.
-const NEW_ENTITY_DEFAULTS: Record<Exclude<KindKey, "sessions">, Record<string, unknown>> = {
+const NEW_ENTITY_DEFAULTS: Record<Exclude<KindKey, "sessions" | "arcs">, Record<string, unknown>> = {
   people:    { name: "Unnamed wayfarer" },
   locations: { name: "Unnamed place", kind: "other" },
   quests:    { title: "Untitled quest" },
@@ -106,7 +106,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
 
   const [addMenuOpen, setAddMenuOpen] = useState(false);
 
-  const onCreate = async (k: Exclude<KindKey, "sessions">) => {
+  const onCreate = async (k: Exclude<KindKey, "sessions" | "arcs">) => {
     setAddMenuOpen(false);
     const id = crypto.randomUUID();
     try {
@@ -263,7 +263,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
                 {kinds.map((k) => (
                   <div
                     key={k.key}
-                    onClick={() => onCreate(k.key as Exclude<KindKey, "sessions">)}
+                    onClick={() => onCreate(k.key as Exclude<KindKey, "sessions" | "arcs">)}
                     style={{
                       display: "flex", alignItems: "center", gap: 10,
                       padding: "8px 12px", cursor: "pointer",

--- a/src/campaignContext.tsx
+++ b/src/campaignContext.tsx
@@ -66,6 +66,7 @@ const mapQuest = (r: any) => ({
   session: r.session_id ?? undefined,
   desc: r.desc ?? undefined,
   hooks: r.hooks ?? undefined,
+  arc: r.arc_id ?? undefined,
   ...archiveFields(r),
 });
 
@@ -112,6 +113,16 @@ const mapSession = (r: any) => ({
   summary: r.summary ?? undefined,
   imageUrl: r.image_url ?? undefined,
   inGameDate: r.in_game_date ?? undefined,
+  arc: r.arc_id ?? undefined,
+});
+
+const mapArc = (r: any) => ({
+  id: r.id,
+  title: r.title,
+  summary: r.summary ?? undefined,
+  startSession: r.start_session_id ?? undefined,
+  endSession: r.end_session_id ?? undefined,
+  orderNum: r.order_num ?? 0,
 });
 
 const mapPresence = (r: any) => ({
@@ -143,6 +154,7 @@ async function fetchCampaign(id: string): Promise<Campaign> {
   const [
     campaignRes,
     sessionsRes,
+    arcsRes,
     peopleRes,
     locationsRes,
     questsRes,
@@ -157,6 +169,7 @@ async function fetchCampaign(id: string): Promise<Campaign> {
   ] = await Promise.all([
     supabase.from("campaigns").select("*").eq("id", id).single(),
     supabase.from("sessions").select("*").eq("campaign_id", id).order("num"),
+    supabase.from("arcs").select("*").eq("campaign_id", id).order("order_num"),
     supabase.from("people").select("*").eq("campaign_id", id),
     supabase.from("locations").select("*").eq("campaign_id", id),
     supabase.from("quests").select("*").eq("campaign_id", id),
@@ -171,7 +184,7 @@ async function fetchCampaign(id: string): Promise<Campaign> {
   ]);
 
   const first = [
-    campaignRes, sessionsRes, peopleRes, locationsRes, questsRes, goalsRes,
+    campaignRes, sessionsRes, arcsRes, peopleRes, locationsRes, questsRes, goalsRes,
     factionsRes, itemsRes, loreRes, connectionsRes, boardRes, presenceRes, notesRes,
   ].find((r) => r.error);
   if (first?.error) throw new Error(first.error.message);
@@ -187,6 +200,7 @@ async function fetchCampaign(id: string): Promise<Campaign> {
     title: campaignRes.data.title,
     subtitle: campaignRes.data.subtitle ?? "",
     sessions: (sessionsRes.data ?? []).map(mapSession),
+    arcs: (arcsRes.data ?? []).map(mapArc),
     people: (peopleRes.data ?? []).map(mapPerson),
     locations: (locationsRes.data ?? []).map(mapLocation),
     quests: (questsRes.data ?? []).map(mapQuest),
@@ -287,6 +301,13 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
           { event: "*", schema: "public", table: "sessions", filter },
           (payload: any) => {
             setCampaign((c) => c ? { ...c, sessions: applyArrayChange(c.sessions, payload.eventType, payload.new ? mapSession(payload.new) : null, payload.old ? mapSession(payload.old) : null) } : c);
+          },
+        );
+        channel.on(
+          "postgres_changes" as any,
+          { event: "*", schema: "public", table: "arcs", filter },
+          (payload: any) => {
+            setCampaign((c) => c ? { ...c, arcs: applyArrayChange(c.arcs, payload.eventType, payload.new ? mapArc(payload.new) : null, payload.old ? mapArc(payload.old) : null) } : c);
           },
         );
         channel.on(

--- a/src/commandPalette.tsx
+++ b/src/commandPalette.tsx
@@ -15,7 +15,7 @@ interface PaletteHit {
   archived?: boolean;
 }
 
-const KIND_ICON: Record<KindKey, "people" | "location" | "quest" | "goal" | "faction" | "item" | "lore" | "session"> = {
+const KIND_ICON: Record<KindKey, "people" | "location" | "quest" | "goal" | "faction" | "item" | "lore" | "session" | "layers"> = {
   people: "people",
   locations: "location",
   quests: "quest",
@@ -24,6 +24,7 @@ const KIND_ICON: Record<KindKey, "people" | "location" | "quest" | "goal" | "fac
   items: "item",
   lore: "lore",
   sessions: "session",
+  arcs: "layers",
 };
 
 const KIND_LABEL: Record<KindKey, string> = {
@@ -35,6 +36,7 @@ const KIND_LABEL: Record<KindKey, string> = {
   items: "Item",
   lore: "Lore",
   sessions: "Session",
+  arcs: "Arc",
 };
 
 interface Indexed {
@@ -129,6 +131,15 @@ function buildIndex(campaign: Campaign): Indexed[] {
       label: entityLabel(s),
       primary: s.title ?? "",
       secondary: joinFields(s.date, s.inGameDate, `Session ${s.num}`, s.summary),
+    });
+  }
+  for (const a of campaign.arcs) {
+    out.push({
+      id: a.id,
+      kind: "arcs",
+      label: entityLabel(a),
+      primary: a.title ?? "",
+      secondary: a.summary ?? "",
     });
   }
   return out;

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -263,9 +263,12 @@ export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts 
   // View filter, not a write — available to read-only viewers too.
   const [arcFilter, setArcFilter] = useState<string>("all");
   const arcsById = new Map(campaign.arcs.map((a) => [a.id, a]));
-  const visibleSessions = arcFilter === "all"
+  // Fall back to "all" if the selected arc was deleted (possibly live, from
+  // another tab) so the list and the select never disagree.
+  const effectiveArcFilter = arcsById.has(arcFilter) ? arcFilter : "all";
+  const visibleSessions = effectiveArcFilter === "all"
     ? campaign.sessions
-    : campaign.sessions.filter((s) => s.arc === arcFilter);
+    : campaign.sessions.filter((s) => s.arc === effectiveArcFilter);
   return (
     <aside className="sidebar">
       <div className="sidebar-label"><span>The Board</span></div>
@@ -336,7 +339,7 @@ export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts 
       </div>
       {campaign.arcs.length > 0 && (
         <select
-          value={arcsById.has(arcFilter) ? arcFilter : "all"}
+          value={effectiveArcFilter}
           onChange={(e) => setArcFilter(e.target.value)}
           title="Filter sessions by arc"
           style={{

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -260,6 +260,12 @@ export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts 
   const kinds = useKinds();
   const { canEdit } = useAuth();
   const totalArchived = kinds.reduce((sum, k) => sum + (counts[k.key]?.archived ?? 0), 0);
+  // View filter, not a write — available to read-only viewers too.
+  const [arcFilter, setArcFilter] = useState<string>("all");
+  const arcsById = new Map(campaign.arcs.map((a) => [a.id, a]));
+  const visibleSessions = arcFilter === "all"
+    ? campaign.sessions
+    : campaign.sessions.filter((s) => s.arc === arcFilter);
   return (
     <aside className="sidebar">
       <div className="sidebar-label"><span>The Board</span></div>
@@ -297,6 +303,13 @@ export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts 
         {totalArchived > 0 && <span className="count-archived">{totalArchived} archived</span>}
       </div>
 
+      <div className="sidebar-label"><span>The Chronicle</span></div>
+      <div className={`nav-item ${active === "arcs" ? "active" : ""}`} onClick={() => onSelect("arcs")}>
+        <span className="icon"><Icon name="layers" /></span>
+        Story Arcs
+        <span className="count">{campaign.arcs.length}</span>
+      </div>
+
       <div className="sidebar-label">
         <span>Sessions</span>
         {canEdit && <button
@@ -321,7 +334,30 @@ export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts 
           }}
         >+</button>}
       </div>
-      {campaign.sessions.slice().reverse().map((s) => (
+      {campaign.arcs.length > 0 && (
+        <select
+          value={arcsById.has(arcFilter) ? arcFilter : "all"}
+          onChange={(e) => setArcFilter(e.target.value)}
+          title="Filter sessions by arc"
+          style={{
+            margin: "2px 16px 6px",
+            background: "transparent",
+            border: "1px dashed var(--ink-faded)",
+            fontFamily: "var(--font-fell)",
+            fontStyle: "italic",
+            fontSize: 12,
+            color: "var(--ink-faded)",
+            padding: "2px 6px",
+            cursor: "pointer",
+          }}
+        >
+          <option value="all">every arc</option>
+          {campaign.arcs.slice().sort((a, b) => a.orderNum - b.orderNum).map((a) => (
+            <option key={a.id} value={a.id}>{a.title}</option>
+          ))}
+        </select>
+      )}
+      {visibleSessions.slice().reverse().map((s) => (
         <div key={s.id} className="session-chip" onClick={() => onOpenEntity(s.id)}>
           <span className="num">SESS {String(s.num).padStart(2, "0")}</span>
           <span style={{ flex: 1 }}>{s.title}</span>
@@ -720,6 +756,64 @@ export function EnumSelect<T extends string>({
       {allowClear && <option value="">—</option>}
       {options.map((o) => (
         <option key={o} value={o}>{o}</option>
+      ))}
+    </select>
+  );
+}
+
+interface EntitySelectProps {
+  value: string | undefined;
+  options: Array<{ id: string; label: string }>;
+  onSave: (next: string | null) => void | Promise<void>;
+  allowClear?: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+// EnumSelect's sibling for FK fields: options carry an id + display label and
+// onSave receives the id (or null when cleared).
+export function EntitySelect({
+  value,
+  options,
+  onSave,
+  allowClear = false,
+  className,
+  style,
+}: EntitySelectProps) {
+  const { canEdit } = useAuth();
+  const current = options.find((o) => o.id === value);
+  if (!canEdit) {
+    return (
+      <span className={className} style={{ fontFamily: "var(--font-fell)", ...style }}>
+        {current?.label ?? "—"}
+      </span>
+    );
+  }
+  return (
+    <select
+      className={className}
+      // A dangling FK (option not in the list) renders as the empty choice
+      // rather than silently selecting the first option.
+      value={current ? value : ""}
+      onChange={(e) => {
+        const v = e.target.value;
+        void onSave(v === "" ? null : v);
+      }}
+      style={{
+        background: "transparent",
+        border: "1px dashed var(--ink-faded)",
+        fontFamily: "var(--font-fell)",
+        fontSize: "inherit",
+        color: "var(--ink)",
+        padding: "2px 6px",
+        cursor: "pointer",
+        maxWidth: "100%",
+        ...style,
+      }}
+    >
+      {(allowClear || !current) && <option value="">—</option>}
+      {options.map((o) => (
+        <option key={o.id} value={o.id}>{o.label}</option>
       ))}
     </select>
   );

--- a/src/data.ts
+++ b/src/data.ts
@@ -7,7 +7,8 @@ export type KindKey =
   | "factions"
   | "items"
   | "lore"
-  | "sessions";
+  | "sessions"
+  | "arcs";
 
 export interface Session {
   id: string;
@@ -17,6 +18,18 @@ export interface Session {
   summary?: string;
   imageUrl?: string;
   inGameDate?: string;
+  arc?: string;
+}
+
+// Story arcs group sessions and quests ("Barovia Saga"). Like sessions they
+// live outside buildKinds: no board cards, no archiving, a bespoke page.
+export interface Arc {
+  id: string;
+  title: string;
+  summary?: string;
+  startSession?: string;
+  endSession?: string;
+  orderNum: number;
 }
 
 export interface ArchivableFields {
@@ -60,6 +73,7 @@ export interface Quest extends ArchivableFields {
   session?: string;
   desc?: string;
   hooks?: string;
+  arc?: string;
 }
 
 export interface Goal extends ArchivableFields {
@@ -121,7 +135,7 @@ export interface PartyNote {
 export type Connection = [string, string, string];
 
 export type Entity =
-  & (Person | Location | Quest | Goal | Faction | Item | Lore | Session)
+  & (Person | Location | Quest | Goal | Faction | Item | Lore | Session | Arc)
   & { _kind?: KindKey; _kindLabel?: string };
 
 export interface Campaign {
@@ -129,6 +143,7 @@ export interface Campaign {
   title: string;
   subtitle: string;
   sessions: Session[];
+  arcs: Arc[];
   people: Person[];
   locations: Location[];
   quests: Quest[];
@@ -176,6 +191,8 @@ export function findEntity(
   }
   const sess = campaign.sessions.find((s) => s.id === id);
   if (sess) return { ...sess, _kind: "sessions", _kindLabel: "Sessions", name: sess.title } as any;
+  const arc = campaign.arcs.find((a) => a.id === id);
+  if (arc) return { ...arc, _kind: "arcs", _kindLabel: "Arcs", name: arc.title } as any;
   return null;
 }
 

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState } from "react";
 import { type KindKey, entityLabel, isArchivableKind, isArchived, isPinned } from "./data";
 import { Icon, kindIcon } from "./icons";
-import { StatusChip, EditableText, EditableMarkdown, EnumSelect } from "./components";
+import { StatusChip, EditableText, EditableMarkdown, EnumSelect, EntitySelect } from "./components";
 import { useCampaign, useFindEntity } from "./hooks";
 import { useAuth } from "./auth";
 import {
@@ -165,6 +165,7 @@ function AddRelationForm({ fromId }: { fromId: string }) {
       ...campaign.items.map((i) => ({ id: i.id, label: i.name, kind: "items" })),
       ...campaign.lore.map((l) => ({ id: l.id, label: l.title, kind: "lore" })),
       ...campaign.sessions.map((s) => ({ id: s.id, label: s.title, kind: "sessions" })),
+      ...campaign.arcs.map((a) => ({ id: a.id, label: a.title, kind: "arcs" })),
     ].filter((o) => o.id !== fromId),
     [campaign, fromId],
   );
@@ -238,6 +239,7 @@ const primaryField: Record<KindKey, string> = {
   quests: "title",
   lore: "title",
   sessions: "title",
+  arcs: "title",
   goals: "text",
 };
 
@@ -318,11 +320,42 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
       }];
     }
   }
+  if ((kind === "sessions" || kind === "quests") && (entity as any).arc) {
+    const a = findEntity((entity as any).arc);
+    if (a) {
+      related.arcs = related.arcs || [];
+      if (!related.arcs.find((r) => r.entity.id === a.id)) {
+        related.arcs.push({ entity: a, rel: "part of arc" });
+      }
+    }
+  }
+  if (kind === "arcs") {
+    // An arc's chapters: the sessions and quests that claim it.
+    campaign.sessions.filter((s) => s.arc === entityId).forEach((s) => {
+      related.sessions = related.sessions || [];
+      if (!related.sessions.find((r) => r.entity.id === s.id)) {
+        related.sessions.push({ entity: findEntity(s.id), rel: "chapter of this arc" });
+      }
+    });
+    campaign.quests.filter((q) => q.arc === entityId).forEach((q) => {
+      related.quests = related.quests || [];
+      if (!related.quests.find((r) => r.entity.id === q.id)) {
+        related.quests.push({ entity: findEntity(q.id), rel: "woven into this arc" });
+      }
+    });
+  }
 
   const patch = (fields: Record<string, unknown>) =>
     updateEntity(kind, entityId, fields).catch((e) =>
       console.error(`updateEntity(${kind}) failed`, e),
     );
+
+  const arcOptions = campaign.arcs
+    .slice()
+    .sort((a, b) => a.orderNum - b.orderNum)
+    .map((a) => ({ id: a.id, label: a.title }));
+  const sessionOptions = campaign.sessions
+    .map((s) => ({ id: s.id, label: `S${String(s.num).padStart(2, "0")} — ${s.title}` }));
 
   const onDelete = () => {
     if (!entity) return;
@@ -356,6 +389,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
   const kindTitle: Record<string, string> = {
     people: "Person of Note", locations: "Location", quests: "Quest",
     goals: "Goal", factions: "Faction", items: "Item", lore: "Lore", sessions: "Session",
+    arcs: "Story Arc",
   };
 
   return (
@@ -454,6 +488,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                     <div className="stat"><div className="stat-label">Status</div><div className="stat-value"><StatusChip status={(entity as any).status} /></div></div>
                     <div className="stat" style={{ gridColumn: "span 2" }}><div className="stat-label">Reward</div><div className="stat-value" style={{ fontSize: 13 }}><EditableText value={(entity as any).reward ?? ""} onSave={(v) => patch({ reward: v })} placeholder="—" /></div></div>
                     <div className="stat"><div className="stat-label">Session</div><div className="stat-value">{(entity as any).session?.toUpperCase()}</div></div>
+                    <div className="stat" style={{ gridColumn: "span 2" }}><div className="stat-label">Arc</div><div className="stat-value" style={{ fontSize: 13 }}><EntitySelect value={(entity as any).arc} options={arcOptions} allowClear onSave={(id) => patch({ arc: id ?? "" })} /></div></div>
                   </>
                 )}
                 {kind === "goals" && (
@@ -479,6 +514,14 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                     <div className="stat"><div className="stat-label">No.</div><div className="stat-value"><EditableNumber value={(entity as any).num ?? 0} onSave={(n) => patch({ num: n })} /></div></div>
                     <div className="stat"><div className="stat-label">Date</div><div className="stat-value" style={{ fontSize: 14 }}><EditableText value={(entity as any).date ?? ""} onSave={(v) => patch({ date: v })} placeholder="—" /></div></div>
                     <div className="stat" style={{ gridColumn: "span 2" }}><div className="stat-label">Reckoning</div><div className="stat-value" style={{ fontSize: 14 }}><EditableText value={(entity as any).inGameDate ?? ""} onSave={(v) => patch({ inGameDate: v })} placeholder="— by Faerûn's reckoning —" /></div></div>
+                    <div className="stat" style={{ gridColumn: "span 2" }}><div className="stat-label">Arc</div><div className="stat-value" style={{ fontSize: 13 }}><EntitySelect value={(entity as any).arc} options={arcOptions} allowClear onSave={(id) => patch({ arc: id ?? "" })} /></div></div>
+                  </>
+                )}
+                {kind === "arcs" && (
+                  <>
+                    <div className="stat" style={{ gridColumn: "span 2" }}><div className="stat-label">First Session</div><div className="stat-value" style={{ fontSize: 13 }}><EntitySelect value={(entity as any).startSession} options={sessionOptions} allowClear onSave={(id) => patch({ startSession: id ?? "" })} /></div></div>
+                    <div className="stat" style={{ gridColumn: "span 2" }}><div className="stat-label">Last Session</div><div className="stat-value" style={{ fontSize: 13 }}><EntitySelect value={(entity as any).endSession} options={sessionOptions} allowClear onSave={(id) => patch({ endSession: id ?? "" })} /></div></div>
+                    <div className="stat"><div className="stat-label">Order</div><div className="stat-value"><EditableNumber value={(entity as any).orderNum ?? 0} onSave={(n) => patch({ orderNum: n })} /></div></div>
                   </>
                 )}
               </div>
@@ -508,6 +551,17 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                     value={(entity as any).summary ?? ""}
                     onSave={(v) => patch({ summary: v })}
                     placeholder="What happened this session…"
+                    style={{ fontFamily: "var(--font-fell)" }}
+                  />
+                </div>
+              )}
+
+              {kind === "arcs" && (
+                <div className="long-note">
+                  <EditableMarkdown
+                    value={(entity as any).summary ?? ""}
+                    onSave={(v) => patch({ summary: v })}
+                    placeholder="The shape of this arc…"
                     style={{ fontFamily: "var(--font-fell)" }}
                   />
                 </div>
@@ -633,13 +687,13 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                 ✦ RELATIONS ✦
               </div>
 
-              {(["people", "locations", "quests", "goals", "factions", "items", "lore", "sessions"] as const).map((k) => {
+              {(["people", "locations", "quests", "goals", "factions", "items", "lore", "sessions", "arcs"] as const).map((k) => {
                 const list = related[k];
                 if (!list || list.length === 0) return null;
                 const label: Record<string, string> = {
                   people: "Known Folk", locations: "Places", quests: "Quests",
                   goals: "Goals", factions: "Factions", items: "Items & Relics",
-                  lore: "Lore", sessions: "Sessions",
+                  lore: "Lore", sessions: "Sessions", arcs: "Story Arcs",
                 };
                 return (
                   <div className="rail-section" key={k}>

--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -61,6 +61,7 @@ export const kindIcon: Record<KindKey, IconName> = {
   items: "item",
   lore: "lore",
   sessions: "session",
+  arcs: "layers",
 };
 
 export const CompassRose = ({ style }: { style?: CSSProperties }) => (

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -18,6 +18,7 @@ const fieldAlias: Record<KindKey, Record<string, string>> = {
   quests: {
     giver: "giver_id",
     session: "session_id",
+    arc: "arc_id",
   },
   locations: {
     imageUrl: "image_url",
@@ -33,6 +34,12 @@ const fieldAlias: Record<KindKey, Record<string, string>> = {
   sessions: {
     imageUrl: "image_url",
     inGameDate: "in_game_date",
+    arc: "arc_id",
+  },
+  arcs: {
+    startSession: "start_session_id",
+    endSession: "end_session_id",
+    orderNum: "order_num",
   },
 };
 

--- a/supabase/migrations/0008_arcs.sql
+++ b/supabase/migrations/0008_arcs.sql
@@ -1,0 +1,26 @@
+-- Issue #11: story arcs grouping sessions and quests.
+create table public.arcs (
+  id text primary key,
+  campaign_id text not null references public.campaigns(id) on delete cascade,
+  title text not null,
+  summary text,
+  start_session_id text references public.sessions(id) on delete set null,
+  end_session_id   text references public.sessions(id) on delete set null,
+  order_num int not null default 0
+);
+
+-- Deleting an arc leaves its sessions/quests intact and unassigned.
+alter table public.sessions add column if not exists arc_id text references public.arcs(id) on delete set null;
+alter table public.quests   add column if not exists arc_id text references public.arcs(id) on delete set null;
+
+alter table public.arcs enable row level security;
+
+create policy "anon read arcs" on public.arcs
+  for select to anon, authenticated using (true);
+
+create policy "member write arcs" on public.arcs
+  for all to authenticated
+  using      ((auth.jwt() ->> 'is_anonymous')::boolean is not true)
+  with check ((auth.jwt() ->> 'is_anonymous')::boolean is not true);
+
+alter publication supabase_realtime add table public.arcs;


### PR DESCRIPTION
## Summary

Second PR of **M2 — Chronicle Depth** (#9 → #11 → #12). Stacked on #25.

- **Migration [0008_arcs.sql](../blob/feat/arcs/supabase/migrations/0008_arcs.sql)**: `arcs` table + nullable `sessions.arc_id` / `quests.arc_id` (`on delete set null`), RLS per the 0006 pattern, realtime publication membership.
- **Arcs follow the sessions "second-class kind" template**: in the `KindKey` union (detail sheet, `findEntity`, connections, command palette all work) but excluded from `buildKinds`/`ARCHIVABLE_KINDS`/board.
- **Story Arcs page** (`src/arcs.tsx`): arcs in `order_num` order with session + quest counts, date range (explicit start/end refs, falling back to assigned sessions), session chips, an unclaimed-sessions section, and a canEdit-gated "+ new arc".
- **`EntitySelect`** (components.tsx): `EnumSelect`'s sibling for FK fields — id-labelled options, saves the id or null, renders dangling FKs as empty instead of mis-selecting. Used for arc pickers on session/quest sheets and first/last-session pickers on the arc sheet.
- **Sidebar**: new "The Chronicle" section with the Story Arcs nav item; the session list gains an arc filter (view-only, visible to anonymous viewers too).
- **Arc sheet**: markdown summary (`EditableMarkdown`), order/first/last stats, and a relations rail synthesizing its member sessions ("chapter of this arc") and quests ("woven into this arc").

## Migration status

⚠️ **The app hard-fails to load until 0008 is applied** (`fetchCampaign` selects from `arcs`). Apply 0007 + 0008 via the dashboard SQL editor before merging.

## Verification

- `npm run build` passes (this PR widens `KindKey`, so tsc checked every `Record<KindKey, …>` site).
- Dev server verified to show the clean error sheet against the un-migrated DB; full flow verification pending migration application.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)