### PR TITLE
Remove hardcoded campaign; add campaign picker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Supabase migrations live in [supabase/migrations/](supabase/migrations/). Apply 
 
 ## Architecture
 
-This is a **collaborative read-write campaign journal** for a D&D group, hardcoded to one campaign at a time via `CURRENT_CAMPAIGN_ID` in [src/data.ts](src/data.ts) (currently `"fendwick"`).
+This is a **collaborative read-write campaign journal** for a D&D group. The active campaign is dynamic (issue #18): it lives in the URL hash — `#/c/:campaignId`, optionally `#/c/:campaignId/e/:entityId` for an entity deep link — parsed by [src/route.ts](src/route.ts). `CampaignProvider` resolves it as hash → `window.__TWEAKS__.campaignId` → first row of the `campaigns` table, and a picker in the Topbar switches it. Switching tears down the realtime channel, clears state, and reloads under the new id; every realtime handler is gated on the campaign id it was subscribed for, so late events from the old channel can't splice into the new campaign's arrays. Mutations read the active id from the module-level store in [src/activeCampaign.ts](src/activeCampaign.ts) (`getActiveCampaignId()`), which only `CampaignProvider` writes.
 
 ### Data flow: writes go out through mutations, state comes back through realtime
 
@@ -54,7 +54,7 @@ The app supports an "edit mode" handshake with a parent window via `window.__TWE
 
 ## Conventions
 
-- **Route everything campaign-scoped through `CURRENT_CAMPAIGN_ID`**; never query without the `campaign_id` filter. RLS doesn't enforce per-campaign access today ([issue #18](https://github.com/Kminkjan/the-codex/issues/18)).
+- **Route everything campaign-scoped through the active campaign id** — components read it via `useCampaign()`/`useCampaignSwitcher()`, mutations via `getActiveCampaignId()` from [src/activeCampaign.ts](src/activeCampaign.ts); never query without the `campaign_id` filter. RLS doesn't enforce per-campaign access today — any signed-in editor can write to any campaign (per-campaign membership is future work).
 - **New entity IDs are `crypto.randomUUID()` strings** generated client-side. All PKs are `text` except `connections.id` (bigserial) and `party_notes.id` (bigserial).
 - **Styling is inline style objects + a few CSS classes** in [src/styles.css](src/styles.css). CSS variables (`--ink`, `--vellum`, `--bloodred`, `--font-fell-sc`, etc.) carry the parchment aesthetic — reach for those before inventing colors.
 - **Committed `.js` / `.d.ts` siblings of the `.tsx` files are gitignored** (`src/**/*.js`, `src/**/*.d.ts` except `global.d.ts`). They're `tsc` outputs — ignore them.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { CampaignProvider } from "./campaignContext";
 import { AuthProvider, DisplayNameGate } from "./auth";
-import { useCampaignStatus, useKinds } from "./hooks";
+import { useCampaign, useCampaignStatus, useFindEntity, useKinds } from "./hooks";
+import { campaignHash, parseHash, writeCampaignHash } from "./route";
 import { Icon } from "./icons";
 import { Sidebar, Topbar } from "./components";
 import { NoticeBoard, KindList } from "./board";
@@ -53,12 +54,19 @@ function ErrorSheet({ message }: { message: string }) {
 
 function AppLoaded() {
   const kinds = useKinds();
+  const campaign = useCampaign();
+  const findEntity = useFindEntity();
 
   const [theme, setTheme] = useState<string>(window.__TWEAKS__.theme || "cartographer");
   const [showPresence, setShowPresence] = useState<boolean>(window.__TWEAKS__.showPresence);
   const [density, setDensity] = useState<string>(window.__TWEAKS__.density || "cozy");
   const [view, setView] = useState("board");
-  const [openId, setOpenId] = useState<string | null>(null);
+  // Entity deep link: #/c/:campaignId/e/:entityId opens the detail sheet on
+  // load; an id that doesn't resolve in this campaign is silently dropped.
+  const [openId, setOpenId] = useState<string | null>(() => {
+    const id = parseHash().entityId;
+    return id && findEntity(id) ? id : null;
+  });
   const [tweaksOpen, setTweaksOpen] = useState(false);
   const [shareToast, setShareToast] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -73,6 +81,23 @@ function AppLoaded() {
   }, [theme]);
   useEffect(() => { window.__TWEAKS__.showPresence = showPresence; }, [showPresence]);
   useEffect(() => { window.__TWEAKS__.density = density; }, [density]);
+
+  // Mirror the open entity into the hash (replace, not push, so browsing
+  // entities doesn't spam history).
+  useEffect(() => {
+    writeCampaignHash(campaign.id, openId, { replace: true });
+  }, [campaign.id, openId]);
+
+  // Entity deep links pasted mid-session are fragment navigations (no page
+  // load), so the mount-time parse above never sees them.
+  useEffect(() => {
+    const onHashChange = () => {
+      const { campaignId: cid, entityId } = parseHash();
+      if (cid === campaign.id) setOpenId(entityId && findEntity(entityId) ? entityId : null);
+    };
+    window.addEventListener("hashchange", onHashChange);
+    return () => window.removeEventListener("hashchange", onHashChange);
+  }, [campaign.id, findEntity]);
 
   useEffect(() => {
     const onMsg = (e: MessageEvent) => {
@@ -99,6 +124,8 @@ function AppLoaded() {
   }, [kinds]);
 
   const onShare = () => {
+    const url = window.location.origin + window.location.pathname + campaignHash(campaign.id);
+    navigator.clipboard.writeText(url).catch(console.error);
     setShareToast(true);
     setTimeout(() => setShareToast(false), 2200);
   };
@@ -147,8 +174,7 @@ function AppLoaded() {
           display: "flex", alignItems: "center", gap: 10,
           zIndex: 70, borderRadius: 2,
         }}>
-          <Icon name="check" size={14} /> Share link copied — anyone with the link may read &amp; write.
-          <span style={{ opacity: .6, fontFamily: "var(--font-ui)", fontStyle: "normal", fontSize: 11, letterSpacing: ".1em" }}>codex.app/c/ember-accord</span>
+          <Icon name="check" size={14} /> Share link copied — anyone with the link may read.
         </div>
       )}
 

--- a/src/activeCampaign.ts
+++ b/src/activeCampaign.ts
@@ -1,0 +1,13 @@
+// Module-level active-campaign store. Written only by CampaignProvider
+// (synchronously, before any await in its load effect); read by mutations.ts,
+// which are plain async functions and can't reach React context.
+let activeCampaignId: string | null = null;
+
+export function setActiveCampaignId(id: string) {
+  activeCampaignId = id;
+}
+
+export function getActiveCampaignId(): string {
+  if (!activeCampaignId) throw new Error("No active campaign");
+  return activeCampaignId;
+}

--- a/src/campaignContext.tsx
+++ b/src/campaignContext.tsx
@@ -1,9 +1,11 @@
-import { createContext, useEffect, useState, type ReactNode } from "react";
+import { createContext, useCallback, useEffect, useState, type ReactNode } from "react";
 import type { RealtimeChannel } from "@supabase/supabase-js";
 import { supabase } from "./utils/supabase";
+import { setActiveCampaignId } from "./activeCampaign";
+import { parseHash, writeCampaignHash } from "./route";
 import {
-  CURRENT_CAMPAIGN_ID,
   type Campaign,
+  type CampaignSummary,
   type BoardPosition,
   type Connection,
   type KindKey,
@@ -14,12 +16,18 @@ interface CampaignContextValue {
   campaign: Campaign | null;
   loading: boolean;
   error: string | null;
+  campaigns: CampaignSummary[];
+  activeCampaignId: string | null;
+  switchCampaign: (id: string) => void;
 }
 
 export const CampaignContext = createContext<CampaignContextValue>({
   campaign: null,
   loading: true,
   error: null,
+  campaigns: [],
+  activeCampaignId: null,
+  switchCampaign: () => {},
 });
 
 // Map a DB row (snake_case, `desc`) to the app's object shape (camelCase).
@@ -257,89 +265,161 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
   const [campaign, setCampaign] = useState<Campaign | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [campaigns, setCampaigns] = useState<CampaignSummary[]>([]);
+  const [campaignId, setCampaignId] = useState<string | null>(null);
+
+  // Load the picker list once, then resolve the active id:
+  // hash → host-page tweak → first campaign by creation date.
+  useEffect(() => {
+    let cancelled = false;
+    supabase
+      .from("campaigns")
+      .select("id,title,subtitle")
+      .order("created_at")
+      .then(({ data, error }) => {
+        if (cancelled) return;
+        if (error) {
+          setError(error.message);
+          setLoading(false);
+          return;
+        }
+        const list = (data ?? []) as CampaignSummary[];
+        if (list.length === 0) {
+          setError("No campaigns found");
+          setLoading(false);
+          return;
+        }
+        setCampaigns(list);
+        const known = (id?: string) => list.some((c) => c.id === id);
+        const fromHash = parseHash().campaignId;
+        const fromTweaks = window.__TWEAKS__.campaignId;
+        const id = known(fromHash) ? fromHash! : known(fromTweaks) ? fromTweaks! : list[0].id;
+        // Normalize a missing or bad campaign hash without adding a history
+        // entry. A non-campaign hash (e.g. #access_token from a magic link)
+        // is left alone for supabase-js to consume.
+        const hash = window.location.hash;
+        if (!hash || /^#\/c\//.test(hash)) {
+          writeCampaignHash(id, fromHash === id ? parseHash().entityId : undefined, { replace: true });
+        }
+        setCampaignId(id);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  // One code path updates the active id: picker clicks write the hash,
+  // and this listener also covers back/forward and manual URL edits.
+  useEffect(() => {
+    const onHashChange = () => {
+      const { campaignId: id } = parseHash();
+      if (id && campaigns.some((c) => c.id === id)) {
+        if (id !== campaignId) setCampaignId(id);
+      } else if (campaignId && /^#\/c\//.test(window.location.hash)) {
+        // Campaign-shaped hash with an unknown id — restore the active one so
+        // the URL doesn't lie. Non-campaign hashes are left alone.
+        writeCampaignHash(campaignId, null, { replace: true });
+      }
+    };
+    window.addEventListener("hashchange", onHashChange);
+    return () => window.removeEventListener("hashchange", onHashChange);
+  }, [campaigns, campaignId]);
+
+  const switchCampaign = useCallback((id: string) => {
+    if (id === campaignId) return;
+    writeCampaignHash(id); // hashchange listener updates campaignId
+    // Persist through the host page, never localStorage.
+    window.parent.postMessage({ type: "__edit_mode_set_keys", edits: { campaignId: id } }, "*");
+  }, [campaignId]);
 
   useEffect(() => {
+    if (!campaignId) return;
     let cancelled = false;
     let channel: RealtimeChannel | null = null;
 
+    // Synchronous, before any await: mutations read this store, and clearing
+    // the campaign unmounts AppLoaded so nothing can write mid-switch.
+    setActiveCampaignId(campaignId);
+    setCampaign(null);
+    setLoading(true);
+    setError(null);
+
     (async () => {
       try {
-        const initial = await fetchCampaign(CURRENT_CAMPAIGN_ID);
+        const initial = await fetchCampaign(campaignId);
         if (cancelled) return;
         setCampaign(initial);
         setLoading(false);
 
-        const filter = `campaign_id=eq.${CURRENT_CAMPAIGN_ID}`;
-        channel = supabase.channel(`campaign:${CURRENT_CAMPAIGN_ID}`);
+        const filter = `campaign_id=eq.${campaignId}`;
+        channel = supabase.channel(`campaign:${campaignId}`);
 
         channel.on(
           "postgres_changes" as any,
           { event: "*", schema: "public", table: "people", filter },
           (payload: any) => {
-            setCampaign((c) => c ? { ...c, people: applyArrayChange(c.people, payload.eventType, payload.new ? mapPerson(payload.new) : null, payload.old ? mapPerson(payload.old) : null) } : c);
+            setCampaign((c) => c && c.id === campaignId ? { ...c, people: applyArrayChange(c.people, payload.eventType, payload.new ? mapPerson(payload.new) : null, payload.old ? mapPerson(payload.old) : null) } : c);
           },
         );
         channel.on(
           "postgres_changes" as any,
           { event: "*", schema: "public", table: "locations", filter },
           (payload: any) => {
-            setCampaign((c) => c ? { ...c, locations: applyArrayChange(c.locations, payload.eventType, payload.new ? mapLocation(payload.new) : null, payload.old ? mapLocation(payload.old) : null) } : c);
+            setCampaign((c) => c && c.id === campaignId ? { ...c, locations: applyArrayChange(c.locations, payload.eventType, payload.new ? mapLocation(payload.new) : null, payload.old ? mapLocation(payload.old) : null) } : c);
           },
         );
         channel.on(
           "postgres_changes" as any,
           { event: "*", schema: "public", table: "quests", filter },
           (payload: any) => {
-            setCampaign((c) => c ? { ...c, quests: applyArrayChange(c.quests, payload.eventType, payload.new ? mapQuest(payload.new) : null, payload.old ? mapQuest(payload.old) : null) } : c);
+            setCampaign((c) => c && c.id === campaignId ? { ...c, quests: applyArrayChange(c.quests, payload.eventType, payload.new ? mapQuest(payload.new) : null, payload.old ? mapQuest(payload.old) : null) } : c);
           },
         );
         channel.on(
           "postgres_changes" as any,
           { event: "*", schema: "public", table: "goals", filter },
           (payload: any) => {
-            setCampaign((c) => c ? { ...c, goals: applyArrayChange(c.goals, payload.eventType, payload.new ? mapGoal(payload.new) : null, payload.old ? mapGoal(payload.old) : null) } : c);
+            setCampaign((c) => c && c.id === campaignId ? { ...c, goals: applyArrayChange(c.goals, payload.eventType, payload.new ? mapGoal(payload.new) : null, payload.old ? mapGoal(payload.old) : null) } : c);
           },
         );
         channel.on(
           "postgres_changes" as any,
           { event: "*", schema: "public", table: "factions", filter },
           (payload: any) => {
-            setCampaign((c) => c ? { ...c, factions: applyArrayChange(c.factions, payload.eventType, payload.new ? mapFaction(payload.new) : null, payload.old ? mapFaction(payload.old) : null) } : c);
+            setCampaign((c) => c && c.id === campaignId ? { ...c, factions: applyArrayChange(c.factions, payload.eventType, payload.new ? mapFaction(payload.new) : null, payload.old ? mapFaction(payload.old) : null) } : c);
           },
         );
         channel.on(
           "postgres_changes" as any,
           { event: "*", schema: "public", table: "items", filter },
           (payload: any) => {
-            setCampaign((c) => c ? { ...c, items: applyArrayChange(c.items, payload.eventType, payload.new ? mapItem(payload.new) : null, payload.old ? mapItem(payload.old) : null) } : c);
+            setCampaign((c) => c && c.id === campaignId ? { ...c, items: applyArrayChange(c.items, payload.eventType, payload.new ? mapItem(payload.new) : null, payload.old ? mapItem(payload.old) : null) } : c);
           },
         );
         channel.on(
           "postgres_changes" as any,
           { event: "*", schema: "public", table: "lore", filter },
           (payload: any) => {
-            setCampaign((c) => c ? { ...c, lore: applyArrayChange(c.lore, payload.eventType, payload.new ? mapLore(payload.new) : null, payload.old ? mapLore(payload.old) : null) } : c);
+            setCampaign((c) => c && c.id === campaignId ? { ...c, lore: applyArrayChange(c.lore, payload.eventType, payload.new ? mapLore(payload.new) : null, payload.old ? mapLore(payload.old) : null) } : c);
           },
         );
         channel.on(
           "postgres_changes" as any,
           { event: "*", schema: "public", table: "sessions", filter },
           (payload: any) => {
-            setCampaign((c) => c ? { ...c, sessions: applyArrayChange(c.sessions, payload.eventType, payload.new ? mapSession(payload.new) : null, payload.old ? mapSession(payload.old) : null) } : c);
+            setCampaign((c) => c && c.id === campaignId ? { ...c, sessions: applyArrayChange(c.sessions, payload.eventType, payload.new ? mapSession(payload.new) : null, payload.old ? mapSession(payload.old) : null) } : c);
           },
         );
         channel.on(
           "postgres_changes" as any,
           { event: "*", schema: "public", table: "arcs", filter },
           (payload: any) => {
-            setCampaign((c) => c ? { ...c, arcs: applyArrayChange(c.arcs, payload.eventType, payload.new ? mapArc(payload.new) : null, payload.old ? mapArc(payload.old) : null) } : c);
+            setCampaign((c) => c && c.id === campaignId ? { ...c, arcs: applyArrayChange(c.arcs, payload.eventType, payload.new ? mapArc(payload.new) : null, payload.old ? mapArc(payload.old) : null) } : c);
           },
         );
         channel.on(
           "postgres_changes" as any,
           { event: "*", schema: "public", table: "events", filter },
           (payload: any) => {
-            setCampaign((c) => c ? { ...c, events: applyArrayChange(c.events, payload.eventType, payload.new ? mapEvent(payload.new) : null, payload.old ? mapEvent(payload.old) : null) } : c);
+            setCampaign((c) => c && c.id === campaignId ? { ...c, events: applyArrayChange(c.events, payload.eventType, payload.new ? mapEvent(payload.new) : null, payload.old ? mapEvent(payload.old) : null) } : c);
           },
         );
         channel.on(
@@ -347,8 +427,9 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
           { event: "*", schema: "public", table: "event_participants", filter },
           () => {
             // Composite PK, no client-side id — refetch, same as connections.
-            supabase.from("event_participants").select("*").eq("campaign_id", CURRENT_CAMPAIGN_ID).then(({ data }) => {
-              setCampaign((c) => c ? { ...c, eventParticipants: buildParticipants(data ?? []) } : c);
+            supabase.from("event_participants").select("*").eq("campaign_id", campaignId).then(({ data }) => {
+              if (cancelled) return;
+              setCampaign((c) => c && c.id === campaignId ? { ...c, eventParticipants: buildParticipants(data ?? []) } : c);
             });
           },
         );
@@ -356,7 +437,7 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
           "postgres_changes" as any,
           { event: "*", schema: "public", table: "presence_users", filter },
           (payload: any) => {
-            setCampaign((c) => c ? { ...c, presence: applyArrayChange(c.presence, payload.eventType, payload.new ? mapPresence(payload.new) : null, payload.old ? mapPresence(payload.old) : null) } : c);
+            setCampaign((c) => c && c.id === campaignId ? { ...c, presence: applyArrayChange(c.presence, payload.eventType, payload.new ? mapPresence(payload.new) : null, payload.old ? mapPresence(payload.old) : null) } : c);
           },
         );
         channel.on(
@@ -364,8 +445,9 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
           { event: "*", schema: "public", table: "connections", filter },
           () => {
             // Connections have no stable `id` on the client (stored as tuples). Refetch.
-            supabase.from("connections").select("*").eq("campaign_id", CURRENT_CAMPAIGN_ID).then(({ data }) => {
-              setCampaign((c) => c ? { ...c, connections: (data ?? []).map(mapConnection) } : c);
+            supabase.from("connections").select("*").eq("campaign_id", campaignId).then(({ data }) => {
+              if (cancelled) return;
+              setCampaign((c) => c && c.id === campaignId ? { ...c, connections: (data ?? []).map(mapConnection) } : c);
             });
           },
         );
@@ -373,8 +455,9 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
           "postgres_changes" as any,
           { event: "*", schema: "public", table: "board_positions", filter },
           () => {
-            supabase.from("board_positions").select("*").eq("campaign_id", CURRENT_CAMPAIGN_ID).then(({ data }) => {
-              setCampaign((c) => c ? { ...c, board: Object.fromEntries((data ?? []).map(mapBoardPosition)) } : c);
+            supabase.from("board_positions").select("*").eq("campaign_id", campaignId).then(({ data }) => {
+              if (cancelled) return;
+              setCampaign((c) => c && c.id === campaignId ? { ...c, board: Object.fromEntries((data ?? []).map(mapBoardPosition)) } : c);
             });
           },
         );
@@ -382,13 +465,14 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
           "postgres_changes" as any,
           { event: "*", schema: "public", table: "party_notes", filter },
           () => {
-            supabase.from("party_notes").select("*").eq("campaign_id", CURRENT_CAMPAIGN_ID).order("created_at").then(({ data }) => {
+            supabase.from("party_notes").select("*").eq("campaign_id", campaignId).order("created_at").then(({ data }) => {
+              if (cancelled) return;
               const byEntity: Record<string, PartyNote[]> = {};
               (data ?? []).forEach((r: any) => {
                 const { entityId, note } = mapPartyNoteRow(r);
                 (byEntity[entityId] = byEntity[entityId] || []).push(note);
               });
-              setCampaign((c) => c ? { ...c, notes: byEntity } : c);
+              setCampaign((c) => c && c.id === campaignId ? { ...c, notes: byEntity } : c);
             });
           },
         );
@@ -405,10 +489,10 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
       cancelled = true;
       if (channel) supabase.removeChannel(channel);
     };
-  }, []);
+  }, [campaignId]);
 
   return (
-    <CampaignContext.Provider value={{ campaign, loading, error }}>
+    <CampaignContext.Provider value={{ campaign, loading, error, campaigns, activeCampaignId: campaignId, switchCampaign }}>
       {children}
     </CampaignContext.Provider>
   );

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -1,8 +1,8 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { type KindKey, type PresenceUser } from "./data";
 import { Icon, MapScribble, kindIcon } from "./icons";
-import { useCampaign, useKinds } from "./hooks";
+import { useCampaign, useCampaignSwitcher, useKinds } from "./hooks";
 import { createEntity } from "./mutations";
 import { SignInDialog, useAuth } from "./auth";
 
@@ -383,6 +383,76 @@ export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts 
   );
 }
 
+// Campaign switcher in the Topbar. Visible to read-only viewers too —
+// switching campaigns is navigation, not an edit.
+function CampaignPicker() {
+  const campaign = useCampaign();
+  const { campaigns, activeCampaignId, switchCampaign } = useCampaignSwitcher();
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const canSwitch = campaigns.length > 1;
+
+  return (
+    <div className="campaign-picker" ref={rootRef}>
+      <button
+        className="campaign-chip"
+        onClick={() => canSwitch && setOpen((o) => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        title={canSwitch ? "Switch campaign" : undefined}
+        style={{ cursor: canSwitch ? "pointer" : "default" }}
+      >
+        <span className="dot" />
+        <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".1em", fontSize: 11 }}>CAMPAIGN</span>
+        <span>·</span>
+        <span style={{ fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 15 }}>{campaign.title}</span>
+        <span style={{ color: "var(--ink-faded)", fontStyle: "italic", fontSize: 12 }}>· {campaign.subtitle}</span>
+        {canSwitch && (
+          <Icon name="chevron" size={11} style={{ transform: open ? "rotate(-90deg)" : "rotate(90deg)", color: "var(--ink-faded)", flexShrink: 0 }} />
+        )}
+      </button>
+      {open && (
+        <div className="campaign-picker-menu" role="listbox">
+          {campaigns.map((c) => (
+            <button
+              key={c.id}
+              role="option"
+              aria-selected={c.id === activeCampaignId}
+              className={"campaign-picker-item" + (c.id === activeCampaignId ? " active" : "")}
+              onClick={() => { switchCampaign(c.id); setOpen(false); }}
+            >
+              <span className="dot" style={{ visibility: c.id === activeCampaignId ? "visible" : "hidden" }} />
+              <span>
+                <span style={{ fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 14, display: "block" }}>{c.title}</span>
+                {c.subtitle && (
+                  <span style={{ color: "var(--ink-faded)", fontStyle: "italic", fontSize: 12 }}>{c.subtitle}</span>
+                )}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function Topbar({ onShare }: { onShare: () => void }) {
   const campaign = useCampaign();
   const { canEdit, displayName, signOut } = useAuth();
@@ -397,13 +467,7 @@ export function Topbar({ onShare }: { onShare: () => void }) {
         </div>
       </div>
       <div className="topbar-center">
-        <div className="campaign-chip">
-          <span className="dot" />
-          <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".1em", fontSize: 11 }}>CAMPAIGN</span>
-          <span>·</span>
-          <span style={{ fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 15 }}>{campaign.title}</span>
-          <span style={{ color: "var(--ink-faded)", fontStyle: "italic", fontSize: 12 }}>· {campaign.subtitle}</span>
-        </div>
+        <CampaignPicker />
       </div>
       <div className="topbar-right">
         <Presence users={campaign.presence} />

--- a/src/data.ts
+++ b/src/data.ts
@@ -174,7 +174,12 @@ export interface Campaign {
   notes: Record<string, PartyNote[]>;
 }
 
-export const CURRENT_CAMPAIGN_ID = "fendwick";
+// Lightweight row for the campaign picker (full data loads per-campaign).
+export interface CampaignSummary {
+  id: string;
+  title: string;
+  subtitle: string | null;
+}
 
 export interface KindDef {
   key: KindKey;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -6,6 +6,9 @@ declare global {
       theme: string;
       showPresence: boolean;
       density: string;
+      // Not in TWEAK_DEFAULTS on purpose — absence falls through to the
+      // first campaign by creation date (see CampaignProvider).
+      campaignId?: string;
       [key: string]: unknown;
     };
   }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -15,6 +15,11 @@ export function useCampaignStatus() {
   return { campaign, loading, error };
 }
 
+export function useCampaignSwitcher() {
+  const { campaigns, activeCampaignId, switchCampaign } = useContext(CampaignContext);
+  return { campaigns, activeCampaignId, switchCampaign };
+}
+
 export function useKinds() {
   const campaign = useCampaign();
   return useMemo(() => buildKinds(campaign), [campaign]);

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -1,5 +1,6 @@
 import { supabase } from "./utils/supabase";
-import { CURRENT_CAMPAIGN_ID, type KindKey, type PartyNote, type BoardPosition } from "./data";
+import { getActiveCampaignId } from "./activeCampaign";
+import { type KindKey, type PartyNote, type BoardPosition } from "./data";
 
 // Realtime subscriptions in campaignContext.tsx reflect writes back into UI
 // state, so callers do not need to patch local state (fire-and-forget is fine).
@@ -63,7 +64,7 @@ function toRow(kind: KindKey, patch: Record<string, unknown>): Record<string, un
 
 export async function insertPartyNote(entityId: string, note: PartyNote) {
   const { error } = await supabase.from("party_notes").insert({
-    campaign_id: CURRENT_CAMPAIGN_ID,
+    campaign_id: getActiveCampaignId(),
     entity_id: entityId,
     author: note.author,
     when_label: note.when,
@@ -80,7 +81,7 @@ export async function upsertBoardPosition(entityId: string, pos: BoardPosition) 
     .from("board_positions")
     .upsert(
       {
-        campaign_id: CURRENT_CAMPAIGN_ID,
+        campaign_id: getActiveCampaignId(),
         entity_id: entityId,
         x: pos.x,
         y: pos.y,
@@ -96,7 +97,7 @@ export async function deleteBoardPosition(entityId: string) {
   const { error } = await supabase
     .from("board_positions")
     .delete()
-    .eq("campaign_id", CURRENT_CAMPAIGN_ID)
+    .eq("campaign_id", getActiveCampaignId())
     .eq("entity_id", entityId);
   if (error) throw error;
 }
@@ -105,7 +106,7 @@ export async function deleteBoardPosition(entityId: string) {
 
 export async function insertConnection(fromId: string, toId: string, label: string) {
   const { error } = await supabase.from("connections").insert({
-    campaign_id: CURRENT_CAMPAIGN_ID,
+    campaign_id: getActiveCampaignId(),
     from_id: fromId,
     to_id: toId,
     label,
@@ -117,7 +118,7 @@ export async function deleteConnection(fromId: string, toId: string, label: stri
   const { error } = await supabase
     .from("connections")
     .delete()
-    .eq("campaign_id", CURRENT_CAMPAIGN_ID)
+    .eq("campaign_id", getActiveCampaignId())
     .eq("from_id", fromId)
     .eq("to_id", toId)
     .eq("label", label);
@@ -129,7 +130,7 @@ async function deleteConnectionsFor(entityId: string) {
   const { error } = await supabase
     .from("connections")
     .delete()
-    .eq("campaign_id", CURRENT_CAMPAIGN_ID)
+    .eq("campaign_id", getActiveCampaignId())
     .or(`from_id.eq.${entityId},to_id.eq.${entityId}`);
   if (error) throw error;
 }
@@ -139,7 +140,7 @@ async function deleteConnectionsFor(entityId: string) {
 
 export async function addEventParticipant(eventId: string, personId: string) {
   const { error } = await supabase.from("event_participants").insert({
-    campaign_id: CURRENT_CAMPAIGN_ID,
+    campaign_id: getActiveCampaignId(),
     event_id: eventId,
     person_id: personId,
   });
@@ -150,7 +151,7 @@ export async function removeEventParticipant(eventId: string, personId: string) 
   const { error } = await supabase
     .from("event_participants")
     .delete()
-    .eq("campaign_id", CURRENT_CAMPAIGN_ID)
+    .eq("campaign_id", getActiveCampaignId())
     .eq("event_id", eventId)
     .eq("person_id", personId);
   if (error) throw error;
@@ -163,7 +164,7 @@ export async function createEntity(
   id: string,
   seed: Record<string, unknown>,
 ) {
-  const row = { id, campaign_id: CURRENT_CAMPAIGN_ID, ...toRow(kind, seed) };
+  const row = { id, campaign_id: getActiveCampaignId(), ...toRow(kind, seed) };
   const { error } = await supabase.from(kind).insert(row);
   if (error) throw error;
 }
@@ -177,7 +178,7 @@ export async function updateEntity(
     .from(kind)
     .update(toRow(kind, patch))
     .eq("id", id)
-    .eq("campaign_id", CURRENT_CAMPAIGN_ID);
+    .eq("campaign_id", getActiveCampaignId());
   if (error) throw error;
 }
 
@@ -185,7 +186,7 @@ async function deletePartyNotesFor(entityId: string) {
   const { error } = await supabase
     .from("party_notes")
     .delete()
-    .eq("campaign_id", CURRENT_CAMPAIGN_ID)
+    .eq("campaign_id", getActiveCampaignId())
     .eq("entity_id", entityId);
   if (error) throw error;
 }
@@ -210,6 +211,6 @@ export async function deleteEntity(kind: KindKey, id: string) {
     .from(kind)
     .delete()
     .eq("id", id)
-    .eq("campaign_id", CURRENT_CAMPAIGN_ID);
+    .eq("campaign_id", getActiveCampaignId());
   if (error) throw error;
 }

--- a/src/route.ts
+++ b/src/route.ts
@@ -3,10 +3,21 @@
 // #access_token=... hash must be left untouched for supabase-js to consume.
 const HASH_RE = /^#\/c\/([^/]+)(?:\/e\/(.+))?$/;
 
+// Malformed percent-encoding (e.g. "#/c/abc%") must not throw — a bad URL
+// then flows through the normal unknown-id fallbacks instead of wedging the
+// loader or crashing the render tree.
+function safeDecode(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
 export function parseHash(): { campaignId?: string; entityId?: string } {
   const m = HASH_RE.exec(window.location.hash);
   if (!m) return {};
-  return { campaignId: decodeURIComponent(m[1]), entityId: m[2] ? decodeURIComponent(m[2]) : undefined };
+  return { campaignId: safeDecode(m[1]), entityId: m[2] ? safeDecode(m[2]) : undefined };
 }
 
 export function campaignHash(campaignId: string, entityId?: string | null): string {

--- a/src/route.ts
+++ b/src/route.ts
@@ -1,0 +1,24 @@
+// Hash routing: #/c/:campaignId with an optional /e/:entityId deep link.
+// Only hashes matching this shape are parsed or rewritten — a magic-link
+// #access_token=... hash must be left untouched for supabase-js to consume.
+const HASH_RE = /^#\/c\/([^/]+)(?:\/e\/(.+))?$/;
+
+export function parseHash(): { campaignId?: string; entityId?: string } {
+  const m = HASH_RE.exec(window.location.hash);
+  if (!m) return {};
+  return { campaignId: decodeURIComponent(m[1]), entityId: m[2] ? decodeURIComponent(m[2]) : undefined };
+}
+
+export function campaignHash(campaignId: string, entityId?: string | null): string {
+  return `#/c/${encodeURIComponent(campaignId)}` + (entityId ? `/e/${encodeURIComponent(entityId)}` : "");
+}
+
+export function writeCampaignHash(campaignId: string, entityId?: string | null, opts?: { replace?: boolean }) {
+  const hash = campaignHash(campaignId, entityId);
+  if (window.location.hash === hash) return;
+  if (opts?.replace) {
+    history.replaceState(null, "", window.location.pathname + window.location.search + hash);
+  } else {
+    window.location.hash = hash;
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -273,6 +273,45 @@ body {
   width: 8px; height: 8px; border-radius: 50%;
   background: var(--bloodred);
   box-shadow: 0 0 0 2px rgba(138,42,31,.25);
+  flex-shrink: 0;
+}
+
+/* Campaign picker (Topbar) — the chip is the trigger, menu drops below it. */
+.campaign-picker { position: relative; max-width: 100%; }
+.campaign-picker-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  min-width: 260px;
+  background: var(--paper-cream);
+  border: 1px solid var(--vellum-deep);
+  border-radius: 4px;
+  box-shadow: 0 8px 24px rgba(40,20,5,.3);
+  padding: 4px;
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+}
+.campaign-picker-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 12px;
+  background: transparent;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font-fell);
+  color: var(--ink);
+  white-space: nowrap;
+}
+.campaign-picker-item:hover { background: var(--vellum-light); }
+.campaign-picker-item.active { cursor: default; }
+.campaign-picker-item .dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--bloodred);
+  box-shadow: 0 0 0 2px rgba(138,42,31,.25);
+  flex-shrink: 0;
 }
 
 /* Presence avatars */

--- a/supabase/migrations/0010_seed_fist_of_ilmater.sql
+++ b/supabase/migrations/0010_seed_fist_of_ilmater.sql
@@ -1,0 +1,5 @@
+-- Second campaign so the picker has something to switch to (issue #18).
+-- Content import from the play notes is issue #20.
+insert into public.campaigns (id, title, subtitle) values
+  ('fist-of-ilmater', 'Fist of Ilmater', 'From Mirabar to the Dollmother''s web')
+on conflict (id) do nothing;


### PR DESCRIPTION
Closes #18.

## What

- **Campaign in the URL**: hash routing `#/c/:campaignId`, with optional `#/c/:campaignId/e/:entityId` entity deep links ([src/route.ts](../blob/feat/campaign-picker/src/route.ts)). Hash chosen over path routing: no server rewrite config, iframe-safe for the host-page embed, and magic-link `#access_token` hashes are left untouched for supabase-js to consume.
- **`CURRENT_CAMPAIGN_ID` is gone.** `CampaignProvider` resolves the active id as hash → `__TWEAKS__.campaignId` → first `campaigns` row, and re-runs the whole load/subscribe effect keyed on it. Unknown ids in the URL are replaced with the active campaign.
- **No cross-campaign bleed on switch**: the channel is per-id, every splice handler is gated on `c.id === campaignId` (the effect-captured id), and the four refetch handlers (connections, board_positions, party_notes, event_participants) additionally check the effect's `cancelled` flag so a late-resolving refetch can't overwrite the new campaign's arrays.
- **Mutations** read the id from a module-level store (`src/activeCampaign.ts`) written only by the provider, synchronously before any await. `AppGate` unmounts all UI while loading, so nothing can write mid-switch.
- **CampaignPicker** replaces the static Topbar chip — visible to read-only viewers (switching is navigation, not an edit); the dropdown only appears once a second campaign exists. Switch persists through the host-page `__edit_mode_set_keys` postMessage, never localStorage.
- **Share link** now copies the real URL (`…/#/c/<id>`) instead of showing a hardcoded fake.
- **Migration 0010** seeds the `fist-of-ilmater` campaign row (insert-only, `on conflict do nothing`; content import is #20). ⚠️ **Not yet applied** — Supabase MCP has no access to this project; needs the dashboard SQL editor.

## Trust model (call-out per #18)

The switcher is **trust-based**: RLS write policies still gate only on the `is_anonymous` JWT claim, not per-campaign membership. Any signed-in editor can write to any campaign. Per-campaign membership (`campaign_members`) remains future work.

## Verified

- `npm run build` clean.
- Playwright against dev: bare URL normalizes to `#/c/fendwick`; cold + mid-session entity deep links open/close the detail sheet; unknown campaign ids in the hash are restored; unknown entity ids are silently dropped; nothing written to localStorage.
- **Pending until 0010 is applied**: picker dropdown + two-tab no-bleed/resubscribe test (requires a second campaign row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)