### PR TITLE
Fix board card drag: round coords to int + read-only affordance

### DIFF
--- a/src/board.tsx
+++ b/src/board.tsx
@@ -437,6 +437,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
                 scale={scale}
                 onOpen={onOpenEntity}
                 onDragEnd={onDragEnd}
+                canEdit={canEdit}
                 connectMode={connectMode}
                 onConnectClick={handleConnectClick}
                 isConnectSource={connectSource === id}

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -61,6 +61,7 @@ interface PinnedCardProps {
   pos: Position;
   onOpen: (id: string) => void;
   onDragEnd: (id: string, p: { x: number; y: number }) => void;
+  canEdit: boolean;
   scale: number;
   connectMode: boolean;
   onConnectClick: (id: string) => void;
@@ -74,6 +75,7 @@ export function PinnedCard({
   pos,
   onOpen,
   onDragEnd,
+  canEdit,
   scale,
   connectMode,
   onConnectClick,
@@ -95,20 +97,23 @@ export function PinnedCard({
     e.stopPropagation();
     const startX = e.clientX, startY = e.clientY;
     const origX = pos.x, origY = pos.y;
-    setDragging(true);
+    if (canEdit) setDragging(true);
     let moved = false;
     const onMove = (ev: MouseEvent) => {
       const dx = (ev.clientX - startX) / scale;
       const dy = (ev.clientY - startY) / scale;
       if (Math.abs(dx) > 3 || Math.abs(dy) > 3) moved = true;
-      setDrag({ x: origX + dx, y: origY + dy });
+      // Viewers can't move cards — don't visually drag them only to snap back.
+      if (canEdit) setDrag({ x: origX + dx, y: origY + dy });
     };
     const onUp = (ev: MouseEvent) => {
       setDragging(false);
       const dx = (ev.clientX - startX) / scale;
       const dy = (ev.clientY - startY) / scale;
       if (moved) {
-        onDragEnd(entity.id, { x: origX + dx, y: origY + dy });
+        // A drag persists only for editors; for viewers it's a no-op (not a
+        // mis-click open), matching the read-only affordance.
+        if (canEdit) onDragEnd(entity.id, { x: origX + dx, y: origY + dy });
       } else {
         onOpen(entity.id);
       }
@@ -138,6 +143,9 @@ export function PinnedCard({
         transform: `rotate(${pos.rot || 0}deg)`,
         outline: isConnectSource ? "2px dashed var(--bloodred)" : "none",
         outlineOffset: 6,
+        // Read-only viewers get a plain pointer (click opens the detail sheet);
+        // only editors see the grab/grabbing move affordance.
+        cursor: dragging ? "grabbing" : connectMode ? "crosshair" : canEdit ? "grab" : "pointer",
       }}
       onMouseDown={onMouseDown}
       onMouseEnter={() => onHover?.(entity.id)}

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -84,9 +84,13 @@ export async function upsertBoardPosition(entityId: string, pos: BoardPosition) 
       {
         campaign_id: getActiveCampaignId(),
         entity_id: entityId,
-        x: pos.x,
-        y: pos.y,
-        rot: pos.rot,
+        // x/y/rot are `int` columns (0001_init.sql). Dragging produces
+        // fractional pixels (dx / scale), and PostgREST rejects a non-integer
+        // into an int4 column (22P02), which would silently fail the write and
+        // snap the card back — so round before persisting.
+        x: Math.round(pos.x),
+        y: Math.round(pos.y),
+        rot: Math.round(pos.rot ?? 0),
         kind: pos.kind,
       },
       { onConflict: "campaign_id,entity_id" },


### PR DESCRIPTION
## Problem

Dragging a card on the notice board didn't stick — it moved while held, then **snapped back** on release.

Two independent causes, both producing that symptom:

1. **Editors:** the drag persisted fractional coordinates (`x = origX + dx`, `dx = (clientX - startX) / scale`) into `board_positions.x`/`.y`, which are declared `int not null` ([0001_init.sql](supabase/migrations/0001_init.sql)). PostgREST rejects a non-integer into an `int4` column (`22P02 invalid input syntax for type integer`), so the write 400'd, the fire-and-forget `.catch(console.error)` swallowed it, and — with no optimistic UI — the card re-rendered from unchanged state and jumped back.
2. **Viewers:** `onDragEnd` early-returns for read-only sessions, yet cards still showed a `grab` cursor and visually dragged before snapping back — a misleading affordance.

## Changes

- **`upsertBoardPosition`** now rounds `x`/`y`/`rot` to integers at the single write choke point.
- **`PinnedCard`** takes a `canEdit` prop:
  - viewers get a `pointer` cursor (not `grab`),
  - the card no longer visually drags-then-snaps-back for viewers,
  - a moved drag is a no-op for viewers rather than a mis-click open.
  - Click-to-open still works for everyone; editor drag/grabbing cursor unchanged.

## Verification

- `tsc --noEmit` clean.
- Reproduced + verified the viewer path live (anonymous session): cards now compute `cursor: pointer`, and clicking a card still opens its detail sheet.
- ⚠️ The editor drag-persist path was **not** verified end-to-end (no editor session available in the test browser; declined to write a diagnostic row to production `board_positions`). The int-rounding fix addresses the known `22P02` cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)