### PR TITLE
Tidy board: weighted Louvain clustering; fix tsc .js footgun

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "@supabase/supabase-js": "^2.45.4",
         "d3-force": "^3.0.0",
         "d3-hierarchy": "^3.1.2",
+        "graphology": "^0.26.0",
+        "graphology-communities-louvain": "^2.0.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0",
@@ -1700,6 +1702,14 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -1729,6 +1739,57 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/graphology": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/graphology/-/graphology-0.26.0.tgz",
+      "integrity": "sha512-8SSImzgUUYC89Z042s+0r/vMibY7GX/Emz4LDO5e7jYXhuoWfHISPFJYjpRLUSJGq6UQ6xlenvX1p/hJdfXuXg==",
+      "dependencies": {
+        "events": "^3.3.0"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.24.0"
+      }
+    },
+    "node_modules/graphology-communities-louvain": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/graphology-communities-louvain/-/graphology-communities-louvain-2.0.2.tgz",
+      "integrity": "sha512-zt+2hHVPYxjEquyecxWXoUoIuN/UvYzsvI7boDdMNz0rRvpESQ7+e+Ejv6wK7AThycbZXuQ6DkG8NPMCq6XwoA==",
+      "dependencies": {
+        "graphology-indices": "^0.17.0",
+        "graphology-utils": "^2.4.4",
+        "mnemonist": "^0.39.0",
+        "pandemonium": "^2.4.1"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.19.0"
+      }
+    },
+    "node_modules/graphology-indices": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/graphology-indices/-/graphology-indices-0.17.0.tgz",
+      "integrity": "sha512-A7RXuKQvdqSWOpn7ZVQo4S33O0vCfPBnUSf7FwE0zNCasqwZVUaCXePuWo5HBpWw68KJcwObZDHpFk6HKH6MYQ==",
+      "dependencies": {
+        "graphology-utils": "^2.4.2",
+        "mnemonist": "^0.39.0"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.20.0"
+      }
+    },
+    "node_modules/graphology-types": {
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/graphology-types/-/graphology-types-0.24.8.tgz",
+      "integrity": "sha512-hDRKYXa8TsoZHjgEaysSRyPdT6uB78Ci8WnjgbStlQysz7xR52PInxNsmnB7IBOM1BhikxkNyCVEFgmPKnpx3Q==",
+      "peer": true
+    },
+    "node_modules/graphology-utils": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/graphology-utils/-/graphology-utils-2.5.2.tgz",
+      "integrity": "sha512-ckHg8MXrXJkOARk56ZaSCM1g1Wihe2d6iTmz1enGOz4W/l831MBCKSayeFQfowgF8wd+PQ4rlch/56Vs/VZLDQ==",
+      "peerDependencies": {
+        "graphology-types": ">=0.23.0"
       }
     },
     "node_modules/hast-util-to-jsx-runtime": {
@@ -2759,6 +2820,14 @@
       ],
       "license": "MIT"
     },
