### PR TITLE
Board readability pass: contrast, type scale, and legible session focus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ The app supports an "edit mode" handshake with a parent window via `window.__TWE
 - **Route everything campaign-scoped through the active campaign id** — components read it via `useCampaign()`/`useCampaignSwitcher()`, mutations via `getActiveCampaignId()` from [src/activeCampaign.ts](src/activeCampaign.ts); never query without the `campaign_id` filter. RLS doesn't enforce per-campaign access today — any signed-in editor can write to any campaign (per-campaign membership is future work).
 - **New entity IDs are `crypto.randomUUID()` strings** generated client-side. All PKs are `text` except `connections.id` (bigserial) and `party_notes.id` (bigserial).
 - **Styling is inline style objects + a few CSS classes** in [src/styles.css](src/styles.css). CSS variables (`--ink`, `--vellum`, `--bloodred`, `--font-fell-sc`, etc.) carry the parchment aesthetic — reach for those before inventing colors.
+- **Ink tiers are picked by role** (see the `:root` comment in styles.css): `--ink-secondary` is the contrast floor for any text ≤14px — IM Fell's thin strokes need it, especially on the grimoire theme. `--ink-faded`/`--ink-ghost` are reserved for off-states, hints, and decoration, never for small content text. Colors that read as text on card stock (tags, chips) must be theme-aware variables — hardcoded light-paper colors vanish on grimoire.
 - **Committed `.js` / `.d.ts` siblings of the `.tsx` files are gitignored** (`src/**/*.js`, `src/**/*.d.ts` except `global.d.ts`). They're `tsc` outputs — ignore them.
 
 ## Ritual

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ function LoadingSheet() {
       fontStyle: "italic",
     }}>
       <div style={{ textAlign: "center" }}>
-        <div style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".3em", fontSize: 12, color: "var(--ink-faded)", marginBottom: 12 }}>
+        <div style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".3em", fontSize: 12, color: "var(--ink-secondary)", marginBottom: 12 }}>
           ✦ THE CODEX ✦
         </div>
         <div>Unbinding the codex…</div>
@@ -44,7 +44,7 @@ function ErrorSheet({ message }: { message: string }) {
         <div style={{ fontStyle: "italic", fontSize: 16, marginBottom: 16 }}>
           The codex could not be opened.
         </div>
-        <pre style={{ fontFamily: "var(--font-ui)", fontSize: 12, color: "var(--ink-faded)", whiteSpace: "pre-wrap" }}>
+        <pre style={{ fontFamily: "var(--font-ui)", fontSize: 12, color: "var(--ink-secondary)", whiteSpace: "pre-wrap" }}>
           {message}
         </pre>
       </div>
@@ -209,7 +209,7 @@ function AppLoaded() {
                 <button className={density === "compact" ? "active" : ""} onClick={() => { setDensity("compact"); persist({ density: "compact" }); }}>Compact</button>
               </div>
             </div>
-            <div style={{ fontFamily: "var(--font-fell)", fontStyle: "italic", fontSize: 12, color: "var(--ink-faded)", textAlign: "center", marginTop: 4 }}>
+            <div style={{ fontFamily: "var(--font-fell)", fontStyle: "italic", fontSize: 12, color: "var(--ink-secondary)", textAlign: "center", marginTop: 4 }}>
               "What a party writes down, the world remembers."
             </div>
           </div>

--- a/src/arcs.tsx
+++ b/src/arcs.tsx
@@ -72,7 +72,7 @@ export function ArcsPage({ onOpenEntity }: { onOpenEntity: (id: string) => void 
                 >
                   {arc.title}
                 </h2>
-                <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".12em", fontSize: 11, color: "var(--ink-faded)" }}>
+                <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".12em", fontSize: 11, color: "var(--ink-secondary)" }}>
                   {assigned.length} {assigned.length === 1 ? "session" : "sessions"}
                   {quests.length > 0 && ` · ${quests.length} ${quests.length === 1 ? "quest" : "quests"}`}
                   {range && ` · ${range}`}
@@ -108,7 +108,7 @@ export function ArcsPage({ onOpenEntity }: { onOpenEntity: (id: string) => void 
 
         {unassigned.length > 0 && arcs.length > 0 && (
           <section style={{ marginTop: 34 }}>
-            <div style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".18em", fontSize: 12, color: "var(--ink-faded)" }}>
+            <div style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".18em", fontSize: 12, color: "var(--ink-secondary)" }}>
               ✦ UNCLAIMED SESSIONS ✦
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 2, marginTop: 8 }}>

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -135,7 +135,7 @@ function AuthError({ message }: { message: string }) {
         <div style={{ fontStyle: "italic", fontSize: 16, marginBottom: 16 }}>
           The codex could not admit you.
         </div>
-        <pre style={{ fontFamily: "var(--font-ui)", fontSize: 12, color: "var(--ink-faded)", whiteSpace: "pre-wrap" }}>
+        <pre style={{ fontFamily: "var(--font-ui)", fontSize: 12, color: "var(--ink-secondary)", whiteSpace: "pre-wrap" }}>
           {message}
         </pre>
       </div>
@@ -181,7 +181,7 @@ export function DisplayNameGate({ children }: { children: ReactNode }) {
         boxShadow: "0 10px 40px rgba(40,20,5,.25)",
         fontFamily: "var(--font-fell)",
       }}>
-        <div style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".3em", fontSize: 11, color: "var(--ink-faded)", marginBottom: 10 }}>
+        <div style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".3em", fontSize: 11, color: "var(--ink-secondary)", marginBottom: 10 }}>
           ✦ THE CODEX ASKS YOUR NAME ✦
         </div>
         <div style={{ fontStyle: "italic", fontSize: 15, marginBottom: 22, color: "var(--ink)" }}>
@@ -263,7 +263,7 @@ export function SignInDialog({ onClose }: { onClose: () => void }) {
           fontFamily: "var(--font-fell)",
         }}
       >
-        <div style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".3em", fontSize: 11, color: "var(--ink-faded)", marginBottom: 10 }}>
+        <div style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".3em", fontSize: 11, color: "var(--ink-secondary)", marginBottom: 10 }}>
           ✦ PROVE YOUR MEMBERSHIP ✦
         </div>
         {sent ? (

--- a/src/board.tsx
+++ b/src/board.tsx
@@ -98,7 +98,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
   // The entities tied to the focused session: quests logged in it and people
   // last seen there (sessions link to nothing else in the model). null means
   // "no focus" — either "All sessions", or a session with nothing linked to it
-  // (an empty set would otherwise dim the whole board, spotlighting nothing).
+  // (an empty set would otherwise recede the whole board, spotlighting nothing).
   const sessionFocus: Set<string> | null = (() => {
     if (filters.sessions === "all") return null;
     const s = new Set([
@@ -108,13 +108,14 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
     return s.size > 0 ? s : null;
   })();
 
-  // Spotlight: a hovered card and its neighbors stay lit while the rest recede.
-  // With no hover, a focused session takes over the spotlight so its cards pop
-  // and the rest of the board dims (see .pinned.dimmed / .yarn.lit in styles.css).
-  const spotlight = hoverCard
+  // Hover spotlight: a hovered card and its neighbors stay lit while the rest
+  // dim (.pinned.dimmed). Session focus is a separate, milder treatment: cards
+  // outside the focused session collapse to headline-only (.pinned.receded)
+  // but stay fully legible — a live session shouldn't ghost the whole board.
+  const hoverSpot = hoverCard
     ? new Set([hoverCard, ...visibleConnections.flatMap(([a, b]) =>
         a === hoverCard ? [b] : b === hoverCard ? [a] : [])])
-    : sessionFocus;
+    : null;
 
   const toggleKind = (k: KindKey) => setFilters((f) => ({ ...f, [k]: !(f as any)[k] }));
 
@@ -283,7 +284,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
             className="session-focus"
             value={filters.sessions}
             onChange={(e) => setFilters((f) => ({ ...f, sessions: e.target.value }))}
-            title="Spotlight the cards from one session; the rest of the board dims"
+            title="Spotlight the cards from one session; the rest of the board drops to headlines"
           >
             <option value="all">All sessions</option>
             {campaign.sessions
@@ -448,7 +449,8 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
                 connectMode={connectMode}
                 onConnectClick={handleConnectClick}
                 isConnectSource={connectSource === id}
-                dimmed={spotlight !== null && !spotlight.has(id)}
+                dimmed={hoverSpot !== null && !hoverSpot.has(id)}
+                receded={hoverSpot === null && sessionFocus !== null && !sessionFocus.has(id)}
                 onHover={setHoverCard}
               />
             );

--- a/src/cleanupPanel.tsx
+++ b/src/cleanupPanel.tsx
@@ -192,7 +192,7 @@ export function CleanupPanel({ onClose, onOpenEntity }: CleanupPanelProps) {
             value={n}
             onChange={(e) => setN(Number(e.target.value))}
           />
-          <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".16em", fontSize: 11, color: "var(--ink-faded)" }}>
+          <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".16em", fontSize: 11, color: "var(--ink-secondary)" }}>
             LAST {n} SESSIONS
           </span>
           <button className="cleanup-link-btn" onClick={selectAll}>select all</button>

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -196,7 +196,7 @@ export function PosterCard({ person }: { person: any }) {
           : <span className="silhouette" />}
       </div>
       <div className="name">{person.name}</div>
-      <div className="desc">— {person.epithet}</div>
+      {!!person.epithet?.trim() && <div className="desc">— {person.epithet}</div>}
       <div className="reward">
         {person.race
           ? <span><strong>Race</strong> · {person.race}</span>

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -446,7 +446,7 @@ export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts 
             fontFamily: "var(--font-fell)",
             fontStyle: "italic",
             fontSize: 12,
-            color: "var(--ink-faded)",
+            color: "var(--ink-secondary)",
             padding: "2px 6px",
             cursor: "pointer",
           }}
@@ -515,7 +515,7 @@ function CampaignPicker() {
         <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".1em", fontSize: 11 }}>CAMPAIGN</span>
         <span>·</span>
         <span style={{ fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 15 }}>{campaign.title}</span>
-        <span style={{ color: "var(--ink-faded)", fontStyle: "italic", fontSize: 12 }}>· {campaign.subtitle}</span>
+        <span style={{ color: "var(--ink-secondary)", fontStyle: "italic", fontSize: 12 }}>· {campaign.subtitle}</span>
         {canSwitch && (
           <Icon name="chevron" size={11} style={{ transform: open ? "rotate(-90deg)" : "rotate(90deg)", color: "var(--ink-faded)", flexShrink: 0 }} />
         )}
@@ -534,7 +534,7 @@ function CampaignPicker() {
               <span>
                 <span style={{ fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 14, display: "block" }}>{c.title}</span>
                 {c.subtitle && (
-                  <span style={{ color: "var(--ink-faded)", fontStyle: "italic", fontSize: 12 }}>{c.subtitle}</span>
+                  <span style={{ color: "var(--ink-secondary)", fontStyle: "italic", fontSize: 12 }}>{c.subtitle}</span>
                 )}
               </span>
             </button>
@@ -627,7 +627,7 @@ function SessionPin() {
               <span className="dot" style={{ visibility: s.id === campaign.activeSessionId ? "visible" : "hidden" }} />
               <span>
                 <span style={{ fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 14, display: "block" }}>Session {s.num}</span>
-                {s.title && <span style={{ color: "var(--ink-faded)", fontStyle: "italic", fontSize: 12 }}>{s.title}</span>}
+                {s.title && <span style={{ color: "var(--ink-secondary)", fontStyle: "italic", fontSize: 12 }}>{s.title}</span>}
               </span>
             </button>
           ))}
@@ -661,7 +661,7 @@ export function Topbar({ onShare }: { onShare: () => void }) {
           <>
             <span style={{
               fontFamily: "var(--font-fell)", fontStyle: "italic",
-              fontSize: 12, color: "var(--ink-faded)",
+              fontSize: 12, color: "var(--ink-secondary)",
             }}>
               {displayName}
             </span>
@@ -677,8 +677,8 @@ export function Topbar({ onShare }: { onShare: () => void }) {
           <>
             <span style={{
               fontFamily: "var(--font-fell-sc)", letterSpacing: ".14em",
-              fontSize: 10, color: "var(--ink-faded)",
-              border: "1px dashed var(--ink-faded)", padding: "3px 8px",
+              fontSize: 10, color: "var(--ink-secondary)",
+              border: "1px dashed var(--ink-secondary)", padding: "3px 8px",
             }}>
               READ-ONLY
             </span>

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -67,6 +67,8 @@ interface PinnedCardProps {
   onConnectClick: (id: string) => void;
   isConnectSource: boolean;
   dimmed?: boolean;
+  // Session focus: card stays fully legible but collapses to headline-only.
+  receded?: boolean;
   onHover?: (id: string | null) => void;
 }
 
@@ -81,6 +83,7 @@ export function PinnedCard({
   onConnectClick,
   isConnectSource,
   dimmed,
+  receded,
   onHover,
 }: PinnedCardProps) {
   const [dragging, setDragging] = useState(false);
@@ -134,7 +137,7 @@ export function PinnedCard({
   return (
     <div
       ref={ref}
-      className={`pinned ${dragging ? "dragging" : ""} ${archived ? "archived" : ""} ${pinnedFlag ? "is-pinned" : ""} ${dimmed ? "dimmed" : ""}`}
+      className={`pinned ${dragging ? "dragging" : ""} ${archived ? "archived" : ""} ${pinnedFlag ? "is-pinned" : ""} ${dimmed ? "dimmed" : ""} ${receded ? "receded" : ""}`}
       data-kind={pos.kind}
       data-id={entity.id}
       style={{
@@ -215,7 +218,7 @@ export function QuestCard({ quest }: { quest: any }) {
       <div className="quest-desc">{quest.desc}</div>
       <div className="quest-meta">
         <span>Reward</span>
-        <span style={{ fontFamily: "var(--font-fell)", textTransform: "none", fontSize: 11, letterSpacing: 0, color: "var(--ink-body)" }}>{quest.reward}</span>
+        <span style={{ fontFamily: "var(--font-fell)", textTransform: "none", fontSize: 12.5, letterSpacing: 0, color: "var(--ink-body)" }}>{quest.reward}</span>
       </div>
     </div>
   );

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -280,7 +280,7 @@ function EventParticipantsEditor({ eventId, onOpen }: { eventId: string; onOpen:
               }}
               style={{
                 background: "transparent", border: "none", cursor: "pointer",
-                color: "var(--ink-faded)", fontSize: 12, padding: "0 2px",
+                color: "var(--ink-secondary)", fontSize: 12, padding: "0 2px",
               }}
             >✕</button>
           ) : (
@@ -747,7 +747,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
               )}
 
               {(kind === "quests" || kind === "goals") && (
-                <div style={{ marginTop: 16, display: "flex", alignItems: "center", gap: 10, fontFamily: "var(--font-fell-sc)", fontSize: 11, letterSpacing: ".2em", color: "var(--ink-faded)" }}>
+                <div style={{ marginTop: 16, display: "flex", alignItems: "center", gap: 10, fontFamily: "var(--font-fell-sc)", fontSize: 11, letterSpacing: ".2em", color: "var(--ink-secondary)" }}>
                   STATUS
                   <EnumSelect
                     value={(entity as any).status}
@@ -760,7 +760,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
               )}
 
               {kind === "people" && (
-                <div style={{ marginTop: 16, display: "flex", alignItems: "center", gap: 10, fontFamily: "var(--font-fell-sc)", fontSize: 11, letterSpacing: ".2em", color: "var(--ink-faded)" }}>
+                <div style={{ marginTop: 16, display: "flex", alignItems: "center", gap: 10, fontFamily: "var(--font-fell-sc)", fontSize: 11, letterSpacing: ".2em", color: "var(--ink-secondary)" }}>
                   DISPOSITION
                   <EnumSelect
                     value={(entity as any).disposition}
@@ -774,7 +774,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
               <h3 style={{ marginTop: 28 }}>Party Notes</h3>
               <div className="notes-stack">
                 {notes.length === 0 && (
-                  <div style={{ fontFamily: "var(--font-fell)", fontStyle: "italic", color: "var(--ink-faded)", fontSize: 13 }}>
+                  <div style={{ fontFamily: "var(--font-fell)", fontStyle: "italic", color: "var(--ink-secondary)", fontSize: 13 }}>
                     No notes yet. The margin waits.
                   </div>
                 )}
@@ -812,7 +812,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
             </div>
 
             <div className="detail-rail">
-              <div style={{ fontFamily: "var(--font-fell-sc)", fontSize: 11, letterSpacing: ".16em", color: "var(--ink-faded)", marginBottom: 14 }}>
+              <div style={{ fontFamily: "var(--font-fell-sc)", fontSize: 11, letterSpacing: ".16em", color: "var(--ink-secondary)", marginBottom: 14 }}>
                 ✦ RELATIONS ✦
               </div>
 

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -33,6 +33,26 @@ const chipStyle: React.CSSProperties = {
   cursor: "pointer",
 };
 
+// A stat box must earn its slot: for read-only viewers an empty stat is pure
+// noise ("Race —"), so it vanishes; editors keep it as the click-to-fill
+// affordance. Pass `empty` from the underlying field.
+function Stat({ label, empty, span, valueStyle, children }: {
+  label: string;
+  empty?: boolean;
+  span?: 2 | 3;
+  valueStyle?: React.CSSProperties;
+  children: React.ReactNode;
+}) {
+  const { canEdit } = useAuth();
+  if (empty && !canEdit) return null;
+  return (
+    <div className="stat" style={span ? { gridColumn: `span ${span}` } : undefined}>
+      <div className="stat-label">{label}</div>
+      <div className="stat-value" style={valueStyle}>{children}</div>
+    </div>
+  );
+}
+
 function PortraitFallback({ kind }: { kind: KindKey }) {
   if (kind === "people") return <span className="silhouette" />;
   return (
@@ -547,7 +567,9 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                 onSave={(v) => patch({ [primaryField[kind]]: v })}
                 placeholder="Untitled"
               />
-              {kind === "people" && (
+              {/* Viewers don't need a "— an epithet —" placeholder taking the
+                  subtitle slot; editors keep it as the click-to-fill affordance. */}
+              {kind === "people" && (canEdit || (entity as any).epithet?.trim()) && (
                 <EditableText
                   className="sb-epithet"
                   value={(entity as any).epithet ?? ""}
@@ -567,66 +589,67 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
               <div className="sb-stats">
                 {kind === "people" && (
                   <>
-                    <div className="stat"><div className="stat-label">Race</div><div className="stat-value"><EditableText value={(entity as any).race ?? ""} onSave={(v) => patch({ race: v })} placeholder="—" /></div></div>
-                    <div className="stat"><div className="stat-label">Role</div><div className="stat-value" style={{ fontSize: 14 }}><EditableText value={(entity as any).role ?? ""} onSave={(v) => patch({ role: v })} placeholder="—" /></div></div>
-                    <div className="stat"><div className="stat-label">Disposition</div><div className="stat-value" style={{ textTransform: "capitalize" }}>{(entity as any).disposition}</div></div>
-                    <div className="stat"><div className="stat-label">Alignment</div><div className="stat-value" style={{ fontSize: 13 }}><EditableText value={(entity as any).alignment ?? ""} onSave={(v) => patch({ alignment: v })} placeholder="—" /></div></div>
+                    <Stat label="Race" empty={!(entity as any).race?.trim()}><EditableText value={(entity as any).race ?? ""} onSave={(v) => patch({ race: v })} placeholder="—" /></Stat>
+                    <Stat label="Role" empty={!(entity as any).role?.trim()} valueStyle={{ fontSize: 14 }}><EditableText value={(entity as any).role ?? ""} onSave={(v) => patch({ role: v })} placeholder="—" /></Stat>
+                    <Stat label="Disposition" empty={!(entity as any).disposition} valueStyle={{ textTransform: "capitalize" }}><EnumSelect value={(entity as any).disposition} options={DISPOSITION_OPTIONS} allowClear onSave={(v) => patch({ disposition: v })} /></Stat>
+                    <Stat label="Alignment" empty={!(entity as any).alignment?.trim()} valueStyle={{ fontSize: 13 }}><EditableText value={(entity as any).alignment ?? ""} onSave={(v) => patch({ alignment: v })} placeholder="—" /></Stat>
                   </>
                 )}
                 {kind === "locations" && (
                   <>
-                    <div className="stat"><div className="stat-label">Kind</div><div className="stat-value"><EditableText value={(entity as any).kind ?? ""} onSave={(v) => (v.trim() ? patch({ kind: v }) : false)} placeholder="—" /></div></div>
-                    <div className="stat"><div className="stat-label">Region</div><div className="stat-value" style={{ fontSize: 13 }}><EditableText value={(entity as any).region ?? ""} onSave={(v) => patch({ region: v })} placeholder="—" /></div></div>
-                    <div className="stat" style={{ gridColumn: "span 2" }}><div className="stat-label">Ruler</div><div className="stat-value" style={{ fontSize: 14 }}><EditableText value={(entity as any).ruler ?? ""} onSave={(v) => patch({ ruler: v })} placeholder="Unclaimed" /></div></div>
+                    <Stat label="Kind" empty={!(entity as any).kind?.trim()}><EditableText value={(entity as any).kind ?? ""} onSave={(v) => (v.trim() ? patch({ kind: v }) : false)} placeholder="—" /></Stat>
+                    <Stat label="Region" empty={!(entity as any).region?.trim()} valueStyle={{ fontSize: 13 }}><EditableText value={(entity as any).region ?? ""} onSave={(v) => patch({ region: v })} placeholder="—" /></Stat>
+                    <Stat label="Ruler" empty={!(entity as any).ruler?.trim()} span={2} valueStyle={{ fontSize: 14 }}><EditableText value={(entity as any).ruler ?? ""} onSave={(v) => patch({ ruler: v })} placeholder="Unclaimed" /></Stat>
                   </>
                 )}
                 {kind === "quests" && (
                   <>
-                    <div className="stat"><div className="stat-label">Status</div><div className="stat-value"><StatusChip status={(entity as any).status} /></div></div>
-                    <div className="stat" style={{ gridColumn: "span 2" }}><div className="stat-label">Reward</div><div className="stat-value" style={{ fontSize: 13 }}><EditableText value={(entity as any).reward ?? ""} onSave={(v) => patch({ reward: v })} placeholder="—" /></div></div>
-                    <div className="stat"><div className="stat-label">Session</div><div className="stat-value">{(entity as any).session?.toUpperCase()}</div></div>
-                    <div className="stat" style={{ gridColumn: "span 2" }}><div className="stat-label">Arc</div><div className="stat-value" style={{ fontSize: 13 }}><EntitySelect value={(entity as any).arc} options={arcOptions} allowClear onSave={(id) => patch({ arc: id ?? "" })} /></div></div>
+                    <Stat label="Status" empty={!(entity as any).status}>{canEdit ? <EnumSelect value={(entity as any).status} options={STATUS_OPTIONS} allowClear onSave={(v) => patch({ status: v })} /> : <StatusChip status={(entity as any).status} />}</Stat>
+                    <Stat label="Reward" empty={!(entity as any).reward?.trim()} span={2} valueStyle={{ fontSize: 13 }}><EditableText value={(entity as any).reward ?? ""} onSave={(v) => patch({ reward: v })} placeholder="—" /></Stat>
+                    <Stat label="Session" empty={!(entity as any).session}>{(() => {
+                      const s = campaign.sessions.find((x) => x.id === (entity as any).session);
+                      return s ? `Sess ${s.num}` : (entity as any).session?.toUpperCase();
+                    })()}</Stat>
+                    <Stat label="Arc" empty={!(entity as any).arc} span={2} valueStyle={{ fontSize: 13 }}><EntitySelect value={(entity as any).arc} options={arcOptions} allowClear onSave={(id) => patch({ arc: id ?? "" })} /></Stat>
                   </>
                 )}
                 {kind === "goals" && (
                   <>
-                    <div className="stat"><div className="stat-label">Kind</div><div className="stat-value"><EditableText value={(entity as any).kind ?? ""} onSave={(v) => patch({ kind: v })} placeholder="—" /></div></div>
-                    <div className="stat"><div className="stat-label">Status</div><div className="stat-value"><StatusChip status={(entity as any).status} /></div></div>
-                    <div className="stat" style={{ gridColumn: "span 2" }}><div className="stat-label">Borne By</div><div className="stat-value" style={{ fontSize: 13 }}>{(entity as any).owner}</div></div>
+                    <Stat label="Kind" empty={!(entity as any).kind?.trim()}><EditableText value={(entity as any).kind ?? ""} onSave={(v) => patch({ kind: v })} placeholder="—" /></Stat>
+                    <Stat label="Status" empty={!(entity as any).status}>{canEdit ? <EnumSelect value={(entity as any).status} options={STATUS_OPTIONS} allowClear onSave={(v) => patch({ status: v })} /> : <StatusChip status={(entity as any).status} />}</Stat>
+                    <Stat label="Borne By" empty={!(entity as any).owner?.trim()} span={2} valueStyle={{ fontSize: 13 }}>{(entity as any).owner}</Stat>
                   </>
                 )}
                 {kind === "factions" && (
                   <>
-                    <div className="stat"><div className="stat-label">Sigil</div><div className="stat-value"><EditableText value={(entity as any).sigil ?? ""} onSave={(v) => patch({ sigil: v })} placeholder="—" /></div></div>
-                    <div className="stat"><div className="stat-label">Stance</div><div className="stat-value"><EditableText value={(entity as any).allegiance ?? ""} onSave={(v) => patch({ allegiance: v })} placeholder="—" /></div></div>
+                    <Stat label="Sigil" empty={!(entity as any).sigil?.trim()}><EditableText value={(entity as any).sigil ?? ""} onSave={(v) => patch({ sigil: v })} placeholder="—" /></Stat>
+                    <Stat label="Stance" empty={!(entity as any).allegiance?.trim()}><EditableText value={(entity as any).allegiance ?? ""} onSave={(v) => patch({ allegiance: v })} placeholder="—" /></Stat>
                   </>
                 )}
                 {kind === "items" && (
-                  <>
-                    <div className="stat"><div className="stat-label">Kind</div><div className="stat-value"><EditableText value={(entity as any).kind ?? ""} onSave={(v) => patch({ kind: v })} placeholder="—" /></div></div>
-                  </>
+                  <Stat label="Kind" empty={!(entity as any).kind?.trim()}><EditableText value={(entity as any).kind ?? ""} onSave={(v) => patch({ kind: v })} placeholder="—" /></Stat>
                 )}
                 {kind === "sessions" && (
                   <>
-                    <div className="stat"><div className="stat-label">No.</div><div className="stat-value"><EditableNumber value={(entity as any).num ?? 0} onSave={(n) => patch({ num: n })} /></div></div>
-                    <div className="stat"><div className="stat-label">Date</div><div className="stat-value" style={{ fontSize: 14 }}><EditableText value={(entity as any).date ?? ""} onSave={(v) => patch({ date: v })} placeholder="—" /></div></div>
-                    <div className="stat" style={{ gridColumn: "span 2" }}><div className="stat-label">Reckoning</div><div className="stat-value" style={{ fontSize: 14 }}><EditableText value={(entity as any).inGameDate ?? ""} onSave={(v) => patch({ inGameDate: v })} placeholder="— by Faerûn's reckoning —" /></div></div>
-                    <div className="stat" style={{ gridColumn: "span 2" }}><div className="stat-label">Arc</div><div className="stat-value" style={{ fontSize: 13 }}><EntitySelect value={(entity as any).arc} options={arcOptions} allowClear onSave={(id) => patch({ arc: id ?? "" })} /></div></div>
+                    <Stat label="No."><EditableNumber value={(entity as any).num ?? 0} onSave={(n) => patch({ num: n })} /></Stat>
+                    <Stat label="Date" empty={!(entity as any).date?.trim()} valueStyle={{ fontSize: 14 }}><EditableText value={(entity as any).date ?? ""} onSave={(v) => patch({ date: v })} placeholder="—" /></Stat>
+                    <Stat label="Reckoning" empty={!(entity as any).inGameDate?.trim()} span={2} valueStyle={{ fontSize: 14 }}><EditableText value={(entity as any).inGameDate ?? ""} onSave={(v) => patch({ inGameDate: v })} placeholder="— by Faerûn's reckoning —" /></Stat>
+                    <Stat label="Arc" empty={!(entity as any).arc} span={2} valueStyle={{ fontSize: 13 }}><EntitySelect value={(entity as any).arc} options={arcOptions} allowClear onSave={(id) => patch({ arc: id ?? "" })} /></Stat>
                   </>
                 )}
                 {kind === "arcs" && (
                   <>
-                    <div className="stat" style={{ gridColumn: "span 2" }}><div className="stat-label">First Session</div><div className="stat-value" style={{ fontSize: 13 }}><EntitySelect value={(entity as any).startSession} options={sessionOptions} allowClear onSave={(id) => patch({ startSession: id ?? "" })} /></div></div>
-                    <div className="stat" style={{ gridColumn: "span 2" }}><div className="stat-label">Last Session</div><div className="stat-value" style={{ fontSize: 13 }}><EntitySelect value={(entity as any).endSession} options={sessionOptions} allowClear onSave={(id) => patch({ endSession: id ?? "" })} /></div></div>
-                    <div className="stat"><div className="stat-label">Order</div><div className="stat-value"><EditableNumber value={(entity as any).orderNum ?? 0} onSave={(n) => patch({ orderNum: n })} /></div></div>
+                    <Stat label="First Session" empty={!(entity as any).startSession} span={2} valueStyle={{ fontSize: 13 }}><EntitySelect value={(entity as any).startSession} options={sessionOptions} allowClear onSave={(id) => patch({ startSession: id ?? "" })} /></Stat>
+                    <Stat label="Last Session" empty={!(entity as any).endSession} span={2} valueStyle={{ fontSize: 13 }}><EntitySelect value={(entity as any).endSession} options={sessionOptions} allowClear onSave={(id) => patch({ endSession: id ?? "" })} /></Stat>
+                    <Stat label="Order"><EditableNumber value={(entity as any).orderNum ?? 0} onSave={(n) => patch({ orderNum: n })} /></Stat>
                   </>
                 )}
                 {kind === "events" && (
                   <>
-                    <div className="stat" style={{ gridColumn: "span 3" }}><div className="stat-label">Reckoning</div><div className="stat-value" style={{ fontSize: 14 }}><EditableText value={(entity as any).inGameDate ?? ""} onSave={(v) => patch({ inGameDate: v })} placeholder="— by Faerûn's reckoning —" /></div></div>
-                    <div className="stat"><div className="stat-label">Order</div><div className="stat-value"><EditableNumber value={(entity as any).orderNum ?? 0} onSave={(n) => patch({ orderNum: n })} /></div></div>
-                    <div className="stat" style={{ gridColumn: "span 2" }}><div className="stat-label">Session</div><div className="stat-value" style={{ fontSize: 13 }}><EntitySelect value={(entity as any).session} options={sessionOptions} allowClear onSave={(id) => patch({ session: id ?? "" })} /></div></div>
-                    <div className="stat" style={{ gridColumn: "span 2" }}><div className="stat-label">Location</div><div className="stat-value" style={{ fontSize: 13 }}><EntitySelect value={(entity as any).location} options={locationOptions} allowClear onSave={(id) => patch({ location: id ?? "" })} /></div></div>
+                    <Stat label="Reckoning" empty={!(entity as any).inGameDate?.trim()} span={3} valueStyle={{ fontSize: 14 }}><EditableText value={(entity as any).inGameDate ?? ""} onSave={(v) => patch({ inGameDate: v })} placeholder="— by Faerûn's reckoning —" /></Stat>
+                    <Stat label="Order"><EditableNumber value={(entity as any).orderNum ?? 0} onSave={(n) => patch({ orderNum: n })} /></Stat>
+                    <Stat label="Session" empty={!(entity as any).session} span={2} valueStyle={{ fontSize: 13 }}><EntitySelect value={(entity as any).session} options={sessionOptions} allowClear onSave={(id) => patch({ session: id ?? "" })} /></Stat>
+                    <Stat label="Location" empty={!(entity as any).location} span={2} valueStyle={{ fontSize: 13 }}><EntitySelect value={(entity as any).location} options={locationOptions} allowClear onSave={(id) => patch({ location: id ?? "" })} /></Stat>
                   </>
                 )}
               </div>
@@ -742,31 +765,6 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                     onSave={(v) => patch({ hooks: v })}
                     placeholder="(no warning given)"
                     style={{ display: "inline" }}
-                  />
-                </div>
-              )}
-
-              {(kind === "quests" || kind === "goals") && (
-                <div style={{ marginTop: 16, display: "flex", alignItems: "center", gap: 10, fontFamily: "var(--font-fell-sc)", fontSize: 11, letterSpacing: ".2em", color: "var(--ink-secondary)" }}>
-                  STATUS
-                  <EnumSelect
-                    value={(entity as any).status}
-                    options={STATUS_OPTIONS}
-                    allowClear
-                    onSave={(v) => patch({ status: v })}
-                  />
-                  <StatusChip status={(entity as any).status} />
-                </div>
-              )}
-
-              {kind === "people" && (
-                <div style={{ marginTop: 16, display: "flex", alignItems: "center", gap: 10, fontFamily: "var(--font-fell-sc)", fontSize: 11, letterSpacing: ".2em", color: "var(--ink-secondary)" }}>
-                  DISPOSITION
-                  <EnumSelect
-                    value={(entity as any).disposition}
-                    options={DISPOSITION_OPTIONS}
-                    allowClear
-                    onSave={(v) => patch({ disposition: v })}
                   />
                 </div>
               )}

--- a/src/events.tsx
+++ b/src/events.tsx
@@ -59,7 +59,7 @@ export function EventsPage({ onOpenEntity }: { onOpenEntity: (id: string) => voi
 
         {groups.map((group, gi) => (
           <section key={gi} style={{ marginTop: 26 }}>
-            <div style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".18em", fontSize: 12, color: "var(--ink-faded)" }}>
+            <div style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".18em", fontSize: 12, color: "var(--ink-secondary)" }}>
               ✦ {group.date.toUpperCase()} ✦
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 12, marginTop: 10, borderLeft: "1px solid var(--ink-ghost)", paddingLeft: 18 }}>
@@ -81,7 +81,7 @@ export function EventsPage({ onOpenEntity }: { onOpenEntity: (id: string) => voi
                       <h3 style={{ margin: 0, fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 19, color: "var(--ink)" }}>
                         {ev.title}
                       </h3>
-                      <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".1em", fontSize: 10.5, color: "var(--ink-faded)" }}>
+                      <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".1em", fontSize: 10.5, color: "var(--ink-secondary)" }}>
                         {session && `S${String(session.num).padStart(2, "0")}`}
                         {location && `${session ? " · " : ""}${location.name}`}
                         {participants > 0 && ` · ${participants} present`}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1179,6 +1179,9 @@ button.session-pin { line-height: 1; }
   backdrop-filter: blur(2px);
   z-index: 50;
   display: flex; justify-content: center;
+  /* Without this the sheet stretches to full viewport height (flex default),
+     leaving a wall of blank vellum under short entries. */
+  align-items: flex-start;
   padding: 40px 20px;
   overflow-y: auto;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -26,6 +26,7 @@
 
   --mustard:       #b08228;        /* gold leaf */
   --mustard-pale:  #d9b870;
+  --mustard-deep:  #6e5018;        /* pursuing-status ink on light paper */
   --forest:        #3d5536;
   --forest-pale:   #7a8f6c;
   --slate:         #465061;
@@ -90,6 +91,7 @@
   --bloodred:      #c63d2f;
   --bloodred-deep: #e05a4a;
   --mustard:       #d4a728;
+  --mustard-deep:  #d9b870;        /* dark stock flips this to a pale ink */
   /* Light rim + deeper drop shadow: card-to-board separation in the dark. */
   --card-edge:     rgba(220,205,160,.32);
   --shadow-card:   0 0 0 1px rgba(232,220,181,.05), 0 1px 0 rgba(255,255,255,.06) inset, 0 10px 22px rgba(0,0,0,.6), 0 2px 3px rgba(0,0,0,.55);
@@ -778,6 +780,19 @@ button.session-pin { line-height: 1; }
   background: radial-gradient(circle at 35% 30%, #9aa5b0 0%, #4a5560 55%, #2a3038 100%);
 }
 
+/* Kind tags ("✦ Quest ✦", "✦ city ✦", …) share one type treatment; each card
+   block below sets only its color. (.card-poster .wanted keeps its own rule —
+   it's larger and doubles as the poster's header band.) */
+.card-quest .quest-tag,
+.card-location .loc-type,
+.card-goal .goal-kind,
+.card-item .i-label,
+.card-lore .l-label {
+  font-family: var(--font-fell-sc);
+  font-size: 11.5px;
+  letter-spacing: .1em;
+}
+
 /* Wanted poster (People) */
 .card-poster {
   width: 220px;
@@ -885,12 +900,7 @@ button.session-pin { line-height: 1; }
   display: flex; align-items: baseline; justify-content: space-between; gap: 8px;
   margin-bottom: 4px;
 }
-.card-quest .quest-tag {
-  font-family: var(--font-fell-sc);
-  font-size: 11.5px;
-  letter-spacing: .1em;
-  color: var(--bloodred-deep);
-}
+.card-quest .quest-tag { color: var(--bloodred-deep); }
 .card-quest .quest-title {
   font-family: var(--font-display);
   font-weight: 600;
@@ -942,12 +952,7 @@ button.session-pin { line-height: 1; }
 .card-location .loc-body {
   padding: 10px 12px 12px;
 }
-.card-location .loc-type {
-  font-family: var(--font-fell-sc);
-  font-size: 11.5px;
-  letter-spacing: .1em;
-  color: var(--teal-deep);
-}
+.card-location .loc-type { color: var(--teal-deep); }
 .card-location .loc-name {
   font-family: var(--font-display);
   font-weight: 600;
@@ -976,12 +981,7 @@ button.session-pin { line-height: 1; }
   border: 1px solid var(--card-edge);
   position: relative;
 }
-.card-goal .goal-kind {
-  font-family: var(--font-fell-sc);
-  font-size: 11.5px;
-  letter-spacing: .1em;
-  color: var(--mustard);
-}
+.card-goal .goal-kind { color: var(--mustard); }
 .card-goal .goal-text {
   font-family: var(--font-hand);
   font-size: 19px;
@@ -1049,12 +1049,7 @@ button.session-pin { line-height: 1; }
   border: 1px solid var(--card-edge);
   position: relative;
 }
-.card-item .i-label {
-  font-family: var(--font-fell-sc);
-  font-size: 11.5px;
-  letter-spacing: .1em;
-  color: var(--mustard);
-}
+.card-item .i-label { color: var(--mustard); }
 .card-item .i-name {
   font-family: var(--font-display);
   font-weight: 600;
@@ -1083,12 +1078,7 @@ button.session-pin { line-height: 1; }
   position: relative;
   transform: rotate(0deg);
 }
-.card-lore .l-label {
-  font-family: var(--font-fell-sc);
-  font-size: 11.5px;
-  letter-spacing: .1em;
-  color: var(--forest);
-}
+.card-lore .l-label { color: var(--forest); }
 .card-lore .l-title {
   font-family: var(--font-fell-sc);
   font-size: 14px;
@@ -1537,10 +1527,8 @@ button.session-pin { line-height: 1; }
 .status-chip .dot { width: 6px; height: 6px; border-radius: 50%; }
 .status-chip.whispered { background: rgba(74,109,104,.12); border-color: var(--teal-deep); color: var(--teal-deep); }
 .status-chip.whispered .dot { background: var(--teal-deep); }
-.status-chip.pursuing { background: rgba(176,130,40,.15); border-color: var(--mustard); color: #6e5018; }
+.status-chip.pursuing { background: rgba(176,130,40,.15); border-color: var(--mustard); color: var(--mustard-deep); }
 .status-chip.pursuing .dot { background: var(--mustard); }
-/* #6e5018 is tuned for light paper; on grimoire stock it vanishes. */
-[data-theme="grimoire"] .status-chip.pursuing { color: var(--mustard-pale); }
 .status-chip.resolved { background: rgba(61,85,54,.15); border-color: var(--forest); color: var(--forest); }
 .status-chip.resolved .dot { background: var(--forest); }
 .status-chip.lost { background: rgba(138,42,31,.12); border-color: var(--bloodred); color: var(--bloodred-deep); }
@@ -1660,6 +1648,12 @@ button.session-pin { line-height: 1; }
 .ent-glyph.items { background: #8a6a28; }
 .ent-glyph.lore { background: var(--forest-pale); color: var(--ink); }
 .ent-glyph.sessions { background: var(--ink-faded); }
+/* Grimoire lifts --teal-deep/--forest/--slate for use as TEXT on dark stock;
+   as glyph backgrounds under white text those pastels lose all contrast, so
+   the glyphs keep the original dark values. */
+[data-theme="grimoire"] .ent-glyph.locations { background: #2f4c48; }
+[data-theme="grimoire"] .ent-glyph.goals     { background: #3d5536; }
+[data-theme="grimoire"] .ent-glyph.factions  { background: #465061; }
 
 /* Compass rosette decoration */
 .compass {

--- a/src/styles.css
+++ b/src/styles.css
@@ -54,6 +54,10 @@
   --shadow-pin:    0 2px 1px rgba(0,0,0,.35), 0 4px 10px rgba(0,0,0,.25);
   --shadow-card:   0 1px 0 rgba(255,255,255,.25) inset, 0 8px 20px rgba(60,35,10,.35), 0 2px 3px rgba(60,35,10,.4);
   --shadow-deep:   0 14px 30px rgba(30,15,5,.45), 0 3px 6px rgba(30,15,5,.5);
+
+  /* Card chrome — themed so dark mode can carry a lighter rim that separates
+     card stock from the cork behind it. */
+  --card-edge:     rgba(139,94,40,.4);
 }
 
 /* ── Theme variants ───────────────────────── */
@@ -64,20 +68,31 @@
   --vellum-deep:   #0d0d16;
   --ink:           #e8dcb5;
   --ink-body:      #d4c79a;
-  --ink-faded:     #9d8f64;
-  --ink-ghost:     #6a5f3f;
-  --paper-cream:   #1f2038;
-  --paper-tan:     #2a2840;
-  --paper-grey:    #1c1d30;
-  --paper-scroll:  #26223a;
-  --paper-note:    #2d2845;
+  /* Lifted from #9d8f64 / #6a5f3f: secondary text on dark card stock was
+     hovering at ~4.6:1 — too low for 12px serif. These clear ~7:1. */
+  --ink-faded:     #b3a578;
+  --ink-ghost:     #7d7050;
+  /* Papers lightened a step so cards separate from the cork behind them. */
+  --paper-cream:   #262847;
+  --paper-tan:     #322f4e;
+  --paper-grey:    #23243c;
+  --paper-scroll:  #2e2a48;
+  --paper-note:    #363052;
   --cork:          #3a2a40;
   --cork-deep:     #241828;
   --board-bg:      #1a1120;
   --teal-oxidized: #6bb5a5;
+  /* These read as text/borders on dark card stock — the light-theme values
+     (#2f4c48 / #3d5536 / #465061) vanish against the dark papers. */
+  --teal-deep:     #7fb5aa;
+  --forest:        #8fae7e;
+  --slate:         #9aa8c0;
   --bloodred:      #c63d2f;
   --bloodred-deep: #e05a4a;
   --mustard:       #d4a728;
+  /* Light rim + deeper drop shadow: card-to-board separation in the dark. */
+  --card-edge:     rgba(220,205,160,.32);
+  --shadow-card:   0 0 0 1px rgba(232,220,181,.05), 0 1px 0 rgba(255,255,255,.06) inset, 0 10px 22px rgba(0,0,0,.6), 0 2px 3px rgba(0,0,0,.55);
 }
 [data-theme="modern"] {
   --vellum:        #f5f1ea;
@@ -707,8 +722,14 @@ button.session-pin { line-height: 1; }
   transform-origin: 50% 10%;
 }
 .pinned:hover { z-index: 4; filter: brightness(1.03); }
-/* Spotlight: while a card is hovered, cards not connected to it recede */
-.pinned.dimmed { opacity: .45; }
+/* Spotlight: while a card is hovered, unrelated cards recede — desaturated and
+   darkened rather than made transparent, so their text stays legible. */
+.pinned.dimmed { opacity: .7; filter: saturate(.35) brightness(.82); }
+
+/* Session focus: cards outside the focused session keep full opacity but drop
+   to headline-only (see the shared block below) with a mild desaturation, so
+   the focused cast pops without turning the rest of the board into ghosts. */
+.pinned.receded:not(.is-pinned) { filter: saturate(.55) brightness(.92); }
 
 /* Hierarchy: featured (pinned) cards anchor the board — they sit above the
    rest, carry a warm glow, and never fade during another card's spotlight.
@@ -722,27 +743,17 @@ button.session-pin { line-height: 1; }
   filter: brightness(1.03) drop-shadow(0 6px 14px rgba(20,12,4,.4)) drop-shadow(0 0 16px rgba(212,167,40,.28));
 }
 .pinned.is-pinned.dimmed { opacity: 1; }
-/* Recede regular cards at rest — but not archived ones, which keep their own
-   fainter .55 treatment (excluded here so this rule can't out-specify it). */
-.pinned:not(.is-pinned):not(.dimmed):not(.archived) { opacity: .9; }
 
-/* Semantic zoom: below ~0.7 scale, regular cards drop to headline + kind-tag so
-   the board reads at a glance; featured cards keep their body as anchors. */
-.board-surface.zoom-far .pinned:not(.is-pinned) .desc,
-.board-surface.zoom-far .pinned:not(.is-pinned) .reward,
-.board-surface.zoom-far .pinned:not(.is-pinned) .quest-desc,
-.board-surface.zoom-far .pinned:not(.is-pinned) .quest-meta,
-.board-surface.zoom-far .pinned:not(.is-pinned) .loc-desc,
-.board-surface.zoom-far .pinned:not(.is-pinned) .goal-owner,
-.board-surface.zoom-far .pinned:not(.is-pinned) .f-sub,
-.board-surface.zoom-far .pinned:not(.is-pinned) .i-desc,
-.board-surface.zoom-far .pinned:not(.is-pinned) .l-text {
+/* Headline-only mode: regular cards drop to title + kind-tag so the board
+   reads at a glance. Triggered by semantic zoom (below ~0.7 scale) and by
+   session focus (.receded); featured cards always keep their body as anchors. */
+:is(.board-surface.zoom-far .pinned, .pinned.receded):not(.is-pinned) :is(.desc, .reward, .quest-desc, .quest-meta, .loc-desc, .goal-owner, .f-sub, .i-desc, .l-text) {
   display: none;
 }
 /* Goals have no separate title — the body IS the headline, so clamp it to one
    line rather than hiding it. (Lore now has its own .l-title, so its body is
    hidden above like every other description.) */
-.board-surface.zoom-far .pinned:not(.is-pinned) .goal-text {
+:is(.board-surface.zoom-far .pinned, .pinned.receded):not(.is-pinned) .goal-text {
   -webkit-line-clamp: 1;
 }
 
@@ -775,7 +786,7 @@ button.session-pin { line-height: 1; }
   padding: 14px 14px 12px;
   box-shadow: var(--shadow-card);
   position: relative;
-  border: 1px solid rgba(139,94,40,.4);
+  border: 1px solid var(--card-edge);
 }
 .card-poster::before {
   /* torn top edge */
@@ -787,7 +798,7 @@ button.session-pin { line-height: 1; }
 .card-poster .wanted {
   font-family: var(--font-fell-sc);
   font-size: 12px;
-  letter-spacing: .16em;
+  letter-spacing: .1em;
   color: var(--bloodred-deep);
   text-align: center;
   padding: 2px 0 6px;
@@ -833,8 +844,9 @@ button.session-pin { line-height: 1; }
 }
 .card-poster .desc {
   font-family: var(--font-fell);
-  font-style: italic;
-  font-size: 12px;
+  font-style: italic; /* epithet — attribution voice, italic on purpose */
+  font-size: 13px;
+  line-height: 1.35;
   text-align: center;
   color: var(--ink-faded);
   margin-top: 2px;
@@ -848,7 +860,7 @@ button.session-pin { line-height: 1; }
   padding-top: 8px;
   border-top: 1px dashed var(--ink-ghost);
   font-family: var(--font-fell);
-  font-size: 12px;
+  font-size: 12.5px;
   color: var(--ink-body);
   display: flex; justify-content: space-between;
 }
@@ -862,7 +874,7 @@ button.session-pin { line-height: 1; }
   padding: 14px 16px 14px;
   position: relative;
   box-shadow: var(--shadow-card);
-  border: 1px solid rgba(139,94,40,.35);
+  border: 1px solid var(--card-edge);
   /* scroll edges */
   clip-path: polygon(
     0% 4%, 3% 0%, 8% 3%, 14% 1%, 20% 4%, 28% 1%, 36% 3%, 46% 0%, 55% 3%, 66% 1%, 76% 3%, 86% 0%, 95% 3%, 100% 5%,
@@ -875,8 +887,8 @@ button.session-pin { line-height: 1; }
 }
 .card-quest .quest-tag {
   font-family: var(--font-fell-sc);
-  font-size: 11px;
-  letter-spacing: .16em;
+  font-size: 11.5px;
+  letter-spacing: .1em;
   color: var(--bloodred-deep);
 }
 .card-quest .quest-title {
@@ -890,9 +902,8 @@ button.session-pin { line-height: 1; }
 .card-quest .quest-desc {
   font-family: var(--font-fell);
   font-size: 14px;
-  font-style: italic;
   color: var(--ink-faded);
-  line-height: 1.35;
+  line-height: 1.45;
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
@@ -901,10 +912,10 @@ button.session-pin { line-height: 1; }
 .card-quest .quest-meta {
   display: flex; gap: 8px; align-items: center; margin-top: 10px;
   font-family: var(--font-ui);
-  font-size: 11px;
+  font-size: 11.5px;
   color: var(--ink-faded);
   text-transform: uppercase;
-  letter-spacing: .1em;
+  letter-spacing: .08em;
 }
 
 /* Location map card */
@@ -914,7 +925,7 @@ button.session-pin { line-height: 1; }
   color: var(--ink);
   padding: 0;
   box-shadow: var(--shadow-card);
-  border: 1px solid rgba(139,94,40,.4);
+  border: 1px solid var(--card-edge);
   position: relative;
 }
 .card-location .map-region {
@@ -933,8 +944,8 @@ button.session-pin { line-height: 1; }
 }
 .card-location .loc-type {
   font-family: var(--font-fell-sc);
-  font-size: 11px;
-  letter-spacing: .16em;
+  font-size: 11.5px;
+  letter-spacing: .1em;
   color: var(--teal-deep);
 }
 .card-location .loc-name {
@@ -946,8 +957,8 @@ button.session-pin { line-height: 1; }
 }
 .card-location .loc-desc {
   font-family: var(--font-fell);
-  font-style: italic;
-  font-size: 13px;
+  font-size: 13.5px;
+  line-height: 1.4;
   color: var(--ink-faded);
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -962,13 +973,13 @@ button.session-pin { line-height: 1; }
   color: var(--ink);
   padding: 12px 14px;
   box-shadow: var(--shadow-card);
-  border: 1px solid rgba(139,94,40,.35);
+  border: 1px solid var(--card-edge);
   position: relative;
 }
 .card-goal .goal-kind {
   font-family: var(--font-fell-sc);
-  font-size: 11px;
-  letter-spacing: .16em;
+  font-size: 11.5px;
+  letter-spacing: .1em;
   color: var(--mustard);
 }
 .card-goal .goal-text {
@@ -984,8 +995,8 @@ button.session-pin { line-height: 1; }
 }
 .card-goal .goal-owner {
   font-family: var(--font-fell);
-  font-style: italic;
-  font-size: 12px;
+  font-style: italic; /* attribution voice, italic on purpose */
+  font-size: 13px;
   color: var(--ink-faded);
   margin-top: 8px;
 }
@@ -996,7 +1007,7 @@ button.session-pin { line-height: 1; }
   background: var(--paper-grey);
   padding: 10px 12px;
   box-shadow: var(--shadow-card);
-  border: 1px solid rgba(139,94,40,.4);
+  border: 1px solid var(--card-edge);
   position: relative;
   display: flex; align-items: center; gap: 10px;
 }
@@ -1020,8 +1031,8 @@ button.session-pin { line-height: 1; }
 }
 .card-faction .f-sub {
   font-family: var(--font-fell);
-  font-style: italic;
-  font-size: 12px;
+  font-size: 13px;
+  line-height: 1.35;
   color: var(--ink-faded);
   margin-top: 3px;
   display: -webkit-box;
@@ -1035,13 +1046,13 @@ button.session-pin { line-height: 1; }
   background: var(--paper-cream);
   padding: 10px 12px;
   box-shadow: var(--shadow-card);
-  border: 1px solid rgba(139,94,40,.4);
+  border: 1px solid var(--card-edge);
   position: relative;
 }
 .card-item .i-label {
   font-family: var(--font-fell-sc);
-  font-size: 11px;
-  letter-spacing: .16em;
+  font-size: 11.5px;
+  letter-spacing: .1em;
   color: var(--mustard);
 }
 .card-item .i-name {
@@ -1053,8 +1064,8 @@ button.session-pin { line-height: 1; }
 }
 .card-item .i-desc {
   font-family: var(--font-fell);
-  font-style: italic;
-  font-size: 12px;
+  font-size: 13px;
+  line-height: 1.4;
   color: var(--ink-faded);
   margin-top: 3px;
   display: -webkit-box;
@@ -1068,14 +1079,14 @@ button.session-pin { line-height: 1; }
   background: var(--paper-cream);
   padding: 10px 12px;
   box-shadow: var(--shadow-card);
-  border: 1px solid rgba(139,94,40,.4);
+  border: 1px solid var(--card-edge);
   position: relative;
   transform: rotate(0deg);
 }
 .card-lore .l-label {
   font-family: var(--font-fell-sc);
-  font-size: 11px;
-  letter-spacing: .16em;
+  font-size: 11.5px;
+  letter-spacing: .1em;
   color: var(--forest);
 }
 .card-lore .l-title {
@@ -1092,9 +1103,8 @@ button.session-pin { line-height: 1; }
 }
 .card-lore .l-text {
   font-family: var(--font-fell);
-  font-style: italic;
   font-size: 13.5px;
-  line-height: 1.3;
+  line-height: 1.4;
   color: var(--ink);
   margin-top: 4px;
   display: -webkit-box;
@@ -1529,6 +1539,8 @@ button.session-pin { line-height: 1; }
 .status-chip.whispered .dot { background: var(--teal-deep); }
 .status-chip.pursuing { background: rgba(176,130,40,.15); border-color: var(--mustard); color: #6e5018; }
 .status-chip.pursuing .dot { background: var(--mustard); }
+/* #6e5018 is tuned for light paper; on grimoire stock it vanishes. */
+[data-theme="grimoire"] .status-chip.pursuing { color: var(--mustard-pale); }
 .status-chip.resolved { background: rgba(61,85,54,.15); border-color: var(--forest); color: var(--forest); }
 .status-chip.resolved .dot { background: var(--forest); }
 .status-chip.lost { background: rgba(138,42,31,.12); border-color: var(--bloodred); color: var(--bloodred-deep); }
@@ -1842,8 +1854,8 @@ button.session-pin { line-height: 1; }
 /* Dim archived cards wherever they render on the Board/KindList */
 .pinned.archived,
 .kind-card.archived {
-  opacity: .55;
-  filter: saturate(.5);
+  opacity: .8;
+  filter: saturate(.45) contrast(.95);
 }
 .pinned.archived::before,
 .kind-card.archived::before {

--- a/src/styles.css
+++ b/src/styles.css
@@ -9,9 +9,17 @@
   --vellum-dark:   #d6c49b;
   --vellum-deep:   #b89c6a;
 
-  /* Ink palette */
+  /* Ink tiers — pick by role, not by taste:
+       --ink            titles and emphasis
+       --ink-body       primary reading text
+       --ink-secondary  small secondary text; the FLOOR for anything ≤14px
+                        (IM Fell's thin strokes need the extra contrast)
+       --ink-faded      de-emphasis only: off-states, hints, decoration —
+                        never on sub-15px content text
+       --ink-ghost      placeholders and whispers */
   --ink:           #2a1f14;        /* deepest ink */
   --ink-body:      #3b2c1c;
+  --ink-secondary: #5a4530;
   --ink-faded:     #6b533a;
   --ink-ghost:     #8a7551;
 
@@ -71,6 +79,7 @@
   --ink-body:      #d4c79a;
   /* Lifted from #9d8f64 / #6a5f3f: secondary text on dark card stock was
      hovering at ~4.6:1 — too low for 12px serif. These clear ~7:1. */
+  --ink-secondary: #c7b98c;
   --ink-faded:     #b3a578;
   --ink-ghost:     #7d7050;
   /* Papers lightened a step so cards separate from the cork behind them. */
@@ -89,7 +98,8 @@
   --forest:        #8fae7e;
   --slate:         #9aa8c0;
   --bloodred:      #c63d2f;
-  --bloodred-deep: #e05a4a;
+  /* #e05a4a sat at ~3.7-3.9:1 as tag text on the dark papers; this clears 5:1. */
+  --bloodred-deep: #ee7d68;
   --mustard:       #d4a728;
   --mustard-deep:  #d9b870;        /* dark stock flips this to a pale ink */
   /* Light rim + deeper drop shadow: card-to-board separation in the dark. */
@@ -103,6 +113,7 @@
   --vellum-deep:   #d6cdb9;
   --ink:           #1a1a1a;
   --ink-body:      #2e2e2e;
+  --ink-secondary: #4a4a4a;
   --ink-faded:     #5e5e5e;
   --ink-ghost:     #9a9a9a;
   --paper-cream:   #ffffff;
@@ -257,7 +268,7 @@ body {
   font-family: var(--font-fell);
   font-style: italic;
   font-size: 12px;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
   margin-top: -2px;
   letter-spacing: .02em;
 }
@@ -413,7 +424,7 @@ button.session-pin { line-height: 1; }
   font-family: var(--font-fell);
   font-style: italic;
   font-size: 12px;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
 }
 
 /* Presence avatars */
@@ -491,7 +502,7 @@ button.session-pin { line-height: 1; }
   font-family: var(--font-fell-sc);
   font-size: 11px;
   letter-spacing: .16em;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
   padding: 8px 16px 4px;
   display: flex; align-items: center; justify-content: space-between;
 }
@@ -527,7 +538,7 @@ button.session-pin { line-height: 1; }
   margin-left: auto;
   font-family: var(--font-ui);
   font-size: 11px;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
   background: var(--vellum-dark);
   padding: 1px 7px;
   border-radius: 10px;
@@ -535,7 +546,7 @@ button.session-pin { line-height: 1; }
 }
 .nav-item .icon {
   width: 16px; height: 16px;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
   flex: 0 0 16px;
 }
 .nav-item.active .icon { color: var(--bloodred); }
@@ -545,14 +556,14 @@ button.session-pin { line-height: 1; }
   display: flex; align-items: center; gap: 8px;
   padding: 6px 16px 6px 20px;
   font-family: var(--font-fell);
-  font-size: 14px;
-  color: var(--ink-faded);
+  font-size: 14.5px;
+  color: var(--ink-body);
   cursor: pointer;
 }
 .session-chip:hover { background: rgba(139,94,40,.06); }
 .session-chip .num {
   font-family: var(--font-fell-sc);
-  font-size: 11px;
+  font-size: 11.5px;
   background: var(--paper-cream);
   border: 1px solid var(--vellum-deep);
   padding: 2px 6px;
@@ -597,7 +608,7 @@ button.session-pin { line-height: 1; }
   font-style: italic;
   font-weight: 400;
   font-size: 14px;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
   margin-left: 8px;
   white-space: nowrap;
 }
@@ -863,7 +874,7 @@ button.session-pin { line-height: 1; }
   font-size: 13px;
   line-height: 1.35;
   text-align: center;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
   margin-top: 2px;
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -912,7 +923,7 @@ button.session-pin { line-height: 1; }
 .card-quest .quest-desc {
   font-family: var(--font-fell);
   font-size: 14px;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
   line-height: 1.45;
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -923,7 +934,7 @@ button.session-pin { line-height: 1; }
   display: flex; gap: 8px; align-items: center; margin-top: 10px;
   font-family: var(--font-ui);
   font-size: 11.5px;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
   text-transform: uppercase;
   letter-spacing: .08em;
 }
@@ -964,7 +975,7 @@ button.session-pin { line-height: 1; }
   font-family: var(--font-fell);
   font-size: 13.5px;
   line-height: 1.4;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
@@ -981,7 +992,7 @@ button.session-pin { line-height: 1; }
   border: 1px solid var(--card-edge);
   position: relative;
 }
-.card-goal .goal-kind { color: var(--mustard); }
+.card-goal .goal-kind { color: var(--mustard-deep); }
 .card-goal .goal-text {
   font-family: var(--font-hand);
   font-size: 19px;
@@ -997,7 +1008,7 @@ button.session-pin { line-height: 1; }
   font-family: var(--font-fell);
   font-style: italic; /* attribution voice, italic on purpose */
   font-size: 13px;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
   margin-top: 8px;
 }
 
@@ -1033,7 +1044,7 @@ button.session-pin { line-height: 1; }
   font-family: var(--font-fell);
   font-size: 13px;
   line-height: 1.35;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
   margin-top: 3px;
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -1049,7 +1060,7 @@ button.session-pin { line-height: 1; }
   border: 1px solid var(--card-edge);
   position: relative;
 }
-.card-item .i-label { color: var(--mustard); }
+.card-item .i-label { color: var(--mustard-deep); }
 .card-item .i-name {
   font-family: var(--font-display);
   font-weight: 600;
@@ -1061,7 +1072,7 @@ button.session-pin { line-height: 1; }
   font-family: var(--font-fell);
   font-size: 13px;
   line-height: 1.4;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
   margin-top: 3px;
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -1309,7 +1320,7 @@ button.session-pin { line-height: 1; }
   font-family: var(--font-fell-sc);
   font-size: 11px;
   letter-spacing: .16em;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
 }
 .stat .stat-value {
   font-family: var(--font-display);
@@ -1323,7 +1334,7 @@ button.session-pin { line-height: 1; }
   font-family: var(--font-fell);
   font-style: italic;
   font-size: 12px;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
 }
 
 /* Body columns */
@@ -1342,7 +1353,7 @@ button.session-pin { line-height: 1; }
   font-family: var(--font-fell-sc);
   font-size: 11px;
   letter-spacing: .2em;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
   margin: 0 0 14px;
   display: flex; align-items: center; gap: 8px;
 }
@@ -1415,7 +1426,7 @@ button.session-pin { line-height: 1; }
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: .08em;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
   margin-top: 10px;
   display: flex; justify-content: space-between;
 }
@@ -1453,7 +1464,7 @@ button.session-pin { line-height: 1; }
   font-family: var(--font-fell-sc);
   font-size: 11px;
   letter-spacing: .16em;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
   margin: 0 0 10px;
 }
 .rail-chip {
@@ -1487,7 +1498,7 @@ button.session-pin { line-height: 1; }
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: .08em;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
 }
 .rail-chip.people  { border-left-color: var(--bloodred); }
 .rail-chip.locations { border-left-color: var(--teal-deep); }
@@ -1561,7 +1572,7 @@ button.session-pin { line-height: 1; }
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: .1em;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
   margin-bottom: 6px;
 }
 .tweak-row .seg {
@@ -1629,7 +1640,7 @@ button.session-pin { line-height: 1; }
   font-size: 11px;
   text-align: center;
   padding: 4px 0;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
   border-bottom: 1px solid var(--vellum-deep);
 }
 
@@ -1790,7 +1801,7 @@ button.session-pin { line-height: 1; }
 }
 .cmdk-snippet {
   font-size: 12px;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1808,13 +1819,13 @@ button.session-pin { line-height: 1; }
   font-family: var(--font-fell-sc);
   letter-spacing: .2em;
   font-size: 10px;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
 }
 /* ── Archive / Pin ──────────────────────── */
 .detail-action-btn {
   background: transparent;
-  border: 1px solid var(--ink-faded);
-  color: var(--ink-faded);
+  border: 1px solid var(--ink-secondary);
+  color: var(--ink-secondary);
   padding: 4px 8px;
   font-family: var(--font-fell-sc);
   letter-spacing: .16em;
@@ -1931,7 +1942,7 @@ button.session-pin { line-height: 1; }
   margin-left: 4px;
   font-family: var(--font-ui);
   font-size: 10px;
-  color: var(--ink-ghost);
+  color: var(--ink-faded);
   font-style: italic;
 }
 
@@ -1989,7 +2000,7 @@ button.session-pin { line-height: 1; }
   font-family: var(--font-fell);
   font-style: italic;
   font-size: 14px;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
 }
 .cleanup-close {
   position: absolute;
@@ -2040,7 +2051,7 @@ button.session-pin { line-height: 1; }
   font-family: var(--font-fell-sc);
   font-size: 12px;
   letter-spacing: .2em;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
 }
 .cleanup-row {
   display: flex; align-items: center; gap: 12px;
@@ -2056,7 +2067,7 @@ button.session-pin { line-height: 1; }
   margin-left: auto;
   font-style: italic;
   font-size: 12px;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
 }
 .cleanup-footer {
   display: flex; justify-content: space-between; align-items: center;
@@ -2069,7 +2080,7 @@ button.session-pin { line-height: 1; }
   font-family: var(--font-fell-sc);
   font-size: 11px;
   letter-spacing: .16em;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
 }
 .cleanup-link-btn {
   background: transparent;


### PR DESCRIPTION
## Summary

The Notice Board leaned on transparency for every kind of hierarchy — resting cards at 90% opacity, spotlight/session-focus dimming at 45%, archived at 55% — and a live session pinned the board into the dimmed state on load, so most of the board rendered as unreadable ghosts. On the grimoire theme, cards also barely separated from the cork (~1.3:1) and secondary text sat at ~4.6:1 in 12px italic serif.

### Changes

- **Session focus is now legible**: out-of-focus cards collapse to headline-only at full opacity (new `.receded` class, reusing the semantic-zoom treatment) instead of fading to 45%. Hover spotlight dims unrelated cards to 70% + desaturation instead.
- **No more resting transparency**: removed the blanket `opacity: .9` on regular cards; archived cards went from 55% to 80% opacity + desaturation (badge still marks them).
- **Grimoire contrast repair**: lifted `--ink-faded`/`--ink-ghost` (~4.6:1 → ~7:1), lightened card papers a step, added a themed `--card-edge` rim + deeper card shadow, and themed `--teal-deep`/`--forest`/`--slate` plus the "Pursuing" status chip — all previously light-paper values rendered near-invisibly on dark stock.
- **Type floor raised**: card descriptions 12–13px italic → 13–14px regular with looser line-height; meta rows up ~1px; small-caps tag letter-spacing .16em → .1em. Italic is reserved for attributions (epithets, goal owners).

### Verification

Verified in the browser against live data on both themes: session-focused board, "All sessions", hover spotlight, and the cartographer theme. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)