### PR TITLE
Active session: shared "we're live" pin + one-tap "seen this session"

### DIFF
--- a/src/activeSession.ts
+++ b/src/activeSession.ts
@@ -1,0 +1,13 @@
+// Module-level active-session store. Written only by CampaignProvider (in the
+// load effect and the campaigns realtime handler); read by mutations.ts, which
+// are plain async functions and can't reach React context. Unlike the active
+// campaign, this can be null — a campaign may have no session pinned as live.
+let activeSessionId: string | null = null;
+
+export function setActiveSessionId(id: string | null) {
+  activeSessionId = id;
+}
+
+export function getActiveSessionId(): string | null {
+  return activeSessionId;
+}

--- a/src/board.tsx
+++ b/src/board.tsx
@@ -14,6 +14,7 @@ import {
   insertConnection,
   deleteConnection,
   createEntity,
+  markSeen,
 } from "./mutations";
 
 // Minimum required columns by kind (NOT NULL constraints in 0001_init.sql).
@@ -65,7 +66,8 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
   }, [positions]);
 
   const [filters, setFilters] = useState<Filters>(() => {
-    const f: Filters = { sessions: "all" };
+    // Open focused on the live session's cast when a session is pinned.
+    const f: Filters = { sessions: campaign.activeSessionId ?? "all" };
     (["people", "locations", "quests", "goals", "factions", "items", "lore"] as const).forEach((k) => {
       (f as any)[k] = true;
     });
@@ -134,6 +136,12 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
     const id = crypto.randomUUID();
     try {
       await createEntity(k, id, NEW_ENTITY_DEFAULTS[k]);
+      // Creating a person while live implies they showed up this session —
+      // auto-mark them seen (people have no session_id, so this is their
+      // creation-only link, mirroring the events/quests default in createEntity).
+      if (k === "people" && campaign.activeSessionId) {
+        markSeen(id).catch(console.error);
+      }
       // Drop the new card into the first open spot so cards don't pile up.
       const spot = findFreeSpot(k);
       await upsertBoardPosition(id, {

--- a/src/campaignContext.tsx
+++ b/src/campaignContext.tsx
@@ -378,6 +378,10 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
           "postgres_changes" as any,
           { event: "UPDATE", schema: "public", table: "campaigns", filter: `id=eq.${campaignId}` },
           (payload: any) => {
+            // Guard the module-store write like the async handlers do: a late
+            // event from the previous campaign's torn-down channel must not
+            // leak a stale active_session_id into the store mutations read.
+            if (cancelled) return;
             const next = payload.new?.active_session_id ?? undefined;
             setActiveSessionId(next ?? null);
             setCampaign((c) => c && c.id === campaignId ? { ...c, activeSessionId: next, title: payload.new?.title ?? c.title, subtitle: payload.new?.subtitle ?? c.subtitle } : c);

--- a/src/campaignContext.tsx
+++ b/src/campaignContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useCallback, useEffect, useState, type ReactNode } from 
 import type { RealtimeChannel } from "@supabase/supabase-js";
 import { supabase } from "./utils/supabase";
 import { setActiveCampaignId } from "./activeCampaign";
+import { setActiveSessionId } from "./activeSession";
 import { parseHash, writeCampaignHash } from "./route";
 import {
   type Campaign,
@@ -151,6 +152,15 @@ const buildParticipants = (rows: any[]): Record<string, string[]> => {
   return byEvent;
 };
 
+// session id → person ids seen in that session (session_participants junction).
+const buildSessionParticipants = (rows: any[]): Record<string, string[]> => {
+  const bySession: Record<string, string[]> = {};
+  rows.forEach((r: any) => {
+    (bySession[r.session_id] = bySession[r.session_id] || []).push(r.person_id);
+  });
+  return bySession;
+};
+
 const mapPresence = (r: any) => ({
   id: r.id,
   name: r.name,
@@ -183,6 +193,7 @@ async function fetchCampaign(id: string): Promise<Campaign> {
     arcsRes,
     eventsRes,
     participantsRes,
+    sessionParticipantsRes,
     peopleRes,
     locationsRes,
     questsRes,
@@ -200,6 +211,7 @@ async function fetchCampaign(id: string): Promise<Campaign> {
     supabase.from("arcs").select("*").eq("campaign_id", id).order("order_num"),
     supabase.from("events").select("*").eq("campaign_id", id).order("order_num"),
     supabase.from("event_participants").select("*").eq("campaign_id", id),
+    supabase.from("session_participants").select("*").eq("campaign_id", id),
     supabase.from("people").select("*").eq("campaign_id", id),
     supabase.from("locations").select("*").eq("campaign_id", id),
     supabase.from("quests").select("*").eq("campaign_id", id),
@@ -214,7 +226,8 @@ async function fetchCampaign(id: string): Promise<Campaign> {
   ]);
 
   const first = [
-    campaignRes, sessionsRes, arcsRes, eventsRes, participantsRes, peopleRes,
+    campaignRes, sessionsRes, arcsRes, eventsRes, participantsRes,
+    sessionParticipantsRes, peopleRes,
     locationsRes, questsRes, goalsRes, factionsRes, itemsRes, loreRes,
     connectionsRes, boardRes, presenceRes, notesRes,
   ].find((r) => r.error);
@@ -234,6 +247,8 @@ async function fetchCampaign(id: string): Promise<Campaign> {
     arcs: (arcsRes.data ?? []).map(mapArc),
     events: (eventsRes.data ?? []).map(mapEvent),
     eventParticipants: buildParticipants(participantsRes.data ?? []),
+    sessionParticipants: buildSessionParticipants(sessionParticipantsRes.data ?? []),
+    activeSessionId: campaignRes.data.active_session_id ?? undefined,
     people: (peopleRes.data ?? []).map(mapPerson),
     locations: (locationsRes.data ?? []).map(mapLocation),
     quests: (questsRes.data ?? []).map(mapQuest),
@@ -336,8 +351,11 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
     let channel: RealtimeChannel | null = null;
 
     // Synchronous, before any await: mutations read this store, and clearing
-    // the campaign unmounts AppLoaded so nothing can write mid-switch.
+    // the campaign unmounts AppLoaded so nothing can write mid-switch. Clear
+    // the active-session store too so a stale pin from the previous campaign
+    // can't leak into a mutation before the new campaign's value loads.
     setActiveCampaignId(campaignId);
+    setActiveSessionId(null);
     setCampaign(null);
     setLoading(true);
     setError(null);
@@ -347,11 +365,24 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
         const initial = await fetchCampaign(campaignId);
         if (cancelled) return;
         setCampaign(initial);
+        setActiveSessionId(initial.activeSessionId ?? null);
         setLoading(false);
 
         const filter = `campaign_id=eq.${campaignId}`;
         channel = supabase.channel(`campaign:${campaignId}`);
 
+        // The shared pin lives on the campaigns row itself, so it's filtered by
+        // `id`, not `campaign_id`. Keep both the React state and the module-level
+        // store (read by mutations) in sync when another client moves the pin.
+        channel.on(
+          "postgres_changes" as any,
+          { event: "UPDATE", schema: "public", table: "campaigns", filter: `id=eq.${campaignId}` },
+          (payload: any) => {
+            const next = payload.new?.active_session_id ?? undefined;
+            setActiveSessionId(next ?? null);
+            setCampaign((c) => c && c.id === campaignId ? { ...c, activeSessionId: next, title: payload.new?.title ?? c.title, subtitle: payload.new?.subtitle ?? c.subtitle } : c);
+          },
+        );
         channel.on(
           "postgres_changes" as any,
           { event: "*", schema: "public", table: "people", filter },
@@ -430,6 +461,18 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
             supabase.from("event_participants").select("*").eq("campaign_id", campaignId).then(({ data }) => {
               if (cancelled) return;
               setCampaign((c) => c && c.id === campaignId ? { ...c, eventParticipants: buildParticipants(data ?? []) } : c);
+            });
+          },
+        );
+        channel.on(
+          "postgres_changes" as any,
+          { event: "*", schema: "public", table: "session_participants", filter },
+          () => {
+            // Composite PK, no client-side id — refetch, same as event_participants.
+            // (The trigger's downstream people UPDATE arrives via the people handler.)
+            supabase.from("session_participants").select("*").eq("campaign_id", campaignId).then(({ data }) => {
+              if (cancelled) return;
+              setCampaign((c) => c && c.id === campaignId ? { ...c, sessionParticipants: buildSessionParticipants(data ?? []) } : c);
             });
           },
         );

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -4,7 +4,7 @@ import remarkGfm from "remark-gfm";
 import { type KindKey, type PresenceUser } from "./data";
 import { Icon, MapScribble, kindIcon } from "./icons";
 import { useCampaign, useCampaignSwitcher, useKinds } from "./hooks";
-import { createEntity } from "./mutations";
+import { createEntity, setActiveSession } from "./mutations";
 import { SignInDialog, useAuth } from "./auth";
 
 interface Position {
@@ -165,8 +165,13 @@ export function CardBody({ entity, kind }: { entity: any; kind: KindKey }) {
 export function PosterCard({ person }: { person: any }) {
   const campaign = useCampaign();
   const sess = person.lastSeen ? campaign.sessions.find((s) => s.id === person.lastSeen) : null;
+  // Seen in the currently-live session? Subtle read-only marker; the toggle
+  // itself lives on the detail sheet.
+  const seenLive = !!campaign.activeSessionId
+    && (campaign.sessionParticipants[campaign.activeSessionId] ?? []).includes(person.id);
   return (
     <div className="card-poster">
+      {seenLive && <span className="seen-live-dot" title="Seen this session" />}
       <div className="wanted">
         {person.disposition === "hostile"
           ? "✦ Wanted ✦"
@@ -321,8 +326,32 @@ export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts 
   const visibleSessions = effectiveArcFilter === "all"
     ? campaign.sessions
     : campaign.sessions.filter((s) => s.arc === effectiveArcFilter);
+  // Roster of people marked seen in the currently-live session.
+  const liveSession = campaign.sessions.find((s) => s.id === campaign.activeSessionId);
+  const seenThisSession = liveSession
+    ? (campaign.sessionParticipants[liveSession.id] ?? [])
+        .map((pid) => campaign.people.find((p) => p.id === pid))
+        .filter((p): p is NonNullable<typeof p> => !!p)
+        .sort((a, b) => a.name.localeCompare(b.name))
+    : [];
   return (
     <aside className="sidebar">
+      {liveSession && (
+        <>
+          <div className="sidebar-label"><span>This Session · {liveSession.num}</span></div>
+          <div className="session-roster">
+            {seenThisSession.length === 0 ? (
+              <div className="session-roster-empty">No one marked seen yet.</div>
+            ) : (
+              seenThisSession.map((p) => (
+                <button key={p.id} className="roster-chip" onClick={() => onOpenEntity(p.id)} title={p.epithet ?? p.name}>
+                  {p.name}
+                </button>
+              ))
+            )}
+          </div>
+        </>
+      )}
       <div className="sidebar-label"><span>The Board</span></div>
       <div className={`nav-item ${active === "board" ? "active" : ""}`} onClick={() => onSelect("board")}>
         <span className="icon"><Icon name="board" /></span>
@@ -505,6 +534,98 @@ function CampaignPicker() {
   );
 }
 
+// The shared "we're live in session N" pin, beside the campaign picker.
+// Editors get a dropdown to go live / switch / stand down; viewers see a static
+// label so everyone at the table knows which session is current. The value is
+// campaign-wide and synced to every client via realtime.
+function SessionPin() {
+  const campaign = useCampaign();
+  const { canEdit } = useAuth();
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const live = campaign.sessions.find((s) => s.id === campaign.activeSessionId);
+  const label = live ? `SESSION ${live.num}` : "NOT LIVE";
+
+  // Viewers: static, non-interactive label (only shown when a session is live).
+  if (!canEdit) {
+    if (!live) return null;
+    return (
+      <div className="session-pin">
+        <span className={"pin-dot live"} />
+        <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".1em", fontSize: 11 }}>LIVE</span>
+        <span>·</span>
+        <span style={{ fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 14 }}>Session {live.num}</span>
+      </div>
+    );
+  }
+
+  const pick = (id: string | null) => {
+    setActiveSession(id).catch(console.error);
+    setOpen(false);
+  };
+  // Newest sessions first — that's the one you're most likely going live on.
+  const ordered = [...campaign.sessions].sort((a, b) => b.num - a.num);
+
+  return (
+    <div className="session-pin-picker" ref={rootRef}>
+      <button
+        className="session-pin"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        title={live ? "Switch or stand down" : "Go live on a session"}
+      >
+        <span className={"pin-dot" + (live ? " live" : "")} />
+        <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".1em", fontSize: 11 }}>{live ? "LIVE" : "GO LIVE"}</span>
+        {live && <><span>·</span><span style={{ fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 14 }}>{label}</span></>}
+        <Icon name="chevron" size={11} style={{ transform: open ? "rotate(-90deg)" : "rotate(90deg)", color: "var(--ink-faded)", flexShrink: 0 }} />
+      </button>
+      {open && (
+        <div className="campaign-picker-menu" role="listbox">
+          {live && (
+            <button role="option" aria-selected={false} className="campaign-picker-item" onClick={() => pick(null)}>
+              <span className="dot" style={{ visibility: "hidden" }} />
+              <span style={{ fontFamily: "var(--font-fell)", fontStyle: "italic", fontSize: 13 }}>Stand down (not live)</span>
+            </button>
+          )}
+          {ordered.map((s) => (
+            <button
+              key={s.id}
+              role="option"
+              aria-selected={s.id === campaign.activeSessionId}
+              className={"campaign-picker-item" + (s.id === campaign.activeSessionId ? " active" : "")}
+              onClick={() => pick(s.id)}
+            >
+              <span className="dot" style={{ visibility: s.id === campaign.activeSessionId ? "visible" : "hidden" }} />
+              <span>
+                <span style={{ fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 14, display: "block" }}>Session {s.num}</span>
+                {s.title && <span style={{ color: "var(--ink-faded)", fontStyle: "italic", fontSize: 12 }}>{s.title}</span>}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function Topbar({ onShare }: { onShare: () => void }) {
   const campaign = useCampaign();
   const { canEdit, displayName, signOut } = useAuth();
@@ -520,6 +641,7 @@ export function Topbar({ onShare }: { onShare: () => void }) {
       </div>
       <div className="topbar-center">
         <CampaignPicker />
+        <SessionPin />
       </div>
       <div className="topbar-right">
         <Presence users={campaign.presence} />

--- a/src/data.ts
+++ b/src/data.ts
@@ -161,6 +161,10 @@ export interface Campaign {
   events: CampaignEvent[];
   // event id → participating person ids (event_participants junction).
   eventParticipants: Record<string, string[]>;
+  // session id → person ids seen in that session (session_participants junction).
+  sessionParticipants: Record<string, string[]>;
+  // The shared "we're live in session N" pin (campaigns.active_session_id).
+  activeSessionId?: string;
   people: Person[];
   locations: Location[];
   quests: Quest[];

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -11,6 +11,8 @@ import {
   insertConnection,
   addEventParticipant,
   removeEventParticipant,
+  markSeen,
+  unmarkSeen,
 } from "./mutations";
 import { uploadEntityImage, type UploadableKind } from "./upload";
 
@@ -640,6 +642,19 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                     ✦ {kind === "events" ? "During" : "Introduced"} — Session {campaign.sessions.find((s) => s.id === (entity as any).session)?.num}
                   </span>
                 )}
+                {kind === "people" && canEdit && campaign.activeSessionId && (() => {
+                  const activeNum = campaign.sessions.find((s) => s.id === campaign.activeSessionId)?.num;
+                  const seen = (campaign.sessionParticipants[campaign.activeSessionId] ?? []).includes(entity.id);
+                  return (
+                    <button
+                      className={"seen-toggle" + (seen ? " seen" : "")}
+                      onClick={() => (seen ? unmarkSeen(entity.id) : markSeen(entity.id)).catch(console.error)}
+                      title={seen ? `Marked seen in session ${activeNum} — click to remove` : `Mark seen in session ${activeNum}`}
+                    >
+                      {seen ? "✓ Seen this session" : "+ Seen this session"}
+                    </button>
+                  );
+                })()}
               </div>
             </div>
           </div>

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -1,5 +1,6 @@
 import { supabase } from "./utils/supabase";
 import { getActiveCampaignId } from "./activeCampaign";
+import { getActiveSessionId } from "./activeSession";
 import { type KindKey, type PartyNote, type BoardPosition } from "./data";
 
 // Realtime subscriptions in campaignContext.tsx reflect writes back into UI
@@ -157,6 +158,45 @@ export async function removeEventParticipant(eventId: string, personId: string) 
   if (error) throw error;
 }
 
+// ===== Active session & seen ================================================
+// The shared "we're live in session N" pin lives on the campaigns row and syncs
+// to every client via realtime. Seen-tracking writes the session_participants
+// junction; a DB trigger keeps people.last_seen_session_id derived from it.
+
+export async function setActiveSession(sessionId: string | null) {
+  const { error } = await supabase
+    .from("campaigns")
+    .update({ active_session_id: sessionId })
+    .eq("id", getActiveCampaignId());
+  if (error) throw error;
+}
+
+export async function markSeen(personId: string) {
+  const sessionId = getActiveSessionId();
+  if (!sessionId) {
+    console.warn("markSeen: no active session — nothing to mark against");
+    return;
+  }
+  const { error } = await supabase.from("session_participants").insert({
+    campaign_id: getActiveCampaignId(),
+    session_id: sessionId,
+    person_id: personId,
+  });
+  if (error) throw error;
+}
+
+export async function unmarkSeen(personId: string) {
+  const sessionId = getActiveSessionId();
+  if (!sessionId) return;
+  const { error } = await supabase
+    .from("session_participants")
+    .delete()
+    .eq("campaign_id", getActiveCampaignId())
+    .eq("session_id", sessionId)
+    .eq("person_id", personId);
+  if (error) throw error;
+}
+
 // ===== Entity CRUD ==========================================================
 
 export async function createEntity(
@@ -164,7 +204,15 @@ export async function createEntity(
   id: string,
   seed: Record<string, unknown>,
 ) {
-  const row = { id, campaign_id: getActiveCampaignId(), ...toRow(kind, seed) };
+  const row: Record<string, unknown> = { id, campaign_id: getActiveCampaignId(), ...toRow(kind, seed) };
+  // Creation-only auto-link: an event/quest made while a session is live
+  // defaults its session_id to that session ("happened this session" /
+  // "introduced this session"). Only fills when the caller left it unset, and
+  // only on create — editing an old entity never relinks it to today.
+  if ((kind === "events" || kind === "quests") && row.session_id == null) {
+    const activeSession = getActiveSessionId();
+    if (activeSession) row.session_id = activeSession;
+  }
   const { error } = await supabase.from(kind).insert(row);
   if (error) throw error;
 }

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -177,11 +177,17 @@ export async function markSeen(personId: string) {
     console.warn("markSeen: no active session — nothing to mark against");
     return;
   }
-  const { error } = await supabase.from("session_participants").insert({
-    campaign_id: getActiveCampaignId(),
-    session_id: sessionId,
-    person_id: personId,
-  });
+  // Idempotent: the composite PK is (session_id, person_id), and there's no
+  // optimistic UI, so a double-click or a second editor marking the same person
+  // would otherwise throw a unique violation. ignoreDuplicates makes it a no-op.
+  const { error } = await supabase.from("session_participants").upsert(
+    {
+      campaign_id: getActiveCampaignId(),
+      session_id: sessionId,
+      person_id: personId,
+    },
+    { onConflict: "session_id,person_id", ignoreDuplicates: true },
+  );
   if (error) throw error;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -246,7 +246,7 @@ body {
 }
 
 .topbar-center {
-  flex: 1; display: flex; justify-content: center; align-items: center;
+  flex: 1; display: flex; justify-content: center; align-items: center; gap: 10px;
 }
 .topbar-right {
   display: flex; align-items: center; gap: 14px;
@@ -312,6 +312,91 @@ body {
   background: var(--bloodred);
   box-shadow: 0 0 0 2px rgba(138,42,31,.25);
   flex-shrink: 0;
+}
+
+/* Active-session pin (Topbar) — same chip language as the campaign picker. */
+.session-pin-picker { position: relative; }
+.session-pin {
+  display: flex; align-items: center; gap: 8px;
+  padding: 5px 12px 5px 10px;
+  background: var(--paper-cream);
+  border: 1px solid var(--vellum-deep);
+  border-radius: 20px;
+  font-family: var(--font-fell);
+  font-size: 13px;
+  color: var(--ink);
+  box-shadow: 0 1px 2px rgba(40,20,5,.12);
+  white-space: nowrap;
+  cursor: pointer;
+}
+button.session-pin { line-height: 1; }
+.session-pin .pin-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--ink-ghost);
+  flex-shrink: 0;
+}
+.session-pin .pin-dot.live {
+  background: var(--bloodred);
+  box-shadow: 0 0 0 2px rgba(138,42,31,.25);
+  animation: pin-pulse 2s ease-in-out infinite;
+}
+@keyframes pin-pulse {
+  0%, 100% { box-shadow: 0 0 0 2px rgba(138,42,31,.25); }
+  50%      { box-shadow: 0 0 0 4px rgba(138,42,31,.10); }
+}
+
+/* "Seen this session" toggle on the person detail sheet. */
+.seen-toggle {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 3px 10px;
+  background: transparent;
+  border: 1px dashed var(--ink-faded);
+  color: var(--ink-faded);
+  font-family: var(--font-fell-sc);
+  font-size: 11px;
+  letter-spacing: .1em;
+  cursor: pointer;
+  clip-path: polygon(4px 0, 100% 0, calc(100% - 4px) 100%, 0 100%);
+}
+.seen-toggle:hover { border-color: var(--bloodred); color: var(--bloodred); }
+.seen-toggle.seen {
+  background: var(--bloodred);
+  border-color: var(--bloodred);
+  color: var(--paper-cream);
+}
+
+/* "Seen this session" marker on a person's board card. */
+.seen-live-dot {
+  position: absolute; top: 8px; right: 8px;
+  width: 9px; height: 9px; border-radius: 50%;
+  background: var(--bloodred);
+  box-shadow: 0 0 0 2px var(--paper-cream), 0 0 0 3px rgba(138,42,31,.4);
+  z-index: 2;
+}
+
+/* "This session" roster in the sidebar. */
+.session-roster {
+  display: flex; flex-wrap: wrap; gap: 5px;
+  padding: 2px 16px 8px;
+}
+.roster-chip {
+  padding: 3px 9px;
+  background: var(--paper-cream);
+  border: 1px solid var(--vellum-deep);
+  border-radius: 12px;
+  font-family: var(--font-fell);
+  font-size: 12px;
+  color: var(--ink);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.roster-chip:hover { border-color: var(--bloodred); color: var(--bloodred); }
+.session-roster-empty {
+  padding: 0 16px 4px;
+  font-family: var(--font-fell);
+  font-style: italic;
+  font-size: 12px;
+  color: var(--ink-faded);
 }
 
 /* Presence avatars */

--- a/supabase/migrations/0013_active_session.sql
+++ b/supabase/migrations/0013_active_session.sql
@@ -1,0 +1,97 @@
+-- Active session (issue #33): a shared, campaign-wide "we're live in session N"
+-- pin, plus an appearance-history junction so people can be marked "seen" in a
+-- session with one tap. `people.last_seen_session_id` becomes DERIVED from the
+-- junction via a trigger, so the existing detail ribbon / cleanup panel / board
+-- filter keep reading it unchanged.
+
+-- 1. Shared pin. One active session per campaign, synced to every client via
+--    realtime. Survives session deletion (set null).
+alter table public.campaigns
+  add column active_session_id text
+  references public.sessions(id) on delete set null;
+
+-- 2. Appearance history — the M:N junction (mirrors event_participants).
+--    Composite PK, no client-side id; FKs cascade on session/person delete, so
+--    deleteEntity needs NO app-side sweep for this table (unlike connections).
+create table public.session_participants (
+  campaign_id text not null references public.campaigns(id) on delete cascade,
+  session_id  text not null references public.sessions(id)  on delete cascade,
+  person_id   text not null references public.people(id)    on delete cascade,
+  primary key (session_id, person_id)
+);
+create index session_participants_campaign_idx on public.session_participants (campaign_id);
+create index session_participants_person_idx on public.session_participants (person_id);
+
+-- 3. RLS — open read, non-anonymous write (same claim-based gate as 0006).
+--    Anonymous JWTs hold the `authenticated` role, so the is_anonymous claim is
+--    the only reliable gate. Rows are insert/delete only (no update policy).
+alter table public.session_participants enable row level security;
+
+create policy "session_participants are readable by anyone"
+  on public.session_participants for select
+  using (true);
+
+create policy "non-anonymous users can add session participants"
+  on public.session_participants for insert
+  with check ((auth.jwt() ->> 'is_anonymous')::boolean is not true);
+
+create policy "non-anonymous users can remove session participants"
+  on public.session_participants for delete
+  using ((auth.jwt() ->> 'is_anonymous')::boolean is not true);
+
+-- 4. Derive people.last_seen_session_id = the highest-num session the person
+--    participates in (NULL if none). The trigger fires AFTER insert/delete on
+--    the junction and updates the people row, which in turn emits its OWN
+--    realtime people UPDATE — that is how clients receive the recomputed
+--    lastSeen without any extra client work. One "mark seen" therefore produces
+--    two realtime events (a session_participants change + a people update);
+--    that is intentional and cheap.
+create or replace function public.recompute_last_seen(p_person_id text)
+returns void language sql as $$
+  update public.people p set last_seen_session_id = (
+    select sp.session_id
+    from public.session_participants sp
+    join public.sessions s on s.id = sp.session_id
+    where sp.person_id = p_person_id
+    order by s.num desc
+    limit 1
+  )
+  where p.id = p_person_id;
+$$;
+
+create or replace function public.session_participants_sync()
+returns trigger language plpgsql as $$
+begin
+  if (tg_op = 'DELETE') then
+    perform public.recompute_last_seen(old.person_id);
+    return old;
+  else
+    perform public.recompute_last_seen(new.person_id);
+    return new;
+  end if;
+end;
+$$;
+
+create trigger trg_session_participants_sync
+  after insert or delete on public.session_participants
+  for each row execute function public.session_participants_sync();
+
+-- 5. Realtime: the shared pin only syncs if the campaigns table is published,
+--    and the roster only updates if the junction is. ALTER PUBLICATION ... ADD
+--    TABLE errors if the table is already a member, so guard for re-runs.
+do $$
+begin
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime' and schemaname = 'public' and tablename = 'campaigns'
+  ) then
+    alter publication supabase_realtime add table public.campaigns;
+  end if;
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime' and schemaname = 'public' and tablename = 'session_participants'
+  ) then
+    alter publication supabase_realtime add table public.session_participants;
+  end if;
+end;
+$$;


### PR DESCRIPTION
Implements #33 — a shared, campaign-wide "we're live in session N" pin plus one-tap "seen this session" tracking, designed for **live-at-the-table** use.

## Schema — [`0013_active_session.sql`](supabase/migrations/0013_active_session.sql)
- **`campaigns.active_session_id`** — the shared pin. One active session per campaign, synced to every client via realtime; `on delete set null`.
- **`session_participants`** junction `(campaign_id, session_id, person_id)` — the appearance history, mirroring `event_participants`. FKs cascade on session/person delete, so `deleteEntity` needs no app-side sweep for it.
- **`people.last_seen_session_id` is now DERIVED** — a trigger recomputes it to the highest-`num` session a person participates in (and steps it *down* on un-mark). The column stays authoritative, so the existing detail ribbon, cleanup panel, and board filter read it unchanged.
- RLS mirrors [0006](supabase/migrations/0006_reject_anonymous_writes.sql) (open read, non-anonymous write). `campaigns` + `session_participants` added to the `supabase_realtime` publication (guarded for re-runs).

> **Migration already applied** to the project via the dashboard.

## Client
- **`src/activeSession.ts`** — module store mirroring `activeCampaign.ts`; read by mutations, written only by `CampaignProvider`, cleared on campaign switch so a stale pin can't leak.
- **Read path** — `campaigns` realtime subscription (filtered by `id`) drives the shared pin; `session_participants` refetch-on-change handler (composite PK, same pattern as `event_participants`); new mappers on the `Campaign` object (`sessionParticipants`, `activeSessionId`).
- **Mutations** — `setActiveSession`, `markSeen`/`unmarkSeen`, and creation-only `session_id` defaulting for events + quests (**never on edit** — fixing a typo on an old entity won't relink it to today).
- **UI** — `SessionPin` in the Topbar (editor dropdown to go live / switch / stand down; viewer static label), a "Seen this session" toggle on the person sheet, a marker dot on board cards, a "This Session" roster in the sidebar, and the board filter defaulting to the live session.
- Creating a **person** while live auto-marks them seen (their creation-only link, since people have no `session_id`).

## Verification
- `npm run build` (tsc -b + vite build) — clean.
- Loaded against the migrated DB: `session_participants` and `campaigns` (incl. new column) reads return 200, no console errors, no render regression.
- ⚠️ **Editor-interactive flows not yet exercised headlessly** — going live, the seen toggle, roster population, board default, and cross-client realtime sync require a signed-in editor (the app auto-signs-in anonymous/read-only, and RLS blocks anonymous writes). Worth a manual pass.

Closes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)