+    "node_modules/mnemonist": {
+      "version": "0.39.8",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.8.tgz",
+      "integrity": "sha512-vyWo2K3fjrUw8YeeZ1zF0fy6Mu59RHokURlld8ymdUPjMlD9EC9ov1/YPqTgqRvUN9nTr3Gqfz29LYAmu0PHPQ==",
+      "dependencies": {
+        "obliterator": "^2.0.1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2790,6 +2859,19 @@
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/obliterator": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.5.tgz",
+      "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw=="
+    },
+    "node_modules/pandemonium": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/pandemonium/-/pandemonium-2.4.1.tgz",
+      "integrity": "sha512-wRqjisUyiUfXowgm7MFH2rwJzKIr20rca5FsHXCMNm1W5YPP1hCtrZfgmQ62kP7OZ7Xt+cR858aB28lu5NX55g==",
+      "dependencies": {
+        "mnemonist": "^0.39.2"
+      }
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "@supabase/supabase-js": "^2.45.4",
     "d3-force": "^3.0.0",
     "d3-hierarchy": "^3.1.2",
+    "graphology": "^0.26.0",
+    "graphology-communities-louvain": "^2.0.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",

--- a/scripts/ab-clustering.ts
+++ b/scripts/ab-clustering.ts
@@ -1,0 +1,240 @@
+// A/B harness: shipped weighted label-propagation vs weighted Louvain
+// (graphology-communities-louvain) over the REAL fist-of-ilmater board graph,
+// fed by the same deriveRelations() projection the app uses.
+//
+// Usage: npx tsx scripts/ab-clustering.ts [campaignId]
+//
+// Reads VITE_SUPABASE_URL / VITE_SUPABASE_PUBLISHABLE_KEY from .env (anon key —
+// reads are open to anon per RLS). Prints, per algorithm: community count/sizes,
+// members by name, weighted modularity, cut edges (edges spanning communities),
+// plus a synthetic "low-weight bridge" acceptance test: two dense w3 cliques
+// joined by ONE w2 manual string must NOT merge.
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createClient } from "@supabase/supabase-js";
+import Graph from "graphology";
+import louvain from "graphology-communities-louvain";
+import { deriveRelations, type DerivedEdge } from "../src/relations";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const CAMPAIGN = process.argv[2] ?? "fist-of-ilmater";
+
+// ---------------------------------------------------------------- env / client
+const env: Record<string, string> = {};
+for (const line of readFileSync(join(ROOT, ".env"), "utf8").split(/\r?\n/)) {
+  const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
+  if (m) env[m[1]] = m[2];
+}
+const supabase = createClient(env.VITE_SUPABASE_URL, env.VITE_SUPABASE_PUBLISHABLE_KEY);
+
+// ------------------------------------------------------------------ fetch data
+const tables = [
+  "people", "locations", "quests", "goals", "factions", "items", "lore",
+  "sessions", "events", "connections", "board_positions",
+] as const;
+const rows: Record<string, any[]> = {};
+await Promise.all(tables.map(async (t) => {
+  const { data, error } = await supabase.from(t).select("*").eq("campaign_id", CAMPAIGN);
+  if (error) throw new Error(`${t}: ${error.message}`);
+  rows[t] = data ?? [];
+}));
+
+// Minimal campaign shape — only the fields deriveRelations reads.
+const campaign = {
+  people: rows.people.map((r) => ({ id: r.id, faction: r.faction_id ?? undefined, location: r.location_id ?? undefined })),
+  quests: rows.quests.map((r) => ({ id: r.id, giver: r.giver_id ?? undefined })),
+  events: rows.events.map((r) => ({ id: r.id, location: r.location_id ?? undefined })),
+  connections: rows.connections.map((r) => [r.from_id, r.to_id, r.label ?? ""] as [string, string, string]),
+} as any;
+
+const name = new Map<string, string>();
+const archived = new Set<string>();
+for (const t of tables) {
+  if (t === "connections" || t === "board_positions") continue;
+  for (const r of rows[t]) {
+    name.set(r.id, r.name ?? r.title ?? r.text ?? r.id);
+    if (r.archived) archived.add(r.id);
+  }
+}
+
+// Board cards the way onTidy sees them: entities with a board position, not archived.
+const cards = rows.board_positions
+  .filter((r) => !archived.has(r.entity_id))
+  .map((r) => ({ id: r.entity_id as string, kind: r.kind as string }));
+const cardIds = new Set(cards.map((c) => c.id));
+
+const allEdges = deriveRelations(campaign);
+const edges = allEdges.filter((e) => cardIds.has(e.a) && cardIds.has(e.b));
+
+// Collapse to one weight per unordered pair (MAX) — same as boardLayout.ts.
+const pairWeight = new Map<string, number>();
+for (const e of edges) {
+  if (e.a === e.b) continue;
+  const key = e.a < e.b ? `${e.a}|${e.b}` : `${e.b}|${e.a}`;
+  pairWeight.set(key, Math.max(pairWeight.get(key) ?? 0, e.weight));
+}
+
+console.log(`campaign=${CAMPAIGN}  cards=${cards.length}  derivedEdges=${edges.length} (manual=${edges.filter(e=>e.source==="manual").length} fk=${edges.filter(e=>e.source==="fk").length})  collapsedPairs=${pairWeight.size}`);
+
+// ---------------------------------------------------------------- algorithms
+type Pairs = Map<string, number>;
+
+function adjacency(ids: string[], pairs: Pairs) {
+  const adj = new Map<string, Map<string, number>>(ids.map((id) => [id, new Map()]));
+  for (const [key, w] of pairs) {
+    const [a, b] = key.split("|");
+    if (!adj.has(a) || !adj.has(b)) continue;
+    adj.get(a)!.set(b, w);
+    adj.get(b)!.set(a, w);
+  }
+  return adj;
+}
+
+// Exact copy of the shipped weighted label propagation (boardLayout.ts).
+function labelProp(ids: string[], pairs: Pairs): Map<string, string> {
+  const adjW = adjacency(ids, pairs);
+  const sortedIds = [...ids].sort();
+  const community = new Map<string, string>(sortedIds.map((id) => [id, id]));
+  for (let round = 0; round < 20; round++) {
+    let changed = false;
+    for (const id of sortedIds) {
+      const nbrs = adjW.get(id)!;
+      if (nbrs.size === 0) continue;
+      const score = new Map<string, number>();
+      for (const [nb, w] of nbrs) {
+        const lb = community.get(nb)!;
+        score.set(lb, (score.get(lb) ?? 0) + w);
+      }
+      let best: string | null = null;
+      let bestScore = -Infinity;
+      for (const [lb, s] of score) {
+        if (s > bestScore || (s === bestScore && (best === null || lb < best))) { best = lb; bestScore = s; }
+      }
+      if (best !== null && best !== community.get(id)) { community.set(id, best); changed = true; }
+    }
+    if (!changed) break;
+  }
+  return community;
+}
+
+// mulberry32 — deterministic rng for Louvain.
+function seededRng(seed: number) {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function runLouvain(ids: string[], pairs: Pairs, resolution: number): Map<string, string> {
+  const g = new Graph({ type: "undirected" });
+  for (const id of [...ids].sort()) g.addNode(id);
+  for (const [key, w] of [...pairs.entries()].sort(([a], [b]) => (a < b ? -1 : 1))) {
+    const [a, b] = key.split("|");
+    if (g.hasNode(a) && g.hasNode(b)) g.addEdge(a, b, { weight: w });
+  }
+  const res = louvain(g, {
+    resolution,
+    rng: seededRng(42),
+    getEdgeWeight: "weight",
+  });
+  return new Map(Object.entries(res).map(([id, c]) => [id, String(c)]));
+}
+
+// Weighted modularity of a partition over the collapsed pairs.
+function modularity(ids: string[], pairs: Pairs, community: Map<string, string>): number {
+  let m2 = 0; // 2m
+  const strength = new Map<string, number>();
+  for (const [key, w] of pairs) {
+    const [a, b] = key.split("|");
+    m2 += 2 * w;
+    strength.set(a, (strength.get(a) ?? 0) + w);
+    strength.set(b, (strength.get(b) ?? 0) + w);
+  }
+  if (m2 === 0) return 0;
+  let q = 0;
+  for (const [key, w] of pairs) {
+    const [a, b] = key.split("|");
+    if (community.get(a) === community.get(b)) q += w / (m2 / 2);
+  }
+  const byC = new Map<string, number>();
+  for (const [id, s] of strength) {
+    const c = community.get(id)!;
+    byC.set(c, (byC.get(c) ?? 0) + s);
+  }
+  for (const s of byC.values()) q -= (s / m2) ** 2;
+  return q;
+}
+
+function report(tag: string, ids: string[], pairs: Pairs, community: Map<string, string>, edgeList: DerivedEdge[]) {
+  const groups = new Map<string, string[]>();
+  for (const id of ids) {
+    const c = community.get(id) ?? id;
+    (groups.get(c) ?? groups.set(c, []).get(c)!).push(id);
+  }
+  const connected = new Set([...pairs.keys()].flatMap((k) => k.split("|")));
+  const real = [...groups.values()].filter((g) => g.length > 1 || connected.has(g[0]));
+  const singletonsIsolated = ids.length - real.reduce((n, g) => n + g.length, 0);
+  real.sort((a, b) => b.length - a.length);
+  console.log(`\n=== ${tag} — ${real.length} communities (sizes: ${real.map((g) => g.length).join(", ")}), isolated=${singletonsIsolated}, modularity=${modularity(ids, pairs, community).toFixed(3)}`);
+  for (const g of real) {
+    const label = (id: string) => name.get(id) ?? id.slice(0, 8);
+    const shown = g.slice(0, 10).map(label).join(" · ");
+    console.log(`  [${String(g.length).padStart(2)}] ${shown}${g.length > 10 ? ` … +${g.length - 10}` : ""}`);
+  }
+  const cut = edgeList.filter((e) => community.get(e.a) !== community.get(e.b));
+  console.log(`  cut edges (${cut.length}):`);
+  for (const e of cut.slice(0, 15)) {
+    console.log(`    ${name.get(e.a) ?? e.a} —"${e.label}"(w${e.weight},${e.source})— ${name.get(e.b) ?? e.b}`);
+  }
+  if (cut.length > 15) console.log(`    … +${cut.length - 15}`);
+}
+
+// -------------------------------------------------------------- real-data A/B
+const ids = cards.map((c) => c.id);
+report("label propagation (shipped)", ids, pairWeight, labelProp(ids, pairWeight), edges);
+for (const r of [0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2]) {
+  report(`louvain resolution=${r}`, ids, pairWeight, runLouvain(ids, pairWeight, r), edges);
+}
+
+// Determinism spot-check: run each twice, compare.
+const same = (a: Map<string, string>, b: Map<string, string>) => {
+  // compare as partitions (labels may differ): canonical signature
+  const sig = (m: Map<string, string>) => {
+    const byC = new Map<string, string[]>();
+    for (const [id, c] of m) (byC.get(c) ?? byC.set(c, []).get(c)!).push(id);
+    return [...byC.values()].map((g) => g.sort().join(",")).sort().join(";");
+  };
+  return sig(a) === sig(b);
+};
+console.log(`\ndeterminism: labelProp=${same(labelProp(ids, pairWeight), labelProp(ids, pairWeight))} louvain(1.0)=${same(runLouvain(ids, pairWeight, 1.0), runLouvain(ids, pairWeight, 1.0))}`);
+
+// ----------------------------------------------------- bridge acceptance test
+// Two dense spheres (w3 cliques, e.g. Zhentarim vs Neverwinter stand-ins)
+// joined by ONE w2 manual "rival of" string. Must stay TWO communities.
+{
+  const A = ["a1", "a2", "a3", "a4", "a5", "a6"];
+  const B = ["b1", "b2", "b3", "b4", "b5", "b6"];
+  const pairs: Pairs = new Map();
+  const clique = (g: string[]) => {
+    for (let i = 0; i < g.length; i++) for (let j = i + 1; j < g.length; j++) pairs.set(`${g[i]}|${g[j]}`, 3);
+  };
+  clique(A); clique(B);
+  pairs.set("a1|b1", 2); // the low-weight bridge
+  const bids = [...A, ...B];
+  const check = (tag: string, community: Map<string, string>) => {
+    const ca = new Set(A.map((id) => community.get(id)));
+    const cb = new Set(B.map((id) => community.get(id)));
+    const merged = community.get("a1") === community.get("b1");
+    const cohesive = ca.size === 1 && cb.size === 1;
+    console.log(`bridge test ${tag}: ${merged ? "MERGED ✗" : "separate ✓"}${cohesive ? "" : " (spheres fragmented!)"}`);
+  };
+  console.log("");
+  check("labelProp", labelProp(bids, pairs));
+  for (const r of [0.7, 1.0, 1.5, 2.0]) check(`louvain r=${r}`, runLouvain(bids, pairs, r));
+}

--- a/scripts/ab-clustering.ts
+++ b/scripts/ab-clustering.ts
@@ -1,78 +1,34 @@
 // A/B harness: shipped weighted label-propagation vs weighted Louvain
-// (graphology-communities-louvain) over the REAL fist-of-ilmater board graph,
-// fed by the same deriveRelations() projection the app uses.
+// (graphology-communities-louvain) over a REAL campaign's board graph, fed by
+// the same deriveRelations() projection the app uses.
 //
 // Usage: npx tsx scripts/ab-clustering.ts [campaignId]
 //
-// Reads VITE_SUPABASE_URL / VITE_SUPABASE_PUBLISHABLE_KEY from .env (anon key —
-// reads are open to anon per RLS). Prints, per algorithm: community count/sizes,
-// members by name, weighted modularity, cut edges (edges spanning communities),
-// plus a synthetic "low-weight bridge" acceptance test: two dense w3 cliques
-// joined by ONE w2 manual string must NOT merge.
+// Prints, per algorithm: community count/sizes, members by name, weighted
+// modularity, cut edges (edges spanning communities), plus a synthetic
+// "low-weight bridge" acceptance test: two dense w3 cliques joined by ONE w2
+// manual string must NOT merge.
+//
+// Outcome (2026-07-05, campaigns fist-of-ilmater + fendwick): Louvain at
+// resolution 0.9 won — label propagation tore semantic groups apart (split the
+// party's guild from its own leader, orphaned members into 2-card islands) at
+// clearly lower modularity. boardLayout.ts ships Louvain accordingly; this
+// harness stays for re-evaluating on future data.
 
-import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-import { createClient } from "@supabase/supabase-js";
 import Graph from "graphology";
 import louvain from "graphology-communities-louvain";
-import { deriveRelations, type DerivedEdge } from "../src/relations";
+import { pairKey, type DerivedEdge } from "../src/relations";
+import { mulberry32 } from "../src/boardLayout";
+import { loadCampaignGraph } from "./campaignGraph";
 
-const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const CAMPAIGN = process.argv[2] ?? "fist-of-ilmater";
-
-// ---------------------------------------------------------------- env / client
-const env: Record<string, string> = {};
-for (const line of readFileSync(join(ROOT, ".env"), "utf8").split(/\r?\n/)) {
-  const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
-  if (m) env[m[1]] = m[2];
-}
-const supabase = createClient(env.VITE_SUPABASE_URL, env.VITE_SUPABASE_PUBLISHABLE_KEY);
-
-// ------------------------------------------------------------------ fetch data
-const tables = [
-  "people", "locations", "quests", "goals", "factions", "items", "lore",
-  "sessions", "events", "connections", "board_positions",
-] as const;
-const rows: Record<string, any[]> = {};
-await Promise.all(tables.map(async (t) => {
-  const { data, error } = await supabase.from(t).select("*").eq("campaign_id", CAMPAIGN);
-  if (error) throw new Error(`${t}: ${error.message}`);
-  rows[t] = data ?? [];
-}));
-
-// Minimal campaign shape — only the fields deriveRelations reads.
-const campaign = {
-  people: rows.people.map((r) => ({ id: r.id, faction: r.faction_id ?? undefined, location: r.location_id ?? undefined })),
-  quests: rows.quests.map((r) => ({ id: r.id, giver: r.giver_id ?? undefined })),
-  events: rows.events.map((r) => ({ id: r.id, location: r.location_id ?? undefined })),
-  connections: rows.connections.map((r) => [r.from_id, r.to_id, r.label ?? ""] as [string, string, string]),
-} as any;
-
-const name = new Map<string, string>();
-const archived = new Set<string>();
-for (const t of tables) {
-  if (t === "connections" || t === "board_positions") continue;
-  for (const r of rows[t]) {
-    name.set(r.id, r.name ?? r.title ?? r.text ?? r.id);
-    if (r.archived) archived.add(r.id);
-  }
-}
-
-// Board cards the way onTidy sees them: entities with a board position, not archived.
-const cards = rows.board_positions
-  .filter((r) => !archived.has(r.entity_id))
-  .map((r) => ({ id: r.entity_id as string, kind: r.kind as string }));
-const cardIds = new Set(cards.map((c) => c.id));
-
-const allEdges = deriveRelations(campaign);
-const edges = allEdges.filter((e) => cardIds.has(e.a) && cardIds.has(e.b));
+const { name, cards, edges } = await loadCampaignGraph(CAMPAIGN);
 
 // Collapse to one weight per unordered pair (MAX) — same as boardLayout.ts.
 const pairWeight = new Map<string, number>();
 for (const e of edges) {
   if (e.a === e.b) continue;
-  const key = e.a < e.b ? `${e.a}|${e.b}` : `${e.b}|${e.a}`;
+  const key = pairKey(e.a, e.b);
   pairWeight.set(key, Math.max(pairWeight.get(key) ?? 0, e.weight));
 }
 
@@ -92,7 +48,8 @@ function adjacency(ids: string[], pairs: Pairs) {
   return adj;
 }
 
-// Exact copy of the shipped weighted label propagation (boardLayout.ts).
+// Copy of the weighted label propagation that shipped before Louvain replaced
+// it (kept here as the A/B baseline).
 function labelProp(ids: string[], pairs: Pairs): Map<string, string> {
   const adjW = adjacency(ids, pairs);
   const sortedIds = [...ids].sort();
@@ -119,18 +76,6 @@ function labelProp(ids: string[], pairs: Pairs): Map<string, string> {
   return community;
 }
 
-// mulberry32 — deterministic rng for Louvain.
-function seededRng(seed: number) {
-  let a = seed >>> 0;
-  return () => {
-    a = (a + 0x6d2b79f5) >>> 0;
-    let t = a;
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
 function runLouvain(ids: string[], pairs: Pairs, resolution: number): Map<string, string> {
   const g = new Graph({ type: "undirected" });
   for (const id of [...ids].sort()) g.addNode(id);
@@ -140,7 +85,7 @@ function runLouvain(ids: string[], pairs: Pairs, resolution: number): Map<string
   }
   const res = louvain(g, {
     resolution,
-    rng: seededRng(42),
+    rng: mulberry32(42),
     getEdgeWeight: "weight",
   });
   return new Map(Object.entries(res).map(([id, c]) => [id, String(c)]));
@@ -175,7 +120,8 @@ function report(tag: string, ids: string[], pairs: Pairs, community: Map<string,
   const groups = new Map<string, string[]>();
   for (const id of ids) {
     const c = community.get(id) ?? id;
-    (groups.get(c) ?? groups.set(c, []).get(c)!).push(id);
+    if (!groups.has(c)) groups.set(c, []);
+    groups.get(c)!.push(id);
   }
   const connected = new Set([...pairs.keys()].flatMap((k) => k.split("|")));
   const real = [...groups.values()].filter((g) => g.length > 1 || connected.has(g[0]));
@@ -197,17 +143,20 @@ function report(tag: string, ids: string[], pairs: Pairs, community: Map<string,
 
 // -------------------------------------------------------------- real-data A/B
 const ids = cards.map((c) => c.id);
-report("label propagation (shipped)", ids, pairWeight, labelProp(ids, pairWeight), edges);
+report("label propagation (baseline)", ids, pairWeight, labelProp(ids, pairWeight), edges);
 for (const r of [0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2]) {
   report(`louvain resolution=${r}`, ids, pairWeight, runLouvain(ids, pairWeight, r), edges);
 }
 
-// Determinism spot-check: run each twice, compare.
+// Determinism spot-check: run each twice, compare as partitions (labels may
+// differ; canonical signature makes the comparison label-agnostic).
 const same = (a: Map<string, string>, b: Map<string, string>) => {
-  // compare as partitions (labels may differ): canonical signature
   const sig = (m: Map<string, string>) => {
     const byC = new Map<string, string[]>();
-    for (const [id, c] of m) (byC.get(c) ?? byC.set(c, []).get(c)!).push(id);
+    for (const [id, c] of m) {
+      if (!byC.has(c)) byC.set(c, []);
+      byC.get(c)!.push(id);
+    }
     return [...byC.values()].map((g) => g.sort().join(",")).sort().join(";");
   };
   return sig(a) === sig(b);

--- a/scripts/campaignGraph.ts
+++ b/scripts/campaignGraph.ts
@@ -1,0 +1,77 @@
+// Shared loader for the analysis scripts (ab-clustering, layout-check): reads
+// the anon Supabase creds from .env, pulls one campaign's rows, and derives the
+// same cards/edges view of the board that the app's Tidy action sees.
+//
+// The row → campaign field mapping below intentionally mirrors the mappers in
+// src/campaignContext.tsx (mapPerson/mapQuest/mapEvent) — only the fields
+// deriveRelations reads. If a column rename lands there, update this too.
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createClient } from "@supabase/supabase-js";
+import { deriveRelations, type DerivedEdge } from "../src/relations";
+import type { BoardPosition, KindKey } from "../src/data";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const TABLES = [
+  "people", "locations", "quests", "goals", "factions", "items", "lore",
+  "sessions", "events", "connections", "board_positions",
+] as const;
+
+export interface CampaignGraph {
+  rows: Record<string, any[]>;
+  /** Display name per entity id (name ?? title ?? text). */
+  name: Map<string, string>;
+  /** Non-archived board cards, the way onTidy sees them. */
+  cards: { id: string; kind: KindKey; pinned: boolean }[];
+  /** Current board positions for those cards. */
+  positions: Record<string, BoardPosition>;
+  /** Unified relations filtered to edges between board cards. */
+  edges: DerivedEdge[];
+}
+
+export async function loadCampaignGraph(campaignId: string): Promise<CampaignGraph> {
+  const env: Record<string, string> = {};
+  for (const line of readFileSync(join(ROOT, ".env"), "utf8").split(/\r?\n/)) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
+    if (m) env[m[1]] = m[2];
+  }
+  const supabase = createClient(env.VITE_SUPABASE_URL, env.VITE_SUPABASE_PUBLISHABLE_KEY);
+
+  const rows: Record<string, any[]> = {};
+  await Promise.all(TABLES.map(async (t) => {
+    const { data, error } = await supabase.from(t).select("*").eq("campaign_id", campaignId);
+    if (error) throw new Error(`${t}: ${error.message}`);
+    rows[t] = data ?? [];
+  }));
+
+  // Minimal campaign shape — only the fields deriveRelations reads.
+  const campaign = {
+    people: rows.people.map((r) => ({ id: r.id, faction: r.faction_id ?? undefined, location: r.location_id ?? undefined })),
+    quests: rows.quests.map((r) => ({ id: r.id, giver: r.giver_id ?? undefined })),
+    events: rows.events.map((r) => ({ id: r.id, location: r.location_id ?? undefined })),
+    connections: rows.connections.map((r) => [r.from_id, r.to_id, r.label ?? ""] as [string, string, string]),
+  } as any;
+
+  const name = new Map<string, string>();
+  const archived = new Set<string>();
+  for (const t of TABLES) {
+    if (t === "connections" || t === "board_positions") continue;
+    for (const r of rows[t]) {
+      name.set(r.id, r.name ?? r.title ?? r.text ?? r.id);
+      if (r.archived) archived.add(r.id);
+    }
+  }
+
+  const positions: Record<string, BoardPosition> = {};
+  for (const r of rows.board_positions) {
+    if (archived.has(r.entity_id)) continue;
+    positions[r.entity_id] = { x: r.x, y: r.y, rot: r.rot ?? 0, kind: r.kind as KindKey };
+  }
+  const cards = Object.keys(positions).map((id) => ({ id, kind: positions[id].kind, pinned: false }));
+  const cardIds = new Set(cards.map((c) => c.id));
+  const edges = deriveRelations(campaign).filter((e) => cardIds.has(e.a) && cardIds.has(e.b));
+
+  return { rows, name, cards, positions, edges };
+}

--- a/scripts/layout-check.ts
+++ b/scripts/layout-check.ts
@@ -4,54 +4,11 @@
 // bounding box / aspect, and layout time.
 //
 // Usage: npx tsx scripts/layout-check.ts [campaignId]
-import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-import { createClient } from "@supabase/supabase-js";
 import { computeTidyLayout, cardDims } from "../src/boardLayout";
-import { deriveRelations } from "../src/relations";
-import type { BoardPosition, KindKey } from "../src/data";
+import { loadCampaignGraph } from "./campaignGraph";
 
-const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const CAMPAIGN = process.argv[2] ?? "fist-of-ilmater";
-
-const env: Record<string, string> = {};
-for (const l of readFileSync(join(ROOT, ".env"), "utf8").split(/\r?\n/)) {
-  const m = l.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
-  if (m) env[m[1]] = m[2];
-}
-const sb = createClient(env.VITE_SUPABASE_URL, env.VITE_SUPABASE_PUBLISHABLE_KEY);
-
-const tables = ["people", "locations", "quests", "goals", "factions", "items", "lore", "sessions", "events", "connections", "board_positions"] as const;
-const rows: Record<string, any[]> = {};
-await Promise.all(tables.map(async (t) => {
-  const { data, error } = await sb.from(t).select("*").eq("campaign_id", CAMPAIGN);
-  if (error) throw new Error(`${t}: ${error.message}`);
-  rows[t] = data ?? [];
-}));
-
-// Minimal campaign shape — only the fields deriveRelations reads.
-const campaign = {
-  people: rows.people.map((r) => ({ id: r.id, faction: r.faction_id ?? undefined, location: r.location_id ?? undefined })),
-  quests: rows.quests.map((r) => ({ id: r.id, giver: r.giver_id ?? undefined })),
-  events: rows.events.map((r) => ({ id: r.id, location: r.location_id ?? undefined })),
-  connections: rows.connections.map((r) => [r.from_id, r.to_id, r.label ?? ""] as [string, string, string]),
-} as any;
-
-const archived = new Set<string>();
-for (const t of tables) {
-  if (t === "connections" || t === "board_positions") continue;
-  for (const r of rows[t]) if (r.archived) archived.add(r.id);
-}
-
-const positions: Record<string, BoardPosition> = {};
-for (const r of rows.board_positions) {
-  if (archived.has(r.entity_id)) continue;
-  positions[r.entity_id] = { x: r.x, y: r.y, rot: r.rot ?? 0, kind: r.kind as KindKey };
-}
-const cards = Object.keys(positions).map((id) => ({ id, kind: positions[id].kind, pinned: false }));
-const cardIds = new Set(cards.map((c) => c.id));
-const edges = deriveRelations(campaign).filter((e) => cardIds.has(e.a) && cardIds.has(e.b));
+const { cards, positions, edges } = await loadCampaignGraph(CAMPAIGN);
 
 const t0 = Date.now();
 const out = computeTidyLayout({ cards, positions, edges });

--- a/scripts/layout-check.ts
+++ b/scripts/layout-check.ts
@@ -1,0 +1,92 @@
+// Layout quality harness: runs the real computeTidyLayout over a campaign's
+// real board data and reports the acceptance metrics for "Tidy board":
+// card overlaps (must be 0), determinism (two runs → identical positions),
+// bounding box / aspect, and layout time.
+//
+// Usage: npx tsx scripts/layout-check.ts [campaignId]
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createClient } from "@supabase/supabase-js";
+import { computeTidyLayout, cardDims } from "../src/boardLayout";
+import { deriveRelations } from "../src/relations";
+import type { BoardPosition, KindKey } from "../src/data";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const CAMPAIGN = process.argv[2] ?? "fist-of-ilmater";
+
+const env: Record<string, string> = {};
+for (const l of readFileSync(join(ROOT, ".env"), "utf8").split(/\r?\n/)) {
+  const m = l.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
+  if (m) env[m[1]] = m[2];
+}
+const sb = createClient(env.VITE_SUPABASE_URL, env.VITE_SUPABASE_PUBLISHABLE_KEY);
+
+const tables = ["people", "locations", "quests", "goals", "factions", "items", "lore", "sessions", "events", "connections", "board_positions"] as const;
+const rows: Record<string, any[]> = {};
+await Promise.all(tables.map(async (t) => {
+  const { data, error } = await sb.from(t).select("*").eq("campaign_id", CAMPAIGN);
+  if (error) throw new Error(`${t}: ${error.message}`);
+  rows[t] = data ?? [];
+}));
+
+// Minimal campaign shape — only the fields deriveRelations reads.
+const campaign = {
+  people: rows.people.map((r) => ({ id: r.id, faction: r.faction_id ?? undefined, location: r.location_id ?? undefined })),
+  quests: rows.quests.map((r) => ({ id: r.id, giver: r.giver_id ?? undefined })),
+  events: rows.events.map((r) => ({ id: r.id, location: r.location_id ?? undefined })),
+  connections: rows.connections.map((r) => [r.from_id, r.to_id, r.label ?? ""] as [string, string, string]),
+} as any;
+
+const archived = new Set<string>();
+for (const t of tables) {
+  if (t === "connections" || t === "board_positions") continue;
+  for (const r of rows[t]) if (r.archived) archived.add(r.id);
+}
+
+const positions: Record<string, BoardPosition> = {};
+for (const r of rows.board_positions) {
+  if (archived.has(r.entity_id)) continue;
+  positions[r.entity_id] = { x: r.x, y: r.y, rot: r.rot ?? 0, kind: r.kind as KindKey };
+}
+const cards = Object.keys(positions).map((id) => ({ id, kind: positions[id].kind, pinned: false }));
+const cardIds = new Set(cards.map((c) => c.id));
+const edges = deriveRelations(campaign).filter((e) => cardIds.has(e.a) && cardIds.has(e.b));
+
+const t0 = Date.now();
+const out = computeTidyLayout({ cards, positions, edges });
+const ms = Date.now() - t0;
+const out2 = computeTidyLayout({ cards, positions, edges });
+
+let identical = true;
+for (const id of Object.keys(out)) {
+  if (!out2[id] || out2[id].x !== out[id].x || out2[id].y !== out[id].y) { identical = false; break; }
+}
+
+const rect = (id: string) => {
+  const d = cardDims(positions[id].kind);
+  return { x: out[id].x, y: out[id].y, w: d.w, h: d.h };
+};
+const ids = Object.keys(out);
+let overlaps = 0;
+const overlapPairs: string[] = [];
+for (let i = 0; i < ids.length; i++) {
+  for (let j = i + 1; j < ids.length; j++) {
+    const A = rect(ids[i]), B = rect(ids[j]);
+    const ox = Math.min(A.x + A.w, B.x + B.w) - Math.max(A.x, B.x);
+    const oy = Math.min(A.y + A.h, B.y + B.h) - Math.max(A.y, B.y);
+    if (ox > 1 && oy > 1) { overlaps++; overlapPairs.push(`${ids[i]} × ${ids[j]} (${Math.round(ox)}×${Math.round(oy)})`); }
+  }
+}
+
+let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+for (const id of ids) {
+  const R = rect(id);
+  minX = Math.min(minX, R.x); minY = Math.min(minY, R.y);
+  maxX = Math.max(maxX, R.x + R.w); maxY = Math.max(maxY, R.y + R.h);
+}
+
+console.log(`campaign=${CAMPAIGN} cards=${cards.length} placed=${ids.length} time=${ms}ms`);
+console.log(`deterministic=${identical} overlaps=${overlaps}`);
+for (const p of overlapPairs.slice(0, 8)) console.log(`  overlap: ${p}`);
+console.log(`board bbox: ${Math.round(maxX - minX)} × ${Math.round(maxY - minY)} (aspect ${((maxX - minX) / (maxY - minY)).toFixed(2)})`);

--- a/src/boardLayout.ts
+++ b/src/boardLayout.ts
@@ -7,6 +7,8 @@ import {
   type SimulationLinkDatum,
 } from "d3-force";
 import { packSiblings, packEnclose } from "d3-hierarchy";
+import Graph from "graphology";
+import louvain from "graphology-communities-louvain";
 import type { BoardPosition, KindKey } from "./data";
 import type { DerivedEdge } from "./relations";
 
@@ -38,7 +40,21 @@ export type TidyTuning = {
   hubPull: number;           // pull members toward their hub (tightness of a sphere)
   collidePad: number;        // breathing room around each card
   clusterGap: number;        // empty space added around each sphere before packing
+  louvainResolution: number; // community granularity: lower merges, higher splits
 };
+
+// mulberry32 — a tiny seeded PRNG so Louvain's tie-breaking is reproducible
+// and "Tidy" stays deterministic run-to-run.
+function mulberry32(seed: number) {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
 
 // forceLink strength scales with edge weight so a shared faction (w3) draws
 // cards tighter than a shared location/manual string (w2) than a quest-giver
@@ -57,9 +73,9 @@ interface MiniLink extends SimulationLinkDatum<MiniNode> {
 /**
  * Two-phase "tidy" that arranges the board into **spheres of influence**:
  *
- *  1. Weighted **label propagation** partitions the cards into communities
- *     (denser than connected components, so an FK-enriched graph splits into
- *     sub-spheres instead of merging into one blob); each community's
+ *  1. Weighted **Louvain** partitions the cards into communities (denser than
+ *     connected components, so an FK-enriched graph splits into sub-spheres
+ *     instead of merging into one blob); each community's
  *     most-connected entity is its hub. Each community is laid out **internally**
  *     with its own small force sim (weighted links + repulsion + collision + a
  *     pull toward the hub), producing a tight sphere centred on its hub. Isolated
@@ -85,9 +101,10 @@ export function computeTidyLayout(input: {
     linkDistance: 55,
     linkStrengthPerWeight: 0.15, // w1→.15, w2→.30 (== old constant), w3→.45
     charge: -200,
-    hubPull: 0.42,
-    collidePad: 24,
-    clusterGap: 170, // generous whitespace between spheres so they read as distinct
+    hubPull: 0.5,
+    collidePad: 20,
+    clusterGap: 140, // whitespace between spheres so they read as distinct
+    louvainResolution: 0.9, // stable plateau on both seeded campaigns (see scripts/ab-clustering.ts)
     ...tuneOverride,
   };
   // Isolated cards (no edges) are parked in a tidy grid below the clusters
@@ -101,53 +118,46 @@ export function computeTidyLayout(input: {
 
   // Collapse the unified edges to one weight per unordered card pair (MAX, so a
   // pair's strength stays in the designed w1..w3 band even with parallel manual
-  // strings), and build a weighted adjacency map + degree count.
+  // strings), and count each card's degree over those pairs.
   const degree = new Map<string, number>(cards.map((c) => [c.id, 0]));
-  const adjW = new Map<string, Map<string, number>>(cards.map((c) => [c.id, new Map()]));
   const pairWeight = new Map<string, number>();
   for (const e of edges) {
     if (e.a === e.b || !cardIds.has(e.a) || !cardIds.has(e.b)) continue;
     const key = e.a < e.b ? `${e.a}|${e.b}` : `${e.b}|${e.a}`;
     pairWeight.set(key, Math.max(pairWeight.get(key) ?? 0, e.weight));
   }
-  for (const [key, w] of pairWeight) {
+  for (const key of pairWeight.keys()) {
     const [a, b] = key.split("|");
     degree.set(a, (degree.get(a) ?? 0) + 1);
     degree.set(b, (degree.get(b) ?? 0) + 1);
-    adjW.get(a)!.set(b, w);
-    adjW.get(b)!.set(a, w);
   }
 
   const radiusOf = (d: { id: string; w: number; h: number }) =>
     Math.hypot(d.w / 2, d.h / 2) + TUNE.collidePad + Math.min(degree.get(d.id) ?? 0, 10) * 6;
 
-  // Community detection via **weighted label propagation**. Each node adopts the
-  // neighbour label with the greatest summed edge weight; ties break to the
-  // lexicographically smallest label. Deterministic (fixed sorted node order,
-  // order-independent tie-break, capped rounds) so "Tidy" is reproducible. This
-  // is denser than connected components — a hub linked to many entities splits
-  // into sub-communities rather than absorbing the whole board into one blob.
+  // Community detection via **weighted Louvain** (modularity optimization over
+  // the same weighted pairs the force sim uses). It replaced the earlier
+  // hand-rolled label propagation after an A/B on both seeded campaigns
+  // (scripts/ab-clustering.ts): label propagation tore semantic groups apart —
+  // e.g. it split the party's own guild from its leader and orphaned members
+  // into 2-card islands — while Louvain recovered the story's actual spheres at
+  // clearly higher modularity. (An earlier pre-#42 Louvain attempt over-split,
+  // but that graph was unweighted and sparse; the weighted projection fixed it,
+  // and a single low-weight bridge between two dense spheres no longer merges
+  // them.) Deterministic: nodes/edges inserted in sorted order + seeded rng.
   const sortedIds = cards.map((c) => c.id).sort();
-  const community = new Map<string, string>(sortedIds.map((id) => [id, id]));
-  for (let round = 0; round < 20; round++) {
-    let changed = false;
-    for (const id of sortedIds) {
-      const nbrs = adjW.get(id)!;
-      if (nbrs.size === 0) continue;
-      const score = new Map<string, number>();
-      for (const [nb, w] of nbrs) {
-        const lb = community.get(nb)!;
-        score.set(lb, (score.get(lb) ?? 0) + w);
-      }
-      let best: string | null = null;
-      let bestScore = -Infinity;
-      for (const [lb, s] of score) {
-        if (s > bestScore || (s === bestScore && (best === null || lb < best))) { best = lb; bestScore = s; }
-      }
-      if (best !== null && best !== community.get(id)) { community.set(id, best); changed = true; }
-    }
-    if (!changed) break;
+  const graph = new Graph({ type: "undirected" });
+  for (const id of sortedIds) graph.addNode(id);
+  for (const [key, w] of [...pairWeight.entries()].sort(([a], [b]) => (a < b ? -1 : 1))) {
+    const [a, b] = key.split("|");
+    graph.addEdge(a, b, { weight: w });
   }
+  const assignments = louvain(graph, {
+    resolution: TUNE.louvainResolution,
+    rng: mulberry32(42),
+    getEdgeWeight: "weight",
+  });
+  const community = new Map<string, string>(sortedIds.map((id) => [id, String(assignments[id])]));
 
   // Group cards by community label; find each community's hub (highest degree,
   // tie-break smallest id).
@@ -218,9 +228,9 @@ export function computeTidyLayout(input: {
 
   // ---- Phase 2: circle-pack the real spheres; grid only the true loners. -----
   // A "loner" is a card with NO edges (degree 0). A 1-member community that
-  // still has edges — label propagation can orphan a connected leaf — is packed
-  // among the spheres, not exiled to the grid, so its yarn doesn't stretch
-  // across the inter-sphere whitespace the grid exists to keep clear.
+  // still has edges — community detection can leave a connected node alone — is
+  // packed among the spheres, not exiled to the grid, so its yarn doesn't
+  // stretch across the inter-sphere whitespace the grid exists to keep clear.
   const isLoner = (b: Blob) => b.local.length === 1 && (degree.get(b.local[0].id) ?? 0) === 0;
   const clusterBlobs = blobs.filter((b) => !isLoner(b));
   const singletonBlobs = blobs.filter(isLoner);

--- a/src/boardLayout.ts
+++ b/src/boardLayout.ts
@@ -10,7 +10,7 @@ import { packSiblings, packEnclose } from "d3-hierarchy";
 import Graph from "graphology";
 import louvain from "graphology-communities-louvain";
 import type { BoardPosition, KindKey } from "./data";
-import type { DerivedEdge } from "./relations";
+import { pairKey, type DerivedEdge } from "./relations";
 
 // Card footprints per kind — the single source of truth shared by the board
 // renderer (centerOf / findFreeSpot in board.tsx) and the tidy layout, so both
@@ -44,8 +44,9 @@ export type TidyTuning = {
 };
 
 // mulberry32 — a tiny seeded PRNG so Louvain's tie-breaking is reproducible
-// and "Tidy" stays deterministic run-to-run.
-function mulberry32(seed: number) {
+// and "Tidy" stays deterministic run-to-run. Exported for the analysis
+// scripts so their Louvain runs match the app's exactly.
+export function mulberry32(seed: number) {
   let a = seed >>> 0;
   return () => {
     a = (a + 0x6d2b79f5) >>> 0;
@@ -123,7 +124,7 @@ export function computeTidyLayout(input: {
   const pairWeight = new Map<string, number>();
   for (const e of edges) {
     if (e.a === e.b || !cardIds.has(e.a) || !cardIds.has(e.b)) continue;
-    const key = e.a < e.b ? `${e.a}|${e.b}` : `${e.b}|${e.a}`;
+    const key = pairKey(e.a, e.b);
     pairWeight.set(key, Math.max(pairWeight.get(key) ?? 0, e.weight));
   }
   for (const key of pairWeight.keys()) {

--- a/src/relations.ts
+++ b/src/relations.ts
@@ -27,7 +27,10 @@ export const LOCATION_WEIGHT = 2;
 export const MANUAL_WEIGHT = 2;
 export const GIVER_WEIGHT = 1;
 
-const pairKey = (a: string, b: string) => (a < b ? `${a}|${b}` : `${b}|${a}`);
+// Order-independent key for an entity pair. Exported so consumers that
+// aggregate per-pair (boardLayout's weight collapse, the analysis scripts)
+// can't drift from the format used here.
+export const pairKey = (a: string, b: string) => (a < b ? `${a}|${b}` : `${b}|${a}`);
 // A NUL char separates pair-key from label so no (id, label) combination can
 // collide with another. Built via fromCharCode so the source stays plain text
 // (a literal NUL byte would make git treat this file as binary).

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,11 @@
     "noFallthroughCasesInSwitch": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "types": ["vite/client"]
+    "types": ["vite/client"],
+    // Typecheck only — Vite owns transpilation. Without this, `tsc -b` drops
+    // compiled .js siblings into src/ that Vite's dev resolver prefers over the
+    // .tsx, so the dev server silently runs stale code after every build.
+    "noEmit": true
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,6 +1,11 @@
 {
   "compilerOptions": {
     "composite": true,
+    // Composite projects must emit, so aim it out of the tree — a vite.config.js
+    // sibling would shadow vite.config.ts the same way src/ .js siblings shadow
+    // the .tsx (see tsconfig.json's noEmit note).
+    "outDir": "./node_modules/.tmp/tsc-node",
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
Now that the unified relations projection (#42/#44) made the board graph weighted and dense, revisit community detection for the notice board's "Tidy board" action.

## Clustering: label propagation → weighted Louvain

- `computeTidyLayout` now partitions cards with **weighted Louvain** (`graphology-communities-louvain`), resolution 0.9, seeded mulberry32 rng + sorted node/edge insertion → fully deterministic.
- A/B on both real campaigns ([scripts/ab-clustering.ts](../blob/feat/notice-board-tidy-clustering/scripts/ab-clustering.ts)): label propagation tore semantic groups apart (split the party's guild from its own leader, orphaned members into 2-card islands) — modularity 0.614 vs Louvain's 0.665 on fist-of-ilmater, 0.417 vs 0.490 on fendwick. Louvain recovers the story's actual spheres (guild / Vecna cult / giants / Harpers / Mephistopheles).
- Bridge acceptance test: a single low-weight manual string between two dense spheres does **not** merge them — the over-subdivision that got the earlier unweighted Louvain removed no longer applies. Resolution 0.9 sits on the stable plateau of both campaigns.
- Edgeless boards are safe: the library's empty-graph branch gives each node its own community, which the singleton-shelf logic expects.

## Layout tightening

`hubPull 0.42→0.5, collidePad 24→20, clusterGap 170→140` — fist-of-ilmater bbox shrinks 4177×5540 → 3907×5142 with 0 overlaps on both campaigns (fill is dominated by collide radii/gaps, not force strengths).

## tsc .js footgun fixed

`tsc -b` used to emit compiled `.js` siblings into `src/` which Vite's dev resolver silently preferred over the `.tsx` — the dev server ran stale code after every build. Root tsconfig is now `noEmit`; the composite node project emits into `node_modules/.tmp`.

## Harnesses

- `npx tsx scripts/ab-clustering.ts [campaignId]` — algorithm A/B, modularity, cut edges, bridge test
- `npx tsx scripts/layout-check.ts [campaignId]` — overlaps (0), determinism, bbox on real data
- shared loader `scripts/campaignGraph.ts`

Verified in-app on fist-of-ilmater via dev sign-in + Tidy: five distinct spheres, deterministic, persisted. Bundle grows ~19 kB gzip from graphology (624→716 kB min) — acceptable; code-split if it keeps growing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)