### PR TITLE
Order entity lists by recency: last-seen for people, status for quests/goals

### DIFF
--- a/src/board.tsx
+++ b/src/board.tsx
@@ -487,6 +487,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
 
 export function KindList({ kind, onOpenEntity }: { kind: string; onOpenEntity: (id: string) => void }) {
   const kinds = useKinds();
+  const campaign = useCampaign();
   const [showArchived, setShowArchived] = useState(false);
   const k = kinds.find((x) => x.key === kind);
   if (!k) return null;
@@ -495,10 +496,12 @@ export function KindList({ kind, onOpenEntity }: { kind: string; onOpenEntity: (
   const all = k.list() as any[];
   const { archivedCount, sorted } = useMemo(() => {
     if (!archivable) return { archivedCount: 0, sorted: all };
+    const numById = new Map(campaign.sessions.map((s) => [s.id, s.num]));
+    const sessionNum = (id: string) => numById.get(id) ?? 0;
     const archived = all.filter((e) => e.archived).length;
     const visible = showArchived ? all : all.filter((e) => !e.archived);
-    return { archivedCount: archived, sorted: sortForDisplay(visible) };
-  }, [all, archivable, showArchived]);
+    return { archivedCount: archived, sorted: sortForDisplay(visible, { kind: k.key as KindKey, sessionNum }) };
+  }, [all, archivable, showArchived, k.key, campaign.sessions]);
 
   return (
     <div style={{ flex: 1, overflow: "auto", padding: "28px 40px 60px", background: "var(--vellum)", position: "relative" }} className="tex-vellum">

--- a/src/data.ts
+++ b/src/data.ts
@@ -236,10 +236,30 @@ export function isPinned(e: any): boolean {
   return !!(e && e.pinned);
 }
 
-// Sort: pinned first, then active by most recently updated, then archived at the bottom.
+// Quest/goal status ordering: active work floats up, abandoned sinks. Unknown
+// status sits between the open states and the finished ones.
+const STATUS_RANK: Record<string, number> = { pursuing: 0, whispered: 1, resolved: 3, lost: 4 };
+const STATUS_RANK_UNKNOWN = 2;
+
+// Sort: pinned first, then active, then a kind-aware recency key, then archived at
+// the bottom. The recency key varies by kind (opts.kind):
+//   - people: most recently *seen* in a session first (lastSeen is a session id,
+//     so the caller passes sessionNum to resolve it to the sequential number).
+//   - quests/goals: by status (pursuing → whispered → resolved → lost).
+//   - everything else: falls straight through to updatedAt (most recently edited).
+// updatedAt is always the final tiebreaker.
 export function sortForDisplay<T extends { id: string; updatedAt?: string; archived?: boolean; pinned?: boolean }>(
   items: T[],
+  opts?: { kind?: KindKey; sessionNum?: (sessionId: string) => number },
 ): T[] {
+  const kind = opts?.kind;
+  const statusRank = (e: any): number => {
+    if (kind !== "quests" && kind !== "goals") return 0;
+    const s = e.status as string | undefined;
+    return s && s in STATUS_RANK ? STATUS_RANK[s] : STATUS_RANK_UNKNOWN;
+  };
+  const seenNum = (e: any): number =>
+    kind === "people" && e.lastSeen && opts?.sessionNum ? opts.sessionNum(e.lastSeen) : 0;
   return items.slice().sort((a, b) => {
     const pa = a.pinned ? 1 : 0;
     const pb = b.pinned ? 1 : 0;
@@ -247,6 +267,12 @@ export function sortForDisplay<T extends { id: string; updatedAt?: string; archi
     const aa = a.archived ? 1 : 0;
     const ab = b.archived ? 1 : 0;
     if (aa !== ab) return aa - ab;
+    const ra = statusRank(a);
+    const rb = statusRank(b);
+    if (ra !== rb) return ra - rb; // lower rank = more active = higher up
+    const sa = seenNum(a);
+    const sb = seenNum(b);
+    if (sa !== sb) return sb - sa; // higher session number = seen more recently
     const ta = a.updatedAt ? Date.parse(a.updatedAt) : 0;
     const tb = b.updatedAt ? Date.parse(b.updatedAt) : 0;
     return tb - ta;


### PR DESCRIPTION
## What

Makes `sortForDisplay()` kind-aware so entity lists surface what's currently relevant, instead of ordering everything by last-edited time.

The sort tiers are now **pinned → active → kind-aware recency key → `updatedAt` tiebreak**, where the recency key varies by kind:

| Kind | Primary key |
|------|-------------|
| `people` | last-seen session number (desc) — recently in the story floats up |
| `quests`, `goals` | status rank: `pursuing` → `whispered` → `resolved` → `lost` |
| everything else | none — falls through to `updatedAt` (unchanged behavior) |

Pinned still floats to the top and archived still sinks in every kind. `Person.lastSeen` stores a session *id*, so `KindList` resolves it to the sequential session number via a `campaign.sessions` id→num map passed in as `sessionNum`.

## Why

Ordering by `updatedAt` conflates "edited recently" with "relevant now." For a campaign journal, "who was seen last session" and "which quests are active" are the signals players actually scan for. This is ordering only — nothing is filtered or hidden, and no schema changes.

## Verification

- `npm run build` typechecks and builds clean.
- Exercised the compiled `sortForDisplay` directly against people/quests/locations fixtures; confirmed pinned-on-top, archived-at-bottom, last-seen-desc for people, status rank for quests, and unchanged `updatedAt` ordering for locations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)