### PR TITLE
Add events as a first-class timeline primitive

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { Icon } from "./icons";
 import { Sidebar, Topbar } from "./components";
 import { NoticeBoard, KindList } from "./board";
 import { ArcsPage } from "./arcs";
+import { EventsPage } from "./events";
 import { DetailSheet } from "./detail";
 import { CommandPalette, useCommandPaletteHotkey } from "./commandPalette";
 import { CleanupPanel } from "./cleanupPanel";
@@ -110,7 +111,8 @@ function AppLoaded() {
         <main className="main">
           {view === "board" && <NoticeBoard onOpenEntity={setOpenId} />}
           {view === "arcs" && <ArcsPage onOpenEntity={setOpenId} />}
-          {view !== "board" && view !== "arcs" && <KindList kind={view} onOpenEntity={setOpenId} />}
+          {view === "events" && <EventsPage onOpenEntity={setOpenId} />}
+          {!["board", "arcs", "events"].includes(view) && <KindList kind={view} onOpenEntity={setOpenId} />}
         </main>
       </div>
 

--- a/src/board.tsx
+++ b/src/board.tsx
@@ -18,7 +18,7 @@ import {
 
 // Minimum required columns by kind (NOT NULL constraints in 0001_init.sql).
 // createEntity injects id + campaign_id, so only the per-kind required fields go here.
-const NEW_ENTITY_DEFAULTS: Record<Exclude<KindKey, "sessions" | "arcs">, Record<string, unknown>> = {
+const NEW_ENTITY_DEFAULTS: Record<Exclude<KindKey, "sessions" | "arcs" | "events">, Record<string, unknown>> = {
   people:    { name: "Unnamed wayfarer" },
   locations: { name: "Unnamed place", kind: "other" },
   quests:    { title: "Untitled quest" },
@@ -106,7 +106,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
 
   const [addMenuOpen, setAddMenuOpen] = useState(false);
 
-  const onCreate = async (k: Exclude<KindKey, "sessions" | "arcs">) => {
+  const onCreate = async (k: Exclude<KindKey, "sessions" | "arcs" | "events">) => {
     setAddMenuOpen(false);
     const id = crypto.randomUUID();
     try {
@@ -263,7 +263,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
                 {kinds.map((k) => (
                   <div
                     key={k.key}
-                    onClick={() => onCreate(k.key as Exclude<KindKey, "sessions" | "arcs">)}
+                    onClick={() => onCreate(k.key as Exclude<KindKey, "sessions" | "arcs" | "events">)}
                     style={{
                       display: "flex", alignItems: "center", gap: 10,
                       padding: "8px 12px", cursor: "pointer",

--- a/src/campaignContext.tsx
+++ b/src/campaignContext.tsx
@@ -125,6 +125,24 @@ const mapArc = (r: any) => ({
   orderNum: r.order_num ?? 0,
 });
 
+const mapEvent = (r: any) => ({
+  id: r.id,
+  title: r.title,
+  summary: r.summary ?? undefined,
+  inGameDate: r.in_game_date ?? undefined,
+  session: r.session_id ?? undefined,
+  location: r.location_id ?? undefined,
+  orderNum: r.order_num ?? 0,
+});
+
+const buildParticipants = (rows: any[]): Record<string, string[]> => {
+  const byEvent: Record<string, string[]> = {};
+  rows.forEach((r: any) => {
+    (byEvent[r.event_id] = byEvent[r.event_id] || []).push(r.person_id);
+  });
+  return byEvent;
+};
+
 const mapPresence = (r: any) => ({
   id: r.id,
   name: r.name,
@@ -155,6 +173,8 @@ async function fetchCampaign(id: string): Promise<Campaign> {
     campaignRes,
     sessionsRes,
     arcsRes,
+    eventsRes,
+    participantsRes,
     peopleRes,
     locationsRes,
     questsRes,
@@ -170,6 +190,8 @@ async function fetchCampaign(id: string): Promise<Campaign> {
     supabase.from("campaigns").select("*").eq("id", id).single(),
     supabase.from("sessions").select("*").eq("campaign_id", id).order("num"),
     supabase.from("arcs").select("*").eq("campaign_id", id).order("order_num"),
+    supabase.from("events").select("*").eq("campaign_id", id).order("order_num"),
+    supabase.from("event_participants").select("*").eq("campaign_id", id),
     supabase.from("people").select("*").eq("campaign_id", id),
     supabase.from("locations").select("*").eq("campaign_id", id),
     supabase.from("quests").select("*").eq("campaign_id", id),
@@ -184,8 +206,9 @@ async function fetchCampaign(id: string): Promise<Campaign> {
   ]);
 
   const first = [
-    campaignRes, sessionsRes, arcsRes, peopleRes, locationsRes, questsRes, goalsRes,
-    factionsRes, itemsRes, loreRes, connectionsRes, boardRes, presenceRes, notesRes,
+    campaignRes, sessionsRes, arcsRes, eventsRes, participantsRes, peopleRes,
+    locationsRes, questsRes, goalsRes, factionsRes, itemsRes, loreRes,
+    connectionsRes, boardRes, presenceRes, notesRes,
   ].find((r) => r.error);
   if (first?.error) throw new Error(first.error.message);
 
@@ -201,6 +224,8 @@ async function fetchCampaign(id: string): Promise<Campaign> {
     subtitle: campaignRes.data.subtitle ?? "",
     sessions: (sessionsRes.data ?? []).map(mapSession),
     arcs: (arcsRes.data ?? []).map(mapArc),
+    events: (eventsRes.data ?? []).map(mapEvent),
+    eventParticipants: buildParticipants(participantsRes.data ?? []),
     people: (peopleRes.data ?? []).map(mapPerson),
     locations: (locationsRes.data ?? []).map(mapLocation),
     quests: (questsRes.data ?? []).map(mapQuest),
@@ -308,6 +333,23 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
           { event: "*", schema: "public", table: "arcs", filter },
           (payload: any) => {
             setCampaign((c) => c ? { ...c, arcs: applyArrayChange(c.arcs, payload.eventType, payload.new ? mapArc(payload.new) : null, payload.old ? mapArc(payload.old) : null) } : c);
+          },
+        );
+        channel.on(
+          "postgres_changes" as any,
+          { event: "*", schema: "public", table: "events", filter },
+          (payload: any) => {
+            setCampaign((c) => c ? { ...c, events: applyArrayChange(c.events, payload.eventType, payload.new ? mapEvent(payload.new) : null, payload.old ? mapEvent(payload.old) : null) } : c);
+          },
+        );
+        channel.on(
+          "postgres_changes" as any,
+          { event: "*", schema: "public", table: "event_participants", filter },
+          () => {
+            // Composite PK, no client-side id — refetch, same as connections.
+            supabase.from("event_participants").select("*").eq("campaign_id", CURRENT_CAMPAIGN_ID).then(({ data }) => {
+              setCampaign((c) => c ? { ...c, eventParticipants: buildParticipants(data ?? []) } : c);
+            });
           },
         );
         channel.on(

--- a/src/commandPalette.tsx
+++ b/src/commandPalette.tsx
@@ -15,7 +15,7 @@ interface PaletteHit {
   archived?: boolean;
 }
 
-const KIND_ICON: Record<KindKey, "people" | "location" | "quest" | "goal" | "faction" | "item" | "lore" | "session" | "layers"> = {
+const KIND_ICON: Record<KindKey, "people" | "location" | "quest" | "goal" | "faction" | "item" | "lore" | "session" | "layers" | "sparkle"> = {
   people: "people",
   locations: "location",
   quests: "quest",
@@ -25,6 +25,7 @@ const KIND_ICON: Record<KindKey, "people" | "location" | "quest" | "goal" | "fac
   lore: "lore",
   sessions: "session",
   arcs: "layers",
+  events: "sparkle",
 };
 
 const KIND_LABEL: Record<KindKey, string> = {
@@ -37,6 +38,7 @@ const KIND_LABEL: Record<KindKey, string> = {
   lore: "Lore",
   sessions: "Session",
   arcs: "Arc",
+  events: "Event",
 };
 
 interface Indexed {
@@ -140,6 +142,15 @@ function buildIndex(campaign: Campaign): Indexed[] {
       label: entityLabel(a),
       primary: a.title ?? "",
       secondary: a.summary ?? "",
+    });
+  }
+  for (const ev of campaign.events) {
+    out.push({
+      id: ev.id,
+      kind: "events",
+      label: entityLabel(ev),
+      primary: ev.title ?? "",
+      secondary: joinFields(ev.inGameDate, ev.summary),
     });
   }
   return out;

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -312,6 +312,11 @@ export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts 
         Story Arcs
         <span className="count">{campaign.arcs.length}</span>
       </div>
+      <div className={`nav-item ${active === "events" ? "active" : ""}`} onClick={() => onSelect("events")}>
+        <span className="icon"><Icon name="sparkle" /></span>
+        Events
+        <span className="count">{campaign.events.length}</span>
+      </div>
 
       <div className="sidebar-label">
         <span>Sessions</span>

--- a/src/data.ts
+++ b/src/data.ts
@@ -8,7 +8,8 @@ export type KindKey =
   | "items"
   | "lore"
   | "sessions"
-  | "arcs";
+  | "arcs"
+  | "events";
 
 export interface Session {
   id: string;
@@ -29,6 +30,19 @@ export interface Arc {
   summary?: string;
   startSession?: string;
   endSession?: string;
+  orderNum: number;
+}
+
+// Key moments of the chronicle ("Karn's death"). Named CampaignEvent to dodge
+// the DOM Event type. Like sessions/arcs: outside buildKinds, bespoke page.
+// inGameDate is free-form text, so orderNum carries the chronology.
+export interface CampaignEvent {
+  id: string;
+  title: string;
+  summary?: string;
+  inGameDate?: string;
+  session?: string;
+  location?: string;
   orderNum: number;
 }
 
@@ -135,7 +149,7 @@ export interface PartyNote {
 export type Connection = [string, string, string];
 
 export type Entity =
-  & (Person | Location | Quest | Goal | Faction | Item | Lore | Session | Arc)
+  & (Person | Location | Quest | Goal | Faction | Item | Lore | Session | Arc | CampaignEvent)
   & { _kind?: KindKey; _kindLabel?: string };
 
 export interface Campaign {
@@ -144,6 +158,9 @@ export interface Campaign {
   subtitle: string;
   sessions: Session[];
   arcs: Arc[];
+  events: CampaignEvent[];
+  // event id → participating person ids (event_participants junction).
+  eventParticipants: Record<string, string[]>;
   people: Person[];
   locations: Location[];
   quests: Quest[];
@@ -193,6 +210,8 @@ export function findEntity(
   if (sess) return { ...sess, _kind: "sessions", _kindLabel: "Sessions", name: sess.title } as any;
   const arc = campaign.arcs.find((a) => a.id === id);
   if (arc) return { ...arc, _kind: "arcs", _kindLabel: "Arcs", name: arc.title } as any;
+  const ev = campaign.events.find((e) => e.id === id);
+  if (ev) return { ...ev, _kind: "events", _kindLabel: "Events", name: ev.title } as any;
   return null;
 }
 

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -9,6 +9,8 @@ import {
   updateEntity,
   deleteEntity,
   insertConnection,
+  addEventParticipant,
+  removeEventParticipant,
 } from "./mutations";
 import { uploadEntityImage, type UploadableKind } from "./upload";
 
@@ -166,6 +168,7 @@ function AddRelationForm({ fromId }: { fromId: string }) {
       ...campaign.lore.map((l) => ({ id: l.id, label: l.title, kind: "lore" })),
       ...campaign.sessions.map((s) => ({ id: s.id, label: s.title, kind: "sessions" })),
       ...campaign.arcs.map((a) => ({ id: a.id, label: a.title, kind: "arcs" })),
+      ...campaign.events.map((e) => ({ id: e.id, label: e.title, kind: "events" })),
     ].filter((o) => o.id !== fromId),
     [campaign, fromId],
   );
@@ -240,8 +243,77 @@ const primaryField: Record<KindKey, string> = {
   lore: "title",
   sessions: "title",
   arcs: "title",
+  events: "title",
   goals: "text",
 };
+
+// "Those Present" — the event_participants junction, editable in the rail.
+// Owns participant display for events, so the related-rail never also
+// synthesizes these people (that would duplicate the chips).
+function EventParticipantsEditor({ eventId, onOpen }: { eventId: string; onOpen: (id: string) => void }) {
+  const campaign = useCampaign();
+  const { canEdit } = useAuth();
+  const ids = campaign.eventParticipants[eventId] ?? [];
+  const participants = ids
+    .map((pid) => campaign.people.find((p) => p.id === pid))
+    .filter((p): p is NonNullable<typeof p> => !!p);
+  const available = campaign.people.filter((p) => !ids.includes(p.id));
+
+  return (
+    <div className="rail-section">
+      <h4>Those Present</h4>
+      {participants.map((p) => (
+        <div key={p.id} className="rail-chip people" onClick={() => onOpen(p.id)}>
+          <div className="rc-icon"><Icon name="people" size={14} /></div>
+          <div style={{ flex: 1 }}>
+            <div className="rc-name">{p.name}</div>
+            <div className="rc-rel">was present</div>
+          </div>
+          {canEdit ? (
+            <button
+              title="No longer counted among those present"
+              onClick={(e) => {
+                e.stopPropagation();
+                removeEventParticipant(eventId, p.id).catch(console.error);
+              }}
+              style={{
+                background: "transparent", border: "none", cursor: "pointer",
+                color: "var(--ink-faded)", fontSize: 12, padding: "0 2px",
+              }}
+            >✕</button>
+          ) : (
+            <Icon name="chevron" size={12} />
+          )}
+        </div>
+      ))}
+      {participants.length === 0 && (
+        <div style={{ fontFamily: "var(--font-fell)", fontStyle: "italic", fontSize: 12, color: "var(--ink-ghost)" }}>
+          No one is recorded at this event.
+        </div>
+      )}
+      {canEdit && available.length > 0 && (
+        <select
+          value=""
+          onChange={(e) => {
+            if (e.target.value) addEventParticipant(eventId, e.target.value).catch(console.error);
+          }}
+          style={{
+            marginTop: 6, width: "100%",
+            background: "transparent",
+            border: "1px dashed var(--ink-ghost)",
+            fontFamily: "var(--font-fell)", fontSize: 12, color: "var(--ink)",
+            padding: "6px 8px", cursor: "pointer",
+          }}
+        >
+          <option value="">— record someone present —</option>
+          {available.map((p) => (
+            <option key={p.id} value={p.id}>{p.name}</option>
+          ))}
+        </select>
+      )}
+    </div>
+  );
+}
 
 interface DetailSheetProps {
   entityId: string;
@@ -288,7 +360,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
     if (loc) {
       related.locations = related.locations || [];
       if (!related.locations.find((r) => r.entity.id === loc.id)) {
-        related.locations.push({ entity: loc, rel: "resides at" });
+        related.locations.push({ entity: loc, rel: kind === "events" ? "happened at" : "resides at" });
       }
     }
   }
@@ -316,7 +388,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
     if (s) {
       related.sessions = related.sessions || [{
         entity: s,
-        rel: (entity as any).session ? "introduced in" : "last seen in",
+        rel: kind === "events" ? "during" : (entity as any).session ? "introduced in" : "last seen in",
       }];
     }
   }
@@ -344,6 +416,27 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
       }
     });
   }
+  // Event chips on the sheets an event touches.
+  {
+    const eventRel =
+      kind === "people"
+        ? (ev: any) => (campaign.eventParticipants[ev.id] ?? []).includes(entityId) && "took part in"
+        : kind === "locations"
+          ? (ev: any) => ev.location === entityId && "happened here"
+          : kind === "sessions"
+            ? (ev: any) => ev.session === entityId && "during this session"
+            : null;
+    if (eventRel) {
+      campaign.events.forEach((ev) => {
+        const rel = eventRel(ev);
+        if (!rel) return;
+        related.events = related.events || [];
+        if (!related.events.find((r) => r.entity.id === ev.id)) {
+          related.events.push({ entity: findEntity(ev.id), rel });
+        }
+      });
+    }
+  }
 
   const patch = (fields: Record<string, unknown>) =>
     updateEntity(kind, entityId, fields).catch((e) =>
@@ -356,6 +449,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
     .map((a) => ({ id: a.id, label: a.title }));
   const sessionOptions = campaign.sessions
     .map((s) => ({ id: s.id, label: `S${String(s.num).padStart(2, "0")} — ${s.title}` }));
+  const locationOptions = campaign.locations.map((l) => ({ id: l.id, label: l.name }));
 
   const onDelete = () => {
     if (!entity) return;
@@ -389,7 +483,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
   const kindTitle: Record<string, string> = {
     people: "Person of Note", locations: "Location", quests: "Quest",
     goals: "Goal", factions: "Faction", items: "Item", lore: "Lore", sessions: "Session",
-    arcs: "Story Arc",
+    arcs: "Story Arc", events: "Event",
   };
 
   return (
@@ -524,6 +618,14 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                     <div className="stat"><div className="stat-label">Order</div><div className="stat-value"><EditableNumber value={(entity as any).orderNum ?? 0} onSave={(n) => patch({ orderNum: n })} /></div></div>
                   </>
                 )}
+                {kind === "events" && (
+                  <>
+                    <div className="stat" style={{ gridColumn: "span 3" }}><div className="stat-label">Reckoning</div><div className="stat-value" style={{ fontSize: 14 }}><EditableText value={(entity as any).inGameDate ?? ""} onSave={(v) => patch({ inGameDate: v })} placeholder="— by Faerûn's reckoning —" /></div></div>
+                    <div className="stat"><div className="stat-label">Order</div><div className="stat-value"><EditableNumber value={(entity as any).orderNum ?? 0} onSave={(n) => patch({ orderNum: n })} /></div></div>
+                    <div className="stat" style={{ gridColumn: "span 2" }}><div className="stat-label">Session</div><div className="stat-value" style={{ fontSize: 13 }}><EntitySelect value={(entity as any).session} options={sessionOptions} allowClear onSave={(id) => patch({ session: id ?? "" })} /></div></div>
+                    <div className="stat" style={{ gridColumn: "span 2" }}><div className="stat-label">Location</div><div className="stat-value" style={{ fontSize: 13 }}><EntitySelect value={(entity as any).location} options={locationOptions} allowClear onSave={(id) => patch({ location: id ?? "" })} /></div></div>
+                  </>
+                )}
               </div>
 
               <div style={{ display: "flex", gap: 8, marginTop: 16 }}>
@@ -534,7 +636,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                 )}
                 {(entity as any).session && (
                   <span className="session-ribbon">
-                    ✦ Introduced — Session {campaign.sessions.find((s) => s.id === (entity as any).session)?.num}
+                    ✦ {kind === "events" ? "During" : "Introduced"} — Session {campaign.sessions.find((s) => s.id === (entity as any).session)?.num}
                   </span>
                 )}
               </div>
@@ -562,6 +664,17 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                     value={(entity as any).summary ?? ""}
                     onSave={(v) => patch({ summary: v })}
                     placeholder="The shape of this arc…"
+                    style={{ fontFamily: "var(--font-fell)" }}
+                  />
+                </div>
+              )}
+
+              {kind === "events" && (
+                <div className="long-note">
+                  <EditableMarkdown
+                    value={(entity as any).summary ?? ""}
+                    onSave={(v) => patch({ summary: v })}
+                    placeholder="What came to pass…"
                     style={{ fontFamily: "var(--font-fell)" }}
                   />
                 </div>
@@ -687,13 +800,15 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                 ✦ RELATIONS ✦
               </div>
 
-              {(["people", "locations", "quests", "goals", "factions", "items", "lore", "sessions", "arcs"] as const).map((k) => {
+              {kind === "events" && <EventParticipantsEditor eventId={entityId} onOpen={onOpen} />}
+
+              {(["people", "locations", "quests", "goals", "factions", "items", "lore", "sessions", "arcs", "events"] as const).map((k) => {
                 const list = related[k];
                 if (!list || list.length === 0) return null;
                 const label: Record<string, string> = {
                   people: "Known Folk", locations: "Places", quests: "Quests",
                   goals: "Goals", factions: "Factions", items: "Items & Relics",
-                  lore: "Lore", sessions: "Sessions", arcs: "Story Arcs",
+                  lore: "Lore", sessions: "Sessions", arcs: "Story Arcs", events: "Events",
                 };
                 return (
                   <div className="rail-section" key={k}>

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -427,7 +427,8 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
             ? (ev: any) => ev.session === entityId && "during this session"
             : null;
     if (eventRel) {
-      campaign.events.forEach((ev) => {
+      // Array order isn't trustworthy after realtime splices — sort by orderNum.
+      campaign.events.slice().sort((a, b) => a.orderNum - b.orderNum).forEach((ev) => {
         const rel = eventRel(ev);
         if (!rel) return;
         related.events = related.events || [];

--- a/src/events.tsx
+++ b/src/events.tsx
@@ -1,0 +1,110 @@
+import { type CampaignEvent } from "./data";
+import { useCampaign } from "./hooks";
+import { useAuth } from "./auth";
+import { createEntity } from "./mutations";
+import { Icon } from "./icons";
+
+function excerpt(text: string | undefined, max = 160): string {
+  if (!text) return "";
+  const plain = text.replace(/[#*_>`~\[\]]/g, "").replace(/\s+/g, " ").trim();
+  return plain.length > max ? `${plain.slice(0, max)}…` : plain;
+}
+
+// order_num carries the chronology (in_game_date is free-form text), so
+// grouping only merges *consecutive* events sharing a date — a recurring
+// date string never pulls events out of order.
+function groupByDate(events: CampaignEvent[]): Array<{ date: string; events: CampaignEvent[] }> {
+  const groups: Array<{ date: string; events: CampaignEvent[] }> = [];
+  events.forEach((ev) => {
+    const date = ev.inGameDate?.trim() || "Undated";
+    const last = groups[groups.length - 1];
+    if (last && last.date === date) last.events.push(ev);
+    else groups.push({ date, events: [ev] });
+  });
+  return groups;
+}
+
+export function EventsPage({ onOpenEntity }: { onOpenEntity: (id: string) => void }) {
+  const campaign = useCampaign();
+  const { canEdit } = useAuth();
+
+  const events = campaign.events.slice().sort((a, b) => a.orderNum - b.orderNum || a.title.localeCompare(b.title));
+  const groups = groupByDate(events);
+  const sessionsById = new Map(campaign.sessions.map((s) => [s.id, s]));
+  const locationsById = new Map(campaign.locations.map((l) => [l.id, l]));
+
+  const onNewEvent = () => {
+    const id = crypto.randomUUID();
+    const orderNum = Math.max(0, ...campaign.events.map((e) => e.orderNum)) + 1;
+    createEntity("events", id, { title: "Untitled event", orderNum })
+      .then(() => onOpenEntity(id))
+      .catch(console.error);
+  };
+
+  return (
+    <div style={{ flex: 1, overflow: "auto", padding: "28px 40px 60px", background: "var(--vellum)", position: "relative" }} className="tex-vellum">
+      <div style={{ position: "relative", zIndex: 1, maxWidth: 860 }}>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 16, marginBottom: 8, flexWrap: "wrap" }}>
+          <h1 style={{ margin: 0, fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 40, color: "var(--ink)", letterSpacing: ".01em" }}>Chronicle of Events</h1>
+          <span style={{ fontFamily: "var(--font-fell)", fontStyle: "italic", fontSize: 16, color: "var(--ink-faded)" }}>
+            {events.length} {events.length === 1 ? "moment" : "moments"} the world remembers
+          </span>
+          {canEdit && (
+            <button onClick={onNewEvent} className="cleanup-link-btn" style={{ marginLeft: "auto" }}>
+              + new event
+            </button>
+          )}
+        </div>
+        <div className="scratch-divider"><em>✦ ✦ ✦</em></div>
+
+        {groups.map((group, gi) => (
+          <section key={gi} style={{ marginTop: 26 }}>
+            <div style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".18em", fontSize: 12, color: "var(--ink-faded)" }}>
+              ✦ {group.date.toUpperCase()} ✦
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 12, marginTop: 10, borderLeft: "1px solid var(--ink-ghost)", paddingLeft: 18 }}>
+              {group.events.map((ev) => {
+                const session = ev.session ? sessionsById.get(ev.session) : undefined;
+                const location = ev.location ? locationsById.get(ev.location) : undefined;
+                const participants = campaign.eventParticipants[ev.id]?.length ?? 0;
+                const summary = excerpt(ev.summary);
+                return (
+                  <div
+                    key={ev.id}
+                    onClick={() => onOpenEntity(ev.id)}
+                    style={{ cursor: "pointer" }}
+                  >
+                    <div style={{ display: "flex", alignItems: "baseline", gap: 10, flexWrap: "wrap" }}>
+                      <span style={{ color: "var(--bloodred)", marginLeft: -25, background: "var(--vellum)", lineHeight: 1 }}>
+                        <Icon name="sparkle" size={13} />
+                      </span>
+                      <h3 style={{ margin: 0, fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 19, color: "var(--ink)" }}>
+                        {ev.title}
+                      </h3>
+                      <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".1em", fontSize: 10.5, color: "var(--ink-faded)" }}>
+                        {session && `S${String(session.num).padStart(2, "0")}`}
+                        {location && `${session ? " · " : ""}${location.name}`}
+                        {participants > 0 && ` · ${participants} present`}
+                      </span>
+                    </div>
+                    {summary && (
+                      <p style={{ margin: "3px 0 0", fontFamily: "var(--font-fell)", fontStyle: "italic", fontSize: 14, color: "var(--ink-body)" }}>
+                        {summary}
+                      </p>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        ))}
+
+        {events.length === 0 && (
+          <p style={{ marginTop: 30, fontFamily: "var(--font-fell)", fontStyle: "italic", fontSize: 15, color: "var(--ink-faded)" }}>
+            Nothing of note has been chronicled yet.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -62,6 +62,7 @@ export const kindIcon: Record<KindKey, IconName> = {
   lore: "lore",
   sessions: "session",
   arcs: "layers",
+  events: "sparkle",
 };
 
 export const CompassRose = ({ style }: { style?: CSSProperties }) => (

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -41,6 +41,12 @@ const fieldAlias: Record<KindKey, Record<string, string>> = {
     endSession: "end_session_id",
     orderNum: "order_num",
   },
+  events: {
+    inGameDate: "in_game_date",
+    session: "session_id",
+    location: "location_id",
+    orderNum: "order_num",
+  },
 };
 
 function toRow(kind: KindKey, patch: Record<string, unknown>): Record<string, unknown> {
@@ -125,6 +131,28 @@ async function deleteConnectionsFor(entityId: string) {
     .delete()
     .eq("campaign_id", CURRENT_CAMPAIGN_ID)
     .or(`from_id.eq.${entityId},to_id.eq.${entityId}`);
+  if (error) throw error;
+}
+
+// ===== Event participants ===================================================
+// FK junction writes (event_participants), not free-form connections.
+
+export async function addEventParticipant(eventId: string, personId: string) {
+  const { error } = await supabase.from("event_participants").insert({
+    campaign_id: CURRENT_CAMPAIGN_ID,
+    event_id: eventId,
+    person_id: personId,
+  });
+  if (error) throw error;
+}
+
+export async function removeEventParticipant(eventId: string, personId: string) {
+  const { error } = await supabase
+    .from("event_participants")
+    .delete()
+    .eq("campaign_id", CURRENT_CAMPAIGN_ID)
+    .eq("event_id", eventId)
+    .eq("person_id", personId);
   if (error) throw error;
 }
 

--- a/supabase/migrations/0009_events.sql
+++ b/supabase/migrations/0009_events.sql
@@ -1,0 +1,40 @@
+-- Issue #12: events as a first-class timeline primitive.
+-- in_game_date is free-form text, so chronology comes from order_num.
+create table public.events (
+  id text primary key,
+  campaign_id text not null references public.campaigns(id) on delete cascade,
+  title text not null,
+  summary text,
+  in_game_date text,
+  session_id  text references public.sessions(id)  on delete set null,
+  location_id text references public.locations(id) on delete set null,
+  order_num int not null default 0
+);
+
+-- campaign_id is denormalized onto the junction so the client's
+-- campaign_id-filtered realtime channel and scoped refetch work.
+create table public.event_participants (
+  campaign_id text not null references public.campaigns(id) on delete cascade,
+  event_id  text not null references public.events(id) on delete cascade,
+  person_id text not null references public.people(id) on delete cascade,
+  primary key (event_id, person_id)
+);
+
+alter table public.events             enable row level security;
+alter table public.event_participants enable row level security;
+
+create policy "anon read events" on public.events
+  for select to anon, authenticated using (true);
+create policy "anon read event_participants" on public.event_participants
+  for select to anon, authenticated using (true);
+
+create policy "member write events" on public.events
+  for all to authenticated
+  using      ((auth.jwt() ->> 'is_anonymous')::boolean is not true)
+  with check ((auth.jwt() ->> 'is_anonymous')::boolean is not true);
+create policy "member write event_participants" on public.event_participants
+  for all to authenticated
+  using      ((auth.jwt() ->> 'is_anonymous')::boolean is not true)
+  with check ((auth.jwt() ->> 'is_anonymous')::boolean is not true);
+
+alter publication supabase_realtime add table public.events, public.event_participants;


### PR DESCRIPTION
## Summary

Final PR of **M2 — Chronicle Depth** (#9 → #11 → #12). Stacked on #26.

- **Migration [0009_events.sql](../blob/feat/events/supabase/migrations/0009_events.sql)**: `events` table + `event_participants` junction (composite PK, cascade on event/person delete, `session_id`/`location_id` `on delete set null`), RLS per the 0006 pattern, realtime publication for both tables. `campaign_id` is denormalized onto the junction so the client's campaign-filtered channel and scoped refetch work.
- **Events follow the sessions/arcs "second-class kind" template** — `KindKey` member (detail sheet / `findEntity` / connections / palette), excluded from `buildKinds`/board/archiving.
- **Chronicle of Events page** (`src/events.tsx`): sorted by `order_num` (the source of truth for chronology — `in_game_date` is free-form Faerûnian text), grouping **consecutive** events that share a date under date headings so a recurring date string can never pull events out of order. Cards show session ribbon, location, participant count.
- **Event sheet**: Reckoning/Order stats, session + location `EntitySelect`s, markdown summary, and a **"Those Present"** rail section that edits the junction directly via new `addEventParticipant`/`removeEventParticipant` mutations (FK writes — deliberately not routed through the free-form `connections` yarn).
- **Event chips** on person ("took part in"), location ("happened here"), and session ("during this session") sheets; clicking navigates. The event sheet's own session/location FKs reuse the existing rail synthesis with event-appropriate labels ("during" / "happened at").

## Migration status

⚠️ **The app hard-fails to load until 0009 is applied** (`fetchCampaign` selects from both new tables). Apply 0007 + 0008 + 0009 via the dashboard SQL editor, in order, before merging the stack.

## Verification

- `npm run build` passes (second `KindKey` widening — every `Record<KindKey, …>` site type-checked).
- Live flow verification pending migration application (tracked with the stack).

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)