### PR TITLE
Fix UI issues from the FoI 179–191 review

### DIFF
--- a/src/arcs.tsx
+++ b/src/arcs.tsx
@@ -16,8 +16,13 @@ function arcRange(arc: Arc, assigned: Session[], byId: Map<string, Session>): st
   const first = (arc.startSession && byId.get(arc.startSession)) || assigned[0];
   const last = (arc.endSession && byId.get(arc.endSession)) || assigned[assigned.length - 1];
   if (!first || !last) return "";
-  if (first.id === last.id) return first.date;
-  return `${first.date} — ${last.date}`;
+  // Guard the date fields, not just the session objects: an arc can span
+  // sessions whose `date` column is null, and an unguarded template would
+  // print the literal string "null".
+  const fd = first.date, ld = last.date;
+  if (first.id === last.id) return fd ?? "";
+  if (!fd || !ld) return fd || ld || "";
+  return `${fd} — ${ld}`;
 }
 
 export function ArcsPage({ onOpenEntity }: { onOpenEntity: (id: string) => void }) {

--- a/src/board.tsx
+++ b/src/board.tsx
@@ -49,6 +49,21 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
   const positions = campaign.board;
   const connections = campaign.connections;
 
+  // The board sizes itself to its content: the cork/frame and the yarn SVG
+  // grow to enclose the furthest-flung card so nothing lands off-canvas and
+  // no string is clipped. 2800×2000 is the floor (the original design size),
+  // and the padding clears the tallest card (~220×344) plus a margin.
+  const bounds = useMemo(() => {
+    let w = 2800, h = 2000;
+    for (const id in positions) {
+      const p = positions[id];
+      if (!p) continue;
+      if (p.x + 320 > w) w = p.x + 320;
+      if (p.y + 420 > h) h = p.y + 420;
+    }
+    return { w, h };
+  }, [positions]);
+
   const [filters, setFilters] = useState<Filters>(() => {
     const f: Filters = { sessions: "all" };
     (["people", "locations", "quests", "goals", "factions", "items", "lore"] as const).forEach((k) => {
@@ -330,7 +345,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
       >
         <div
           className={`board-surface ${scale < 0.7 ? "zoom-far" : ""}`}
-          style={{ transform: `translate(${pan.x}px, ${pan.y}px) scale(${scale})` }}
+          style={{ transform: `translate(${pan.x}px, ${pan.y}px) scale(${scale})`, width: bounds.w, height: bounds.h }}
         >
           <div className="board-frame" />
           <CompassRose style={{ top: 60, right: 120, color: "var(--ink)" } as any} />
@@ -353,7 +368,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
             ✦ THE NOTICE BOARD OF THE CROOKED TANKARD ✦
           </div>
 
-          <svg className="yarn-layer" viewBox={`0 0 2800 2000`} preserveAspectRatio="none">
+          <svg className="yarn-layer" viewBox={`0 0 ${bounds.w} ${bounds.h}`} preserveAspectRatio="none">
             <defs>
               <filter id="yarn-glow">
                 <feGaussianBlur stdDeviation="0.6" />

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -22,18 +22,34 @@ interface Position {
 // left untouched.
 const isDelimRow = (l: string) => /^\|?[\s:\-|]+\|?$/.test(l.trim()) && l.includes("-");
 const isPipeRow = (l: string) => /^\|.*\|$/.test(l.trim());
+// Split a pipe row into trimmed cells, respecting escaped pipes (`\|` is a
+// literal, not a cell boundary), then unescape them.
+const splitRow = (t: string) =>
+  t.replace(/^\|/, "").replace(/\|$/, "")
+    .split(/(?<!\\)\|/)
+    .map((c) => c.trim().replace(/\\\|/g, "|"))
+    .filter(Boolean);
 function normalizeLoosePipeRows(md: string): string {
   const lines = md.split("\n");
+  // First, mark every line that belongs to a *real* GFM table: a header row
+  // (its next line is the delimiter), the delimiter itself, and the body rows
+  // that follow. Anything else that looks like a pipe row is "loose".
+  const inTable = new Array(lines.length).fill(false);
+  for (let i = 0; i < lines.length; i++) {
+    const t = lines[i].trim();
+    if (!isPipeRow(t) || isDelimRow(t)) continue;
+    if (!isDelimRow(lines[i + 1]?.trim() ?? "")) continue;
+    inTable[i] = inTable[i + 1] = true;
+    let j = i + 2;
+    while (j < lines.length && isPipeRow(lines[j].trim())) inTable[j++] = true;
+    i = j - 1;
+  }
   return lines
     .map((line, i) => {
       const t = line.trim();
-      if (!isPipeRow(t) || isDelimRow(t)) return line;
-      const prev = lines[i - 1]?.trim() ?? "";
-      const next = lines[i + 1]?.trim() ?? "";
-      // Part of a real table: a body row (prev is a row) or a header (next is
-      // the delimiter). Everything else is a loose row to collapse.
-      if (isPipeRow(prev) || isDelimRow(next)) return line;
-      const cells = t.replace(/^\|/, "").replace(/\|$/, "").split("|").map((c) => c.trim()).filter(Boolean);
+      if (inTable[i] || !isPipeRow(t) || isDelimRow(t)) return line;
+      // Loose row (incl. several stacked back-to-back): collapse to text.
+      const cells = splitRow(t);
       if (cells.length < 2) return cells[0] ?? line;
       return `${cells[0]}: ${cells.slice(1).join(" — ")}`;
     })

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -14,6 +14,32 @@ interface Position {
   kind: KindKey;
 }
 
+// Play-note exports write single key/value rows as one-row "tables"
+// (`| **Attendees** | Mort, Fynn |`). Without a `| --- |` delimiter these
+// aren't GFM tables, so react-markdown renders them as literal pipe text.
+// Collapse any such loose pipe row into a plain "label: value" line; real
+// tables (a row adjacent to a delimiter, or a body row under a header) are
+// left untouched.
+const isDelimRow = (l: string) => /^\|?[\s:\-|]+\|?$/.test(l.trim()) && l.includes("-");
+const isPipeRow = (l: string) => /^\|.*\|$/.test(l.trim());
+function normalizeLoosePipeRows(md: string): string {
+  const lines = md.split("\n");
+  return lines
+    .map((line, i) => {
+      const t = line.trim();
+      if (!isPipeRow(t) || isDelimRow(t)) return line;
+      const prev = lines[i - 1]?.trim() ?? "";
+      const next = lines[i + 1]?.trim() ?? "";
+      // Part of a real table: a body row (prev is a row) or a header (next is
+      // the delimiter). Everything else is a loose row to collapse.
+      if (isPipeRow(prev) || isDelimRow(next)) return line;
+      const cells = t.replace(/^\|/, "").replace(/\|$/, "").split("|").map((c) => c.trim()).filter(Boolean);
+      if (cells.length < 2) return cells[0] ?? line;
+      return `${cells[0]}: ${cells.slice(1).join(" — ")}`;
+    })
+    .join("\n");
+}
+
 interface PinnedCardProps {
   entity: any;
   pos: Position;
@@ -140,7 +166,9 @@ export function PosterCard({ person }: { person: any }) {
       <div className="name">{person.name}</div>
       <div className="desc">— {person.epithet}</div>
       <div className="reward">
-        <span><strong>Race</strong> · {person.race}</span>
+        {person.race
+          ? <span><strong>Race</strong> · {person.race}</span>
+          : <span />}
         {sess && <span>Sess {sess.num}</span>}
       </div>
     </div>
@@ -715,7 +743,7 @@ export function EditableMarkdown({
         className={`md-body ${className ?? ""}`}
         style={{ opacity: empty ? 0.55 : 1, fontStyle: empty ? "italic" : undefined, ...style }}
       >
-        {empty ? placeholder : <ReactMarkdown remarkPlugins={[remarkGfm]}>{display}</ReactMarkdown>}
+        {empty ? placeholder : <ReactMarkdown remarkPlugins={[remarkGfm]}>{normalizeLoosePipeRows(display)}</ReactMarkdown>}
       </div>
     );
   }
@@ -784,7 +812,7 @@ export function EditableMarkdown({
         setEditing(true);
       }}
     >
-      {empty ? (placeholder || "Click to edit…") : <ReactMarkdown remarkPlugins={[remarkGfm]}>{display}</ReactMarkdown>}
+      {empty ? (placeholder || "Click to edit…") : <ReactMarkdown remarkPlugins={[remarkGfm]}>{normalizeLoosePipeRows(display)}</ReactMarkdown>}
     </div>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -541,7 +541,9 @@ body {
 .board-surface {
   position: absolute;
   top: 0; left: 0;
-  width: 2800px; height: 2000px;
+  /* Floor only — board.tsx sets explicit width/height from the furthest card
+     so the cork/frame/yarn grow to enclose all content. */
+  min-width: 2800px; min-height: 2000px;
   transform-origin: 0 0;
 }
 


### PR DESCRIPTION
Fixes the visual/UX and data-rendering issues found during the UI review of the newly-imported Fist of Ilmater sessions 179–191 (run against live Supabase).

## Changes

### Board sizes itself to its content (`src/board.tsx`)
The notice board was hard-coded to `2800×2000`, but the new Vecna/Neverwinter cluster reaches y≈2110 (card bottoms ≈2454) and x=2500. Result: the lowest cards spilled off the cork frame onto bare background, and yarn strings to them (reaching y=2260) were clipped by the fixed-size SVG (`overflow:hidden`, `viewBox="0 0 2800 2000"`). The surface, frame, and yarn `viewBox` now grow from the furthest card position, with `2800×2000` as the floor.

### Story Arcs no longer prints "null" (`src/arcs.tsx`)
`arcRange()` guarded against a missing *session* but interpolated `first.date`/`last.date` unguarded, so arcs whose sessions lack a `date` rendered "null — null". Now missing dates are omitted gracefully (also cleans up the older arcs 1–3).

### No dangling "Race ·" on poster cards (`src/components.tsx`)
`PosterCard` always rendered `Race · {race}`; portrait-less people with no race (Eldon Keyward, Zalryr, Sarcelle, …) showed a dangling "Race ·". The label now renders only when a race is present; `Sess N` stays right-aligned.

### Attendees rows render as text, not raw pipes (`src/components.tsx`)
Play-note exports write `| **Attendees** | … |` as a one-row "table" with no `| --- |` delimiter, so remark-gfm renders literal pipe text. This affected **29 sessions (163–191)** — a render-layer normalizer (`normalizeLoosePipeRows`) collapses any delimiter-less loose pipe row into a bold `label: value` line. Verified that real GFM tables (the "To do" tables in 189/191) are left intact, and that the fix reaches older sessions too.

## Verification
- `npm run build` passes (typecheck clean).
- Driven in-browser against live Supabase: board frame now encloses the bottom cluster with unclipped strings; arcs show no "null"; 0 dangling Race cards; sessions 170/185/189 render bold "Attendees:" with images and real tables preserved. Console clean (0 errors/warnings).

## Deliberately out of scope
- The "To do" cell's run-on text (a *valid* table; reflowing needs DM content decisions on item boundaries).
- `q11` "Uncover Vecna's Design" missing arc (semantic, unconfirmed).
- Pre-existing duplicate "SESS 37" in older data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)