### PR TITLE
Search-driven "locate on board" wayfinding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CampaignProvider } from "./campaignContext";
 import { AuthProvider, DisplayNameGate } from "./auth";
 import { useCampaign, useCampaignStatus, useFindEntity, useKinds } from "./hooks";
@@ -71,9 +71,22 @@ function AppLoaded() {
   const [shareToast, setShareToast] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [cleanupOpen, setCleanupOpen] = useState(false);
+  // Ephemeral "jump to this card on the board" intent, raised by the command
+  // palette and consumed by NoticeBoard (which owns pan/zoom). seq (a
+  // monotonic counter that survives the null reset) lets the same card be
+  // re-located; onLocated nulls the intent so returning to the board later
+  // doesn't re-pan. This is a UI intent, not mirrored DB state.
+  const [locate, setLocate] = useState<{ id: string; seq: number } | null>(null);
+  const locateSeq = useRef(0);
 
   const togglePalette = useCallback(() => setPaletteOpen((o) => !o), []);
   useCommandPaletteHotkey(togglePalette);
+
+  const locateOnBoard = useCallback((id: string) => {
+    setView("board");
+    setLocate({ id, seq: ++locateSeq.current });
+    setPaletteOpen(false);
+  }, []);
 
   useEffect(() => {
     document.documentElement.setAttribute("data-theme", theme);
@@ -136,7 +149,13 @@ function AppLoaded() {
         <Topbar onShare={onShare} />
         <Sidebar active={view} onSelect={setView} onOpenEntity={setOpenId} onOpenCleanup={() => setCleanupOpen(true)} counts={counts} />
         <main className="main">
-          {view === "board" && <NoticeBoard onOpenEntity={setOpenId} />}
+          {view === "board" && (
+            <NoticeBoard
+              onOpenEntity={setOpenId}
+              locateRequest={locate}
+              onLocated={() => setLocate(null)}
+            />
+          )}
           {view === "arcs" && <ArcsPage onOpenEntity={setOpenId} />}
           {view === "events" && <EventsPage onOpenEntity={setOpenId} />}
           {!["board", "arcs", "events"].includes(view) && <KindList kind={view} onOpenEntity={setOpenId} />}
@@ -155,6 +174,7 @@ function AppLoaded() {
         open={paletteOpen}
         onClose={() => setPaletteOpen(false)}
         onOpenEntity={(id) => { setOpenId(id); setPaletteOpen(false); }}
+        onLocate={locateOnBoard}
       />
 
       {cleanupOpen && (

--- a/src/board.tsx
+++ b/src/board.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   type KindKey,
   sortForDisplay,
@@ -41,7 +41,15 @@ interface Filters {
   [key: string]: boolean | string | undefined;
 }
 
-export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => void }) {
+export function NoticeBoard({
+  onOpenEntity,
+  locateRequest,
+  onLocated,
+}: {
+  onOpenEntity: (id: string) => void;
+  locateRequest?: { id: string; seq: number } | null;
+  onLocated?: () => void;
+}) {
   const campaign = useCampaign();
   const findEntity = useFindEntity();
   const kinds = useKinds();
@@ -81,7 +89,14 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
   const [connectSource, setConnectSource] = useState<string | null>(null);
   const [hoverConn, setHoverConn] = useState<number | null>(null);
   const [hoverCard, setHoverCard] = useState<string | null>(null);
+  // Locate-on-board: the card being flashed, and whether the surface is mid-
+  // glide (a one-shot transition on the pan/zoom — kept off at rest so panning
+  // and dragging stay snappy). Both are ephemeral UI state, not DB mirrors.
+  const [flashId, setFlashId] = useState<string | null>(null);
+  const [gliding, setGliding] = useState(false);
   const canvasRef = useRef<HTMLDivElement>(null);
+  const lastLocateSeq = useRef(-1);
+  const flashTimers = useRef<number[]>([]);
 
   const visible = (id: string) => {
     const pos = positions[id];
@@ -202,6 +217,48 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
     const s = cardSize[p.kind] || { w: 200, h: 140 };
     return { x: p.x + s.w / 2, y: p.y + s.h / 2 };
   };
+
+  // Search wayfinding: when the palette raises a locate request, reveal the
+  // card (turn its kind filter / archived visibility back on if hidden), pan
+  // and zoom so it sits dead-center, then flash it. Guarded by seq so it fires
+  // once per request; timers live in a ref so nulling the request (via
+  // onLocated) can't cancel the flash mid-decay.
+  useEffect(() => {
+    if (!locateRequest || locateRequest.seq === lastLocateSeq.current) return;
+    lastLocateSeq.current = locateRequest.seq;
+    const { id } = locateRequest;
+
+    const pos = positions[id];
+    if (!pos) {
+      // Not pinned to the board — nothing to center on; open its sheet instead.
+      onOpenEntity(id);
+      onLocated?.();
+      return;
+    }
+
+    if (!(filters as any)[pos.kind]) setFilters((f) => ({ ...f, [pos.kind]: true }));
+    const ent = findEntity(id);
+    if (ent && (ent as any).archived) setShowArchived(true);
+
+    const rect = canvasRef.current?.getBoundingClientRect();
+    const c = centerOf(id);
+    if (rect && c) {
+      const target = Math.min(1.6, Math.max(scale, 1));
+      setGliding(true);
+      setScale(target);
+      setPan({ x: rect.width / 2 - c.x * target, y: rect.height / 2 - c.y * target });
+    }
+
+    flashTimers.current.forEach(clearTimeout);
+    setFlashId(id);
+    flashTimers.current = [
+      window.setTimeout(() => setGliding(false), 650),
+      window.setTimeout(() => setFlashId(null), 2000),
+    ];
+    onLocated?.();
+  }, [locateRequest]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => () => { flashTimers.current.forEach(clearTimeout); }, []);
 
   // Probe outward for an open spot so a new card doesn't stack on others (or
   // land under the title banner). Sweeps a grid below the banner strip and
@@ -360,7 +417,7 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
         onWheel={onWheel}
       >
         <div
-          className={`board-surface ${scale < 0.7 ? "zoom-far" : ""}`}
+          className={`board-surface ${scale < 0.7 ? "zoom-far" : ""} ${gliding ? "gliding" : ""}`}
           style={{ transform: `translate(${pan.x}px, ${pan.y}px) scale(${scale})`, width: bounds.w, height: bounds.h }}
         >
           <div className="board-frame" />
@@ -449,8 +506,12 @@ export function NoticeBoard({ onOpenEntity }: { onOpenEntity: (id: string) => vo
                 connectMode={connectMode}
                 onConnectClick={handleConnectClick}
                 isConnectSource={connectSource === id}
-                dimmed={hoverSpot !== null && !hoverSpot.has(id)}
+                dimmed={
+                  (hoverSpot !== null && !hoverSpot.has(id)) ||
+                  (flashId !== null && id !== flashId)
+                }
                 receded={hoverSpot === null && sessionFocus !== null && !sessionFocus.has(id)}
+                locating={flashId === id}
                 onHover={setHoverCard}
               />
             );

--- a/src/board.tsx
+++ b/src/board.tsx
@@ -89,14 +89,16 @@ export function NoticeBoard({
   const [connectSource, setConnectSource] = useState<string | null>(null);
   const [hoverConn, setHoverConn] = useState<number | null>(null);
   const [hoverCard, setHoverCard] = useState<string | null>(null);
-  // Locate-on-board: the card being flashed, and whether the surface is mid-
-  // glide (a one-shot transition on the pan/zoom — kept off at rest so panning
-  // and dragging stay snappy). Both are ephemeral UI state, not DB mirrors.
-  const [flashId, setFlashId] = useState<string | null>(null);
+  // Locate-on-board: the card being flashed (with the locate seq as a nonce so
+  // re-locating the same card restarts the flash), and whether the surface is
+  // mid-glide (a one-shot transition on the pan/zoom — kept off at rest so
+  // panning and dragging stay snappy). Both are ephemeral UI state, not DB
+  // mirrors.
+  const [flash, setFlash] = useState<{ id: string; n: number } | null>(null);
   const [gliding, setGliding] = useState(false);
+  const flashId = flash?.id ?? null;
   const canvasRef = useRef<HTMLDivElement>(null);
   const lastLocateSeq = useRef(-1);
-  const flashTimers = useRef<number[]>([]);
 
   const visible = (id: string) => {
     const pos = positions[id];
@@ -220,13 +222,14 @@ export function NoticeBoard({
 
   // Search wayfinding: when the palette raises a locate request, reveal the
   // card (turn its kind filter / archived visibility back on if hidden), pan
-  // and zoom so it sits dead-center, then flash it. Guarded by seq so it fires
-  // once per request; timers live in a ref so nulling the request (via
-  // onLocated) can't cancel the flash mid-decay.
+  // and zoom so it sits dead-center, then arm the flash. Guarded by seq so it
+  // fires once per request. The flash's decay lives in its own effect below,
+  // keyed on the flash state — not tied to locateRequest — so nulling the
+  // request (via onLocated) can't cut the flash short.
   useEffect(() => {
     if (!locateRequest || locateRequest.seq === lastLocateSeq.current) return;
     lastLocateSeq.current = locateRequest.seq;
-    const { id } = locateRequest;
+    const { id, seq } = locateRequest;
 
     const pos = positions[id];
     if (!pos) {
@@ -249,16 +252,20 @@ export function NoticeBoard({
       setPan({ x: rect.width / 2 - c.x * target, y: rect.height / 2 - c.y * target });
     }
 
-    flashTimers.current.forEach(clearTimeout);
-    setFlashId(id);
-    flashTimers.current = [
-      window.setTimeout(() => setGliding(false), 650),
-      window.setTimeout(() => setFlashId(null), 2000),
-    ];
+    setFlash({ id, n: seq });
     onLocated?.();
   }, [locateRequest]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  useEffect(() => () => { flashTimers.current.forEach(clearTimeout); }, []);
+  // Decay the flash: end the glide, then clear the flash. Keyed on the flash
+  // state (not locateRequest), so it re-derives its timers from state on every
+  // run — including React StrictMode's mount/cleanup/mount replay, which would
+  // otherwise tear the timers down and leave the flash stuck on.
+  useEffect(() => {
+    if (!flash) return;
+    const t1 = window.setTimeout(() => setGliding(false), 650);
+    const t2 = window.setTimeout(() => setFlash(null), 2000);
+    return () => { clearTimeout(t1); clearTimeout(t2); };
+  }, [flash]);
 
   // Probe outward for an open spot so a new card doesn't stack on others (or
   // land under the title banner). Sweeps a grid below the banner strip and

--- a/src/commandPalette.tsx
+++ b/src/commandPalette.tsx
@@ -244,9 +244,10 @@ interface CommandPaletteProps {
   open: boolean;
   onClose: () => void;
   onOpenEntity: (id: string) => void;
+  onLocate?: (id: string) => void;
 }
 
-export function CommandPalette({ open, onClose, onOpenEntity }: CommandPaletteProps) {
+export function CommandPalette({ open, onClose, onOpenEntity, onLocate }: CommandPaletteProps) {
   const campaign = useCampaign();
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState(0);
@@ -256,6 +257,10 @@ export function CommandPalette({ open, onClose, onOpenEntity }: CommandPalettePr
 
   const index = useMemo(() => buildIndex(campaign), [campaign]);
   const results = useMemo(() => searchHits(index, campaign, query), [index, campaign, query]);
+  // Which hits actually have a pin on the notice board — only those can be
+  // located there. Sessions/arcs/events and never-pinned cards have no
+  // position, so they show no locate affordance.
+  const boardIds = useMemo(() => new Set(Object.keys(campaign.board)), [campaign.board]);
 
   useEffect(() => { setSelected(0); }, [query]);
 
@@ -285,6 +290,14 @@ export function CommandPalette({ open, onClose, onOpenEntity }: CommandPalettePr
     onOpenEntity(hit.id);
   }, [onOpenEntity]);
 
+  const locate = useCallback((hit: PaletteHit | undefined) => {
+    if (!hit) return;
+    // Alt+Enter on a card without a board pin has nowhere to jump — fall back
+    // to opening its detail sheet so the shortcut is never a dead key.
+    if (onLocate && boardIds.has(hit.id)) onLocate(hit.id);
+    else onOpenEntity(hit.id);
+  }, [onLocate, boardIds, onOpenEntity]);
+
   if (!open) return null;
 
   const handleKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
@@ -308,7 +321,8 @@ export function CommandPalette({ open, onClose, onOpenEntity }: CommandPalettePr
     }
     if (e.key === "Enter") {
       e.preventDefault();
-      choose(results[selected]);
+      if (e.altKey) locate(results[selected]);
+      else choose(results[selected]);
     }
   };
 
@@ -336,13 +350,14 @@ export function CommandPalette({ open, onClose, onOpenEntity }: CommandPalettePr
             <div className="cmdk-empty">Nothing in the codex matches "{query}".</div>
           )}
           {results.map((hit, i) => (
-            <button
+            <div
               key={`${hit.id}:${hit.matchSource}`}
               data-idx={i}
+              role="option"
+              aria-selected={i === selected}
               className={`cmdk-row${i === selected ? " active" : ""}`}
               onMouseEnter={() => setSelected(i)}
               onClick={() => choose(hit)}
-              type="button"
             >
               <Icon name={KIND_ICON[hit.kind]} size={16} />
               <div className="cmdk-row-text">
@@ -356,12 +371,23 @@ export function CommandPalette({ open, onClose, onOpenEntity }: CommandPalettePr
               </div>
               <span className="cmdk-kind">{KIND_LABEL[hit.kind]}</span>
               {hit.archived && <span className="cmdk-kind-archived">archived</span>}
-            </button>
+              {onLocate && boardIds.has(hit.id) && (
+                <button
+                  type="button"
+                  className="cmdk-locate"
+                  title="Jump to this card on the notice board (⌥↵)"
+                  onClick={(e) => { e.stopPropagation(); onLocate(hit.id); }}
+                >
+                  <Icon name="search" size={12} /> On board
+                </button>
+              )}
+            </div>
           ))}
         </div>
         <div className="cmdk-hint">
           <span>↑↓ navigate</span>
           <span>↵ open</span>
+          <span>⌥↵ on board</span>
           <span>esc close</span>
         </div>
       </div>

--- a/src/commandPalette.tsx
+++ b/src/commandPalette.tsx
@@ -261,6 +261,12 @@ export function CommandPalette({ open, onClose, onOpenEntity, onLocate }: Comman
   // located there. Sessions/arcs/events and never-pinned cards have no
   // position, so they show no locate affordance.
   const boardIds = useMemo(() => new Set(Object.keys(campaign.board)), [campaign.board]);
+  // Single source of truth for "can this hit be located on the board" — keeps
+  // the ⌥↵ handler and the row's "On board" button in lockstep.
+  const canLocate = useCallback(
+    (hit: PaletteHit | undefined): boolean => !!onLocate && !!hit && boardIds.has(hit.id),
+    [onLocate, boardIds],
+  );
 
   useEffect(() => { setSelected(0); }, [query]);
 
@@ -294,9 +300,9 @@ export function CommandPalette({ open, onClose, onOpenEntity, onLocate }: Comman
     if (!hit) return;
     // Alt+Enter on a card without a board pin has nowhere to jump — fall back
     // to opening its detail sheet so the shortcut is never a dead key.
-    if (onLocate && boardIds.has(hit.id)) onLocate(hit.id);
+    if (canLocate(hit)) onLocate!(hit.id);
     else onOpenEntity(hit.id);
-  }, [onLocate, boardIds, onOpenEntity]);
+  }, [canLocate, onLocate, onOpenEntity]);
 
   if (!open) return null;
 
@@ -340,9 +346,13 @@ export function CommandPalette({ open, onClose, onOpenEntity, onLocate }: Comman
             placeholder="Search the codex…"
             spellCheck={false}
             autoComplete="off"
+            role="combobox"
+            aria-expanded={results.length > 0}
+            aria-controls="cmdk-listbox"
+            aria-activedescendant={results.length > 0 ? `cmdk-opt-${selected}` : undefined}
           />
         </div>
-        <div className="cmdk-list" ref={listRef}>
+        <div className="cmdk-list" ref={listRef} role="listbox" id="cmdk-listbox">
           {query.trim() === "" && (
             <div className="cmdk-empty">Type to search people, places, quests, goals, factions, items, lore, sessions, and party notes.</div>
           )}
@@ -353,6 +363,7 @@ export function CommandPalette({ open, onClose, onOpenEntity, onLocate }: Comman
             <div
               key={`${hit.id}:${hit.matchSource}`}
               data-idx={i}
+              id={`cmdk-opt-${i}`}
               role="option"
               aria-selected={i === selected}
               className={`cmdk-row${i === selected ? " active" : ""}`}
@@ -371,12 +382,12 @@ export function CommandPalette({ open, onClose, onOpenEntity, onLocate }: Comman
               </div>
               <span className="cmdk-kind">{KIND_LABEL[hit.kind]}</span>
               {hit.archived && <span className="cmdk-kind-archived">archived</span>}
-              {onLocate && boardIds.has(hit.id) && (
+              {canLocate(hit) && (
                 <button
                   type="button"
                   className="cmdk-locate"
                   title="Jump to this card on the notice board (⌥↵)"
-                  onClick={(e) => { e.stopPropagation(); onLocate(hit.id); }}
+                  onClick={(e) => { e.stopPropagation(); onLocate!(hit.id); }}
                 >
                   <Icon name="search" size={12} /> On board
                 </button>

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -69,6 +69,8 @@ interface PinnedCardProps {
   dimmed?: boolean;
   // Session focus: card stays fully legible but collapses to headline-only.
   receded?: boolean;
+  // Search wayfinding: brief flash when the palette jumps here.
+  locating?: boolean;
   onHover?: (id: string | null) => void;
 }
 
@@ -84,6 +86,7 @@ export function PinnedCard({
   isConnectSource,
   dimmed,
   receded,
+  locating,
   onHover,
 }: PinnedCardProps) {
   const [dragging, setDragging] = useState(false);
@@ -137,7 +140,7 @@ export function PinnedCard({
   return (
     <div
       ref={ref}
-      className={`pinned ${dragging ? "dragging" : ""} ${archived ? "archived" : ""} ${pinnedFlag ? "is-pinned" : ""} ${dimmed ? "dimmed" : ""} ${receded ? "receded" : ""}`}
+      className={`pinned ${dragging ? "dragging" : ""} ${archived ? "archived" : ""} ${pinnedFlag ? "is-pinned" : ""} ${dimmed ? "dimmed" : ""} ${receded ? "receded" : ""} ${locating ? "locating" : ""}`}
       data-kind={pos.kind}
       data-id={entity.id}
       style={{

--- a/src/styles.css
+++ b/src/styles.css
@@ -787,9 +787,9 @@ button.session-pin { line-height: 1; }
   55%  { filter: drop-shadow(0 0 14px rgba(212,167,40,.55)) drop-shadow(0 0 6px rgba(138,42,31,.4)); }
   100% { filter: drop-shadow(0 0 0 rgba(212,167,40,0)); }
 }
+/* z-index 8 lifts the flaring card above both regular (3) and featured (6)
+   cards so it's never occluded mid-flash; only one card flares at a time. */
 .pinned.locating { animation: locate-flash 1.9s ease-out; z-index: 8; }
-/* Featured cards outrank the flash z-index; keep them on top while flaring. */
-.pinned.is-pinned.locating { z-index: 8; }
 
 .pin-head {
   position: absolute;

--- a/src/styles.css
+++ b/src/styles.css
@@ -681,6 +681,10 @@ button.session-pin { line-height: 1; }
   min-width: 2800px; min-height: 2000px;
   transform-origin: 0 0;
 }
+/* One-shot glide applied only while a locate is animating the pan/zoom home;
+   kept off at rest so live panning and card drags aren't smeared by a
+   transition. */
+.board-surface.gliding { transition: transform .55s cubic-bezier(.22,.61,.36,1); }
 
 /* Plank frame around the board */
 .board-frame {
@@ -772,6 +776,20 @@ button.session-pin { line-height: 1; }
 
 .pinned.dragging { cursor: grabbing; z-index: 10; transition: none; }
 .pinned.dragging .pin-head { filter: brightness(1.1); }
+
+/* Locate-on-board flash: when search jumps to a card, it flares with a warm
+   gold + bloodred glow that decays to nothing over ~1.9s, then hands back to
+   its resting filter. Animates `filter` (not transform) because cards carry an
+   inline rotate — reuses the gold accent of the featured-card glow. */
+@keyframes locate-flash {
+  0%   { filter: drop-shadow(0 0 0 rgba(212,167,40,0)); }
+  12%  { filter: drop-shadow(0 0 24px rgba(212,167,40,.95)) drop-shadow(0 0 10px rgba(138,42,31,.75)); }
+  55%  { filter: drop-shadow(0 0 14px rgba(212,167,40,.55)) drop-shadow(0 0 6px rgba(138,42,31,.4)); }
+  100% { filter: drop-shadow(0 0 0 rgba(212,167,40,0)); }
+}
+.pinned.locating { animation: locate-flash 1.9s ease-out; z-index: 8; }
+/* Featured cards outrank the flash z-index; keep them on top while flaring. */
+.pinned.is-pinned.locating { z-index: 8; }
 
 .pin-head {
   position: absolute;
@@ -1823,6 +1841,39 @@ button.session-pin { line-height: 1; }
   letter-spacing: .2em;
   font-size: 10px;
   color: var(--ink-secondary);
+}
+/* "On board" locate action on a search row. Hidden until the row is active or
+   hovered so it doesn't clutter the list, but always tab-reachable. Small text
+   sits at the --ink-secondary contrast floor per the ink-tier rule. */
+.cmdk-locate {
+  flex-shrink: 0;
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 3px 8px;
+  background: transparent;
+  border: 1px solid var(--ink-ghost);
+  border-radius: 3px;
+  font-family: var(--font-fell-sc);
+  letter-spacing: .12em;
+  font-size: 10px;
+  color: var(--ink-secondary);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity .12s, color .12s, border-color .12s;
+}
+.cmdk-row.active .cmdk-locate,
+.cmdk-locate:focus-visible { opacity: 1; }
+.cmdk-locate:hover {
+  color: var(--bloodred);
+  border-color: var(--bloodred);
+}
+.cmdk-locate > svg { flex-shrink: 0; }
+
+@media (prefers-reduced-motion: reduce) {
+  .board-surface.gliding { transition: none; }
+  .pinned.locating {
+    animation: none;
+    filter: drop-shadow(0 0 10px rgba(212,167,40,.9)) drop-shadow(0 0 5px rgba(138,42,31,.6));
+  }
 }
 /* ── Archive / Pin ──────────────────────── */
 .detail-action-btn {


### PR DESCRIPTION
## What & why

The Notice Board holds 100+ pinned cards, but the only wayfinding was kind filters and the session-focus dropdown — there was no way to *find* a specific card. This adds search-driven wayfinding: from the existing Cmd+K command palette, jump straight to a card on the board.

## How it works

Any search result that has a pin on the board now shows an **"⤢ On board"** action (and `Alt+Enter` on the selected row). Choosing it:
1. Switches to the board view
2. Reveals the card (re-enables its kind filter, and `showArchived`, if it was hidden)
3. Glides + zooms so the card sits dead-center (at a legible `scale ≥ 1`)
4. Flashes it with a gold/bloodred glow while the rest of the board dims into a spotlight

Plain `Enter` still opens the detail sheet — **unchanged**.

## Implementation notes

- **No DB mirroring** — `App` raises an ephemeral `{id, seq}` locate intent to `NoticeBoard` (which owns pan/zoom). `seq` is a monotonic `useRef` counter that survives the null-reset, so the same card can be re-located and repeated locates don't get swallowed. Board reads state via `useCampaign()` per convention.
- **Palette** gates the action on `campaign.board` keys. The result row changed from `<button>` to a `role="option"` div so the locate control can be a real nested `<button>` (valid a11y).
- **Board effect** centers via `viewportW/2 − cardCenter·scale`; flash timers live in a ref so nulling the request via `onLocated` can't cancel the decay mid-flight.
- **Styles** reuse the parchment palette and existing spotlight primitives (`.pinned.dimmed`): `locate-flash` animates `filter` (not `transform`, which the cards use for rotation), a one-shot `.gliding` transition kept off at rest so panning/dragging stay snappy, an `--ink-secondary` locate button (respects the small-text contrast floor), and a `prefers-reduced-motion` fallback.

## Design decisions

- **No board position** (sessions/arcs/events, never-pinned cards) → no action shown; `Alt+Enter` falls back to opening the detail sheet.
- **Kind filter off / archived hidden** → locate re-enables what's needed to reveal the card (you asked to find it).

## Verification

- `npm run build` (tsc + vite) passes.
- Exercised in the dev server against the demo campaign (`#/c/fist-of-ilmater`) at a real 1440×900 viewport: card centers within ~6px of dead-center, the "On board" action appears only on board-pinned hits, repeated locates work, kind-filter-off auto-reveals, `Alt+Enter` works, plain `Enter` still opens detail, flash + spotlight render as intended, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)