### PR TITLE
Remove fixture demo decorations from the Notice Board

### DIFF
--- a/src/board.tsx
+++ b/src/board.tsx
@@ -253,7 +253,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
   return (
     <>
       <div className="board-toolbar">
-        <h1>The Notice Board <em>— last edit: just now, by Kael</em></h1>
+        <h1>The Notice Board</h1>
         <div style={{ flex: 1 }} />
 
         <div className="filter-group">
@@ -381,7 +381,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
           }}>
             <span className="pin-head" style={{ left: "10%" }} />
             <span className="pin-head" style={{ left: "90%" }} />
-            ✦ THE NOTICE BOARD OF THE CROOKED TANKARD ✦
+            ✦ {campaign.title.toUpperCase()} ✦
           </div>
 
           <svg className="yarn-layer" viewBox={`0 0 ${bounds.w} ${bounds.h}`} preserveAspectRatio="none">
@@ -456,22 +456,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
             );
           })}
 
-          <div className="pinned" style={{ left: 1050, top: 500, transform: "rotate(-6deg)", cursor: "default" }}>
-            <span className="pin-head" />
-            <div className="card-note">
-              <div className="n-text">Don't break the black seal. Vareth read it once — he can't remember his own sister now.</div>
-              <div className="n-author">— Nym</div>
-            </div>
-          </div>
-          <div className="pinned" style={{ left: 1750, top: 1100, transform: "rotate(4deg)", cursor: "default" }}>
-            <span className="pin-head iron" />
-            <div className="card-note" style={{ background: "#f0e4b8" }}>
-              <div className="n-text">The bells at Blackmere rang TWICE last tide. Once for Oriane. Once for someone we haven't met yet.</div>
-              <div className="n-author">— Sera</div>
-            </div>
-          </div>
-
-          <div className="wax-seal" style={{ top: 120, left: 60 }}>EC</div>
+          <div className="wax-seal" style={{ top: 120, left: 60 }}>✦</div>
           <div className="wax-seal" style={{ top: 1820, left: 2200, background: "radial-gradient(circle at 35% 30%, #c5a04a 0%, #8a6820 60%, #5a430f 100%)" }}>✦</div>
         </div>
 


### PR DESCRIPTION
﻿## What

The Notice Board rendered leftover mockup content on **every** real campaign — data from the original Ember Accord fixture that reads as false on any other campaign (e.g. Fist of Ilmater). This removes or data-drives each piece.

| Item | Decision | Why |
|------|----------|-----|
| Two hard-coded sticky notes (Nym/Sera lore) | **Deleted** | They were free-floating, tied to no entity. Real `party_notes` require a NOT-NULL `entity_id` and render on the detail sheet — turning these into real notes would need new schema, out of scope. |
| Wax seals ("EC" + "✦") | **Neutralized** | "EC" = Ember Accord initials → campaign-specific. Now both are a neutral `✦`, kept as pure decoration. |
| "last edit: just now, by Kael" subtitle | **Deleted** | Fully fake; no `updated_at`/author columns exist. A tracking migration isn't justified for a heading. |
| Banner "…OF THE CROOKED TANKARD" | **Data-driven** to `campaign.title` | The tavern name was Ember-Accord-specific; now shows the real per-campaign title with zero schema work. |

## Notes

- `.card-note` / `.n-text` / `.n-author` CSS in `styles.css` is now orphaned but harmless; left in place.
- No schema/migration changes.

## Verification

- `npm run build` (tsc + vite) passes.
- Dev server on `#/c/fist-of-ilmater`: banner reads **"✦ FIST OF ILMATER ✦"**, heading is **"The Notice Board"** (no subtitle), **0** `.card-note` elements, both seals `✦`, no "Kael"/"Nym"/"Blackmere"/"Crooked Tankard" in the DOM, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
