### PR TITLE
Searchable entity combobox for relations & FK fields

### DIFF
--- a/src/commandPalette.tsx
+++ b/src/commandPalette.tsx
@@ -1,206 +1,24 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useCampaign } from "./hooks";
-import { entityLabel, type Campaign, type KindKey } from "./data";
-import { Icon } from "./icons";
+import { type Campaign } from "./data";
+import { Icon, kindIcon } from "./icons";
+import {
+  buildIndex,
+  keepBest,
+  makeSnippet,
+  rankEntities,
+  sortHits,
+  KIND_LABEL,
+  type Indexed,
+  type RankedHit,
+} from "./entitySearch";
 
-type MatchSource = "primary" | "secondary" | "note";
-
-interface PaletteHit {
-  id: string;
-  kind: KindKey;
-  label: string;
-  snippet?: string;
-  matchSource: MatchSource;
-  rank: 0 | 1 | 2 | 3;
-  archived?: boolean;
-}
-
-const KIND_ICON: Record<KindKey, "people" | "location" | "quest" | "goal" | "faction" | "item" | "lore" | "session" | "layers" | "sparkle"> = {
-  people: "people",
-  locations: "location",
-  quests: "quest",
-  goals: "goal",
-  factions: "faction",
-  items: "item",
-  lore: "lore",
-  sessions: "session",
-  arcs: "layers",
-  events: "sparkle",
-};
-
-const KIND_LABEL: Record<KindKey, string> = {
-  people: "Person",
-  locations: "Location",
-  quests: "Quest",
-  goals: "Goal",
-  factions: "Faction",
-  items: "Item",
-  lore: "Lore",
-  sessions: "Session",
-  arcs: "Arc",
-  events: "Event",
-};
-
-interface Indexed {
-  id: string;
-  kind: KindKey;
-  label: string;
-  primary: string;
-  secondary: string;
-  archived?: boolean;
-}
-
-function joinFields(...parts: Array<string | number | null | undefined>): string {
-  return parts.filter((p) => p !== undefined && p !== null && p !== "").join(" · ");
-}
-
-function buildIndex(campaign: Campaign): Indexed[] {
-  const out: Indexed[] = [];
-  for (const p of campaign.people) {
-    out.push({
-      id: p.id,
-      kind: "people",
-      label: entityLabel(p),
-      primary: p.name ?? "",
-      secondary: joinFields(p.epithet, p.race, p.role, p.disposition, p.alignment, p.notes),
-      archived: p.archived,
-    });
-  }
-  for (const l of campaign.locations) {
-    out.push({
-      id: l.id,
-      kind: "locations",
-      label: entityLabel(l),
-      primary: l.name ?? "",
-      secondary: joinFields(l.kind, l.region, l.ruler, l.desc, l.notes),
-      archived: l.archived,
-    });
-  }
-  for (const q of campaign.quests) {
-    out.push({
-      id: q.id,
-      kind: "quests",
-      label: entityLabel(q),
-      primary: q.title ?? "",
-      secondary: joinFields(q.status, q.reward, q.desc, q.hooks),
-      archived: q.archived,
-    });
-  }
-  for (const g of campaign.goals) {
-    out.push({
-      id: g.id,
-      kind: "goals",
-      label: entityLabel(g),
-      primary: g.text ?? "",
-      secondary: joinFields(g.owner, g.kind, g.status),
-      archived: g.archived,
-    });
-  }
-  for (const f of campaign.factions) {
-    out.push({
-      id: f.id,
-      kind: "factions",
-      label: entityLabel(f),
-      primary: f.name ?? "",
-      secondary: joinFields(f.sigil, f.desc, f.allegiance),
-      archived: f.archived,
-    });
-  }
-  for (const i of campaign.items) {
-    out.push({
-      id: i.id,
-      kind: "items",
-      label: entityLabel(i),
-      primary: i.name ?? "",
-      secondary: joinFields(i.kind, i.desc),
-      archived: i.archived,
-    });
-  }
-  for (const lo of campaign.lore) {
-    out.push({
-      id: lo.id,
-      kind: "lore",
-      label: entityLabel(lo),
-      primary: lo.title ?? "",
-      secondary: lo.text ?? "",
-      archived: lo.archived,
-    });
-  }
-  for (const s of campaign.sessions) {
-    out.push({
-      id: s.id,
-      kind: "sessions",
-      label: entityLabel(s),
-      primary: s.title ?? "",
-      secondary: joinFields(s.date, s.inGameDate, `Session ${s.num}`, s.summary),
-    });
-  }
-  for (const a of campaign.arcs) {
-    out.push({
-      id: a.id,
-      kind: "arcs",
-      label: entityLabel(a),
-      primary: a.title ?? "",
-      secondary: a.summary ?? "",
-    });
-  }
-  for (const ev of campaign.events) {
-    out.push({
-      id: ev.id,
-      kind: "events",
-      label: entityLabel(ev),
-      primary: ev.title ?? "",
-      secondary: joinFields(ev.inGameDate, ev.summary),
-    });
-  }
-  return out;
-}
-
-function makeSnippet(source: string, queryLower: string): string {
-  const idx = source.toLowerCase().indexOf(queryLower);
-  if (idx < 0) return source.slice(0, 90);
-  const start = Math.max(0, idx - 30);
-  const end = Math.min(source.length, idx + queryLower.length + 40);
-  const prefix = start > 0 ? "…" : "";
-  const suffix = end < source.length ? "…" : "";
-  const core = source.slice(start, end);
-  const snippet = `${prefix}${core}${suffix}`;
-  return snippet.length > 100 ? `${snippet.slice(0, 97)}…` : snippet;
-}
-
-function searchHits(index: Indexed[], campaign: Campaign, query: string): PaletteHit[] {
+function searchHits(index: Indexed[], campaign: Campaign, query: string): RankedHit[] {
   const q = query.trim().toLowerCase();
   if (!q) return [];
 
-  const best = new Map<string, PaletteHit>();
-  const keepBest = (hit: PaletteHit) => {
-    const prev = best.get(hit.id);
-    if (!prev || hit.rank < prev.rank) best.set(hit.id, hit);
-  };
-
-  for (const e of index) {
-    const primary = e.primary.toLowerCase();
-    if (primary.startsWith(q)) {
-      keepBest({ id: e.id, kind: e.kind, label: e.label, matchSource: "primary", rank: 0, archived: e.archived });
-      continue;
-    }
-    if (primary.includes(q)) {
-      keepBest({ id: e.id, kind: e.kind, label: e.label, matchSource: "primary", rank: 1, archived: e.archived });
-      continue;
-    }
-    const secondary = e.secondary.toLowerCase();
-    if (secondary.includes(q)) {
-      keepBest({
-        id: e.id,
-        kind: e.kind,
-        label: e.label,
-        snippet: makeSnippet(e.secondary, q),
-        matchSource: "secondary",
-        rank: 2,
-        archived: e.archived,
-      });
-    }
-  }
+  const best = new Map<string, RankedHit>();
+  rankEntities(index, q, best);
 
   const indexById = new Map(index.map((e) => [e.id, e] as const));
   for (const [entityId, notes] of Object.entries(campaign.notes)) {
@@ -208,7 +26,7 @@ function searchHits(index: Indexed[], campaign: Campaign, query: string): Palett
     if (!parent) continue;
     for (const note of notes) {
       if (note.text.toLowerCase().includes(q)) {
-        keepBest({
+        keepBest(best, {
           id: entityId,
           kind: parent.kind,
           label: parent.label,
@@ -222,9 +40,7 @@ function searchHits(index: Indexed[], campaign: Campaign, query: string): Palett
     }
   }
 
-  return Array.from(best.values())
-    .sort((a, b) => a.rank - b.rank || a.label.localeCompare(b.label))
-    .slice(0, 30);
+  return sortHits(best, 30);
 }
 
 export function useCommandPaletteHotkey(onToggle: () => void) {
@@ -264,7 +80,7 @@ export function CommandPalette({ open, onClose, onOpenEntity, onLocate }: Comman
   // Single source of truth for "can this hit be located on the board" — keeps
   // the ⌥↵ handler and the row's "On board" button in lockstep.
   const canLocate = useCallback(
-    (hit: PaletteHit | undefined): boolean => !!onLocate && !!hit && boardIds.has(hit.id),
+    (hit: RankedHit | undefined): boolean => !!onLocate && !!hit && boardIds.has(hit.id),
     [onLocate, boardIds],
   );
 
@@ -291,12 +107,12 @@ export function CommandPalette({ open, onClose, onOpenEntity, onLocate }: Comman
     active?.scrollIntoView({ block: "nearest" });
   }, [selected, open, results.length]);
 
-  const choose = useCallback((hit: PaletteHit | undefined) => {
+  const choose = useCallback((hit: RankedHit | undefined) => {
     if (!hit) return;
     onOpenEntity(hit.id);
   }, [onOpenEntity]);
 
-  const locate = useCallback((hit: PaletteHit | undefined) => {
+  const locate = useCallback((hit: RankedHit | undefined) => {
     if (!hit) return;
     // Alt+Enter on a card without a board pin has nowhere to jump — fall back
     // to opening its detail sheet so the shortcut is never a dead key.
@@ -370,7 +186,7 @@ export function CommandPalette({ open, onClose, onOpenEntity, onLocate }: Comman
               onMouseEnter={() => setSelected(i)}
               onClick={() => choose(hit)}
             >
-              <Icon name={KIND_ICON[hit.kind]} size={16} />
+              <Icon name={kindIcon[hit.kind]} size={16} />
               <div className="cmdk-row-text">
                 <div className={`cmdk-row-label ${hit.archived ? "archived" : ""}`}>{hit.label}</div>
                 {hit.snippet && (

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -1027,6 +1027,7 @@ export interface EntityOption {
   id: string;
   label: string;
   kind: KindKey;
+  archived?: boolean;
 }
 
 interface EntityComboboxProps {
@@ -1070,16 +1071,26 @@ export function EntityCombobox({
   const [rect, setRect] = useState<{ left: number; top: number; width: number; flip: boolean; maxHeight: number } | null>(null);
 
   const index = useMemo<Indexed[]>(
-    () => options.map((o) => ({ id: o.id, kind: o.kind, label: o.label, primary: o.label, secondary: "" })),
+    () => options.map((o) => ({ id: o.id, kind: o.kind, label: o.label, primary: o.label, secondary: "", archived: o.archived })),
     [options],
   );
   const results = useMemo(() => rankIndex(index, query), [index, query]);
 
   // A "clear" pseudo-row sits at index 0 when clearable and unfiltered, so the
-  // row indices below are offset by it.
-  const showClear = allowClear && query.trim() === "" && !!current;
+  // row indices below are offset by it. Shown whenever clearing is allowed —
+  // including when the current value is dangling (references a deleted
+  // entity, so `current` doesn't resolve) — matching the old <select>, which
+  // always exposed an empty option in that case regardless of allowClear.
+  const showClear = allowClear && query.trim() === "";
   const offset = showClear ? 1 : 0;
   const rowCount = results.length + offset;
+
+  // Clamp the active row whenever the list shrinks for any reason (a new
+  // search query, or the options themselves changing e.g. via a realtime
+  // update) so Enter never targets a row past the end of a stale index.
+  useEffect(() => {
+    setSelected((s) => Math.min(s, Math.max(rowCount - 1, 0)));
+  }, [rowCount]);
 
   const reposition = useCallback(() => {
     const el = triggerRef.current;
@@ -1093,7 +1104,12 @@ export function EntityCombobox({
     // popover never runs past the viewport edge.
     const flip = spaceBelow < 300 && spaceAbove > spaceBelow;
     const maxHeight = Math.min(320, Math.max(140, flip ? spaceAbove : spaceBelow));
-    setRect({ left: r.left, top: flip ? r.top : r.bottom, width: r.width, flip, maxHeight });
+    const width = Math.max(r.width, 240);
+    // Clamp left so the popover's right edge never runs past the viewport —
+    // it defaults to the trigger's left edge but slides left if that would
+    // overflow (e.g. a narrow FK field near the right edge of a resized window).
+    const left = Math.min(r.left, window.innerWidth - width - margin);
+    setRect({ left: Math.max(left, margin), top: flip ? r.top : r.bottom, width: r.width, flip, maxHeight });
   }, []);
 
   useEffect(() => {

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { type KindKey, type PresenceUser } from "./data";
 import { Icon, MapScribble, kindIcon } from "./icons";
+import { rankIndex, KIND_LABEL, type Indexed } from "./entitySearch";
 import { useCampaign, useCampaignSwitcher, useKinds } from "./hooks";
 import { createEntity, setActiveSession } from "./mutations";
 import { SignInDialog, useAuth } from "./auth";
@@ -1021,17 +1023,244 @@ export function EnumSelect<T extends string>({
   );
 }
 
+export interface EntityOption {
+  id: string;
+  label: string;
+  kind: KindKey;
+}
+
+interface EntityComboboxProps {
+  value?: string;
+  options: EntityOption[];
+  onSelect: (id: string | null) => void | Promise<void>;
+  allowClear?: boolean;
+  placeholder?: string;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+// Searchable entity picker: a dashed-border trigger that opens a type-to-filter
+// popover ranked through the shared entity search (entitySearch.ts). Used for
+// cross-kind relation targets and single-kind FK fields alike. Read-only
+// viewers see the current label as plain text, matching EnumSelect/EntitySelect.
+//
+// The popover is portalled to <body> so it escapes the detail sheet's
+// overflow:auto scroll container and the overlay's backdrop-filter (which would
+// otherwise clip or re-anchor a fixed child); it's positioned against the
+// trigger's rect and flips above the trigger when there's no room below.
+export function EntityCombobox({
+  value,
+  options,
+  onSelect,
+  allowClear = false,
+  placeholder = "Search…",
+  className,
+  style,
+}: EntityComboboxProps) {
+  const { canEdit } = useAuth();
+  const current = options.find((o) => o.id === value);
+
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const popRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState(0);
+  const [rect, setRect] = useState<{ left: number; top: number; width: number; flip: boolean; maxHeight: number } | null>(null);
+
+  const index = useMemo<Indexed[]>(
+    () => options.map((o) => ({ id: o.id, kind: o.kind, label: o.label, primary: o.label, secondary: "" })),
+    [options],
+  );
+  const results = useMemo(() => rankIndex(index, query), [index, query]);
+
+  // A "clear" pseudo-row sits at index 0 when clearable and unfiltered, so the
+  // row indices below are offset by it.
+  const showClear = allowClear && query.trim() === "" && !!current;
+  const offset = showClear ? 1 : 0;
+  const rowCount = results.length + offset;
+
+  const reposition = useCallback(() => {
+    const el = triggerRef.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    const margin = 10;
+    const spaceBelow = window.innerHeight - r.bottom - margin;
+    const spaceAbove = r.top - margin;
+    // Prefer dropping down; flip up only when below can't fit a useful list and
+    // above has more room. Either way cap the height to the side we chose so the
+    // popover never runs past the viewport edge.
+    const flip = spaceBelow < 300 && spaceAbove > spaceBelow;
+    const maxHeight = Math.min(320, Math.max(140, flip ? spaceAbove : spaceBelow));
+    setRect({ left: r.left, top: flip ? r.top : r.bottom, width: r.width, flip, maxHeight });
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    reposition();
+    setQuery("");
+    setSelected(0);
+    const t = window.setTimeout(() => inputRef.current?.focus(), 0);
+    const onDown = (e: MouseEvent) => {
+      const n = e.target as Node;
+      if (popRef.current?.contains(n) || triggerRef.current?.contains(n)) return;
+      setOpen(false);
+    };
+    const onScroll = () => reposition();
+    document.addEventListener("mousedown", onDown);
+    window.addEventListener("scroll", onScroll, true);
+    window.addEventListener("resize", onScroll);
+    return () => {
+      window.clearTimeout(t);
+      document.removeEventListener("mousedown", onDown);
+      window.removeEventListener("scroll", onScroll, true);
+      window.removeEventListener("resize", onScroll);
+    };
+  }, [open, reposition]);
+
+  useEffect(() => { setSelected(0); }, [query]);
+
+  useEffect(() => {
+    if (!open || !listRef.current) return;
+    const active = listRef.current.querySelector<HTMLElement>(`[data-idx="${selected}"]`);
+    active?.scrollIntoView({ block: "nearest" });
+  }, [selected, open, rowCount]);
+
+  const close = () => {
+    setOpen(false);
+    setQuery("");
+    triggerRef.current?.focus();
+  };
+  const choose = (id: string | null) => {
+    void onSelect(id);
+    close();
+  };
+
+  const onInputKey: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
+    if (e.nativeEvent.isComposing || e.keyCode === 229) return;
+    if (e.key === "Escape") { e.preventDefault(); close(); return; }
+    if (e.key === "ArrowDown") { e.preventDefault(); if (rowCount) setSelected((i) => (i + 1) % rowCount); return; }
+    if (e.key === "ArrowUp") { e.preventDefault(); if (rowCount) setSelected((i) => (i - 1 + rowCount) % rowCount); return; }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (rowCount === 0) return;
+      if (showClear && selected === 0) { choose(null); return; }
+      const hit = results[selected - offset];
+      if (hit) choose(hit.id);
+    }
+  };
+
+  if (!canEdit) {
+    return (
+      <span className={className} style={{ fontFamily: "var(--font-fell)", ...style }}>
+        {current?.label ?? "—"}
+      </span>
+    );
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        ref={triggerRef}
+        className={`entity-combobox-trigger${className ? ` ${className}` : ""}`}
+        style={style}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+      >
+        {current && <Icon name={kindIcon[current.kind]} size={13} />}
+        <span className={`entity-combobox-value${current ? "" : " placeholder"}`}>
+          {current?.label ?? placeholder}
+        </span>
+        <Icon name="chevron" size={12} className="entity-combobox-caret" />
+      </button>
+      {open && rect && createPortal(
+        <div
+          ref={popRef}
+          className="entity-combobox-pop"
+          style={{
+            position: "fixed",
+            left: rect.left,
+            width: Math.max(rect.width, 240),
+            maxHeight: rect.maxHeight,
+            ...(rect.flip
+              ? { bottom: window.innerHeight - rect.top + 4 }
+              : { top: rect.top + 4 }),
+          }}
+        >
+          <div className="entity-combobox-input-row">
+            <Icon name="search" size={14} />
+            <input
+              ref={inputRef}
+              className="entity-combobox-input"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={onInputKey}
+              placeholder={placeholder}
+              spellCheck={false}
+              autoComplete="off"
+              role="combobox"
+              aria-expanded={rowCount > 0}
+              aria-controls="entity-combobox-listbox"
+              aria-activedescendant={rowCount > 0 ? `entity-combobox-opt-${selected}` : undefined}
+            />
+          </div>
+          <div className="entity-combobox-list" ref={listRef} role="listbox" id="entity-combobox-listbox">
+            {rowCount === 0 && <div className="entity-combobox-empty">Nothing matches.</div>}
+            {showClear && (
+              <div
+                data-idx={0}
+                id="entity-combobox-opt-0"
+                role="option"
+                aria-selected={selected === 0}
+                className={`entity-combobox-row clear${selected === 0 ? " active" : ""}`}
+                onMouseEnter={() => setSelected(0)}
+                onClick={() => choose(null)}
+              >
+                <span className="entity-combobox-row-label">— clear —</span>
+              </div>
+            )}
+            {results.map((hit, i) => {
+              const idx = i + offset;
+              return (
+                <div
+                  key={hit.id}
+                  data-idx={idx}
+                  id={`entity-combobox-opt-${idx}`}
+                  role="option"
+                  aria-selected={idx === selected}
+                  className={`entity-combobox-row${idx === selected ? " active" : ""}`}
+                  onMouseEnter={() => setSelected(idx)}
+                  onClick={() => choose(hit.id)}
+                >
+                  <Icon name={kindIcon[hit.kind]} size={14} />
+                  <span className={`entity-combobox-row-label${hit.archived ? " archived" : ""}`}>{hit.label}</span>
+                  <span className="entity-combobox-kind">{KIND_LABEL[hit.kind]}</span>
+                  {hit.archived && <span className="entity-combobox-archived">archived</span>}
+                </div>
+              );
+            })}
+          </div>
+        </div>,
+        document.body,
+      )}
+    </>
+  );
+}
+
 interface EntitySelectProps {
   value: string | undefined;
-  options: Array<{ id: string; label: string }>;
+  options: EntityOption[];
   onSave: (next: string | null) => void | Promise<void>;
   allowClear?: boolean;
   className?: string;
   style?: React.CSSProperties;
 }
 
-// EnumSelect's sibling for FK fields: options carry an id + display label and
-// onSave receives the id (or null when cleared).
+// EnumSelect's sibling for FK fields, now a thin wrapper over EntityCombobox so
+// single-kind FK pickers get the same type-to-filter UI as the relation picker.
 export function EntitySelect({
   value,
   options,
@@ -1040,41 +1269,15 @@ export function EntitySelect({
   className,
   style,
 }: EntitySelectProps) {
-  const { canEdit } = useAuth();
-  const current = options.find((o) => o.id === value);
-  if (!canEdit) {
-    return (
-      <span className={className} style={{ fontFamily: "var(--font-fell)", ...style }}>
-        {current?.label ?? "—"}
-      </span>
-    );
-  }
   return (
-    <select
+    <EntityCombobox
+      value={value}
+      options={options}
+      onSelect={onSave}
+      allowClear={allowClear}
+      placeholder="—"
       className={className}
-      // A dangling FK (option not in the list) renders as the empty choice
-      // rather than silently selecting the first option.
-      value={current ? value : ""}
-      onChange={(e) => {
-        const v = e.target.value;
-        void onSave(v === "" ? null : v);
-      }}
-      style={{
-        background: "transparent",
-        border: "1px dashed var(--ink-faded)",
-        fontFamily: "var(--font-fell)",
-        fontSize: "inherit",
-        color: "var(--ink)",
-        padding: "2px 6px",
-        cursor: "pointer",
-        maxWidth: "100%",
-        ...style,
-      }}
-    >
-      {(allowClear || !current) && <option value="">—</option>}
-      {options.map((o) => (
-        <option key={o.id} value={o.id}>{o.label}</option>
-      ))}
-    </select>
+      style={style}
+    />
   );
 }

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -182,13 +182,13 @@ function AddRelationForm({ fromId }: { fromId: string }) {
 
   const allOptions = useMemo(
     () => [
-      ...campaign.people.map((p) => ({ id: p.id, label: p.name, kind: "people" as const })),
-      ...campaign.locations.map((l) => ({ id: l.id, label: l.name, kind: "locations" as const })),
-      ...campaign.quests.map((q) => ({ id: q.id, label: q.title, kind: "quests" as const })),
-      ...campaign.goals.map((g) => ({ id: g.id, label: g.text, kind: "goals" as const })),
-      ...campaign.factions.map((f) => ({ id: f.id, label: f.name, kind: "factions" as const })),
-      ...campaign.items.map((i) => ({ id: i.id, label: i.name, kind: "items" as const })),
-      ...campaign.lore.map((l) => ({ id: l.id, label: l.title, kind: "lore" as const })),
+      ...campaign.people.map((p) => ({ id: p.id, label: p.name, kind: "people" as const, archived: p.archived })),
+      ...campaign.locations.map((l) => ({ id: l.id, label: l.name, kind: "locations" as const, archived: l.archived })),
+      ...campaign.quests.map((q) => ({ id: q.id, label: q.title, kind: "quests" as const, archived: q.archived })),
+      ...campaign.goals.map((g) => ({ id: g.id, label: g.text, kind: "goals" as const, archived: g.archived })),
+      ...campaign.factions.map((f) => ({ id: f.id, label: f.name, kind: "factions" as const, archived: f.archived })),
+      ...campaign.items.map((i) => ({ id: i.id, label: i.name, kind: "items" as const, archived: i.archived })),
+      ...campaign.lore.map((l) => ({ id: l.id, label: l.title, kind: "lore" as const, archived: l.archived })),
       ...campaign.sessions.map((s) => ({ id: s.id, label: s.title, kind: "sessions" as const })),
       ...campaign.arcs.map((a) => ({ id: a.id, label: a.title, kind: "arcs" as const })),
       ...campaign.events.map((e) => ({ id: e.id, label: e.title, kind: "events" as const })),
@@ -441,13 +441,22 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
       console.error(`updateEntity(${kind}) failed`, e),
     );
 
-  const arcOptions = campaign.arcs
-    .slice()
-    .sort((a, b) => a.orderNum - b.orderNum)
-    .map((a) => ({ id: a.id, label: a.title, kind: "arcs" as const }));
-  const sessionOptions = campaign.sessions
-    .map((s) => ({ id: s.id, label: `S${String(s.num).padStart(2, "0")} — ${s.title}`, kind: "sessions" as const }));
-  const locationOptions = campaign.locations.map((l) => ({ id: l.id, label: l.name, kind: "locations" as const }));
+  const arcOptions = useMemo(
+    () => campaign.arcs
+      .slice()
+      .sort((a, b) => a.orderNum - b.orderNum)
+      .map((a) => ({ id: a.id, label: a.title, kind: "arcs" as const })),
+    [campaign.arcs],
+  );
+  const sessionOptions = useMemo(
+    () => campaign.sessions
+      .map((s) => ({ id: s.id, label: `S${String(s.num).padStart(2, "0")} — ${s.title}`, kind: "sessions" as const })),
+    [campaign.sessions],
+  );
+  const locationOptions = useMemo(
+    () => campaign.locations.map((l) => ({ id: l.id, label: l.name, kind: "locations" as const, archived: l.archived })),
+    [campaign.locations],
+  );
 
   const onDelete = () => {
     if (!entity) return;

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState } from "react";
 import { type KindKey, entityLabel, isArchivableKind, isArchived, isPinned } from "./data";
 import { Icon, kindIcon } from "./icons";
-import { StatusChip, EditableText, EditableMarkdown, EnumSelect, EntitySelect } from "./components";
+import { StatusChip, EditableText, EditableMarkdown, EnumSelect, EntitySelect, EntityCombobox } from "./components";
 import { useCampaign, useFindEntity } from "./hooks";
 import { useAuth } from "./auth";
 import {
@@ -182,16 +182,16 @@ function AddRelationForm({ fromId }: { fromId: string }) {
 
   const allOptions = useMemo(
     () => [
-      ...campaign.people.map((p) => ({ id: p.id, label: p.name, kind: "people" })),
-      ...campaign.locations.map((l) => ({ id: l.id, label: l.name, kind: "locations" })),
-      ...campaign.quests.map((q) => ({ id: q.id, label: q.title, kind: "quests" })),
-      ...campaign.goals.map((g) => ({ id: g.id, label: g.text, kind: "goals" })),
-      ...campaign.factions.map((f) => ({ id: f.id, label: f.name, kind: "factions" })),
-      ...campaign.items.map((i) => ({ id: i.id, label: i.name, kind: "items" })),
-      ...campaign.lore.map((l) => ({ id: l.id, label: l.title, kind: "lore" })),
-      ...campaign.sessions.map((s) => ({ id: s.id, label: s.title, kind: "sessions" })),
-      ...campaign.arcs.map((a) => ({ id: a.id, label: a.title, kind: "arcs" })),
-      ...campaign.events.map((e) => ({ id: e.id, label: e.title, kind: "events" })),
+      ...campaign.people.map((p) => ({ id: p.id, label: p.name, kind: "people" as const })),
+      ...campaign.locations.map((l) => ({ id: l.id, label: l.name, kind: "locations" as const })),
+      ...campaign.quests.map((q) => ({ id: q.id, label: q.title, kind: "quests" as const })),
+      ...campaign.goals.map((g) => ({ id: g.id, label: g.text, kind: "goals" as const })),
+      ...campaign.factions.map((f) => ({ id: f.id, label: f.name, kind: "factions" as const })),
+      ...campaign.items.map((i) => ({ id: i.id, label: i.name, kind: "items" as const })),
+      ...campaign.lore.map((l) => ({ id: l.id, label: l.title, kind: "lore" as const })),
+      ...campaign.sessions.map((s) => ({ id: s.id, label: s.title, kind: "sessions" as const })),
+      ...campaign.arcs.map((a) => ({ id: a.id, label: a.title, kind: "arcs" as const })),
+      ...campaign.events.map((e) => ({ id: e.id, label: e.title, kind: "events" as const })),
     ].filter((o) => o.id !== fromId),
     [campaign, fromId],
   );
@@ -212,21 +212,13 @@ function AddRelationForm({ fromId }: { fromId: string }) {
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-      <select
-        value={targetId}
-        onChange={(e) => setTargetId(e.target.value)}
-        style={{
-          background: "transparent",
-          border: "1px dashed var(--ink-ghost)",
-          fontFamily: "var(--font-fell)", fontSize: 12, color: "var(--ink)",
-          padding: "6px 8px", cursor: "pointer",
-        }}
-      >
-        <option value="">— pick an entity —</option>
-        {allOptions.map((o) => (
-          <option key={o.id} value={o.id}>{o.kind}: {o.label}</option>
-        ))}
-      </select>
+      <EntityCombobox
+        value={targetId || undefined}
+        options={allOptions}
+        onSelect={(id) => setTargetId(id ?? "")}
+        placeholder="Search entities…"
+        style={{ fontSize: 12, padding: "6px 8px" }}
+      />
       <input
         value={label}
         onChange={(e) => setLabel(e.target.value)}
@@ -452,10 +444,10 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
   const arcOptions = campaign.arcs
     .slice()
     .sort((a, b) => a.orderNum - b.orderNum)
-    .map((a) => ({ id: a.id, label: a.title }));
+    .map((a) => ({ id: a.id, label: a.title, kind: "arcs" as const }));
   const sessionOptions = campaign.sessions
-    .map((s) => ({ id: s.id, label: `S${String(s.num).padStart(2, "0")} — ${s.title}` }));
-  const locationOptions = campaign.locations.map((l) => ({ id: l.id, label: l.name }));
+    .map((s) => ({ id: s.id, label: `S${String(s.num).padStart(2, "0")} — ${s.title}`, kind: "sessions" as const }));
+  const locationOptions = campaign.locations.map((l) => ({ id: l.id, label: l.name, kind: "locations" as const }));
 
   const onDelete = () => {
     if (!entity) return;

--- a/src/entitySearch.ts
+++ b/src/entitySearch.ts
@@ -1,0 +1,215 @@
+import { entityLabel, type Campaign, type KindKey } from "./data";
+
+// Shared entity search: the command palette and the entity combobox both index
+// the campaign and rank substring matches through this one implementation so
+// their behavior can't drift. The palette layers a party-notes pass on top of
+// the primary/secondary tiering here (see searchHits in commandPalette.tsx).
+
+export type MatchSource = "primary" | "secondary" | "note";
+
+export interface RankedHit {
+  id: string;
+  kind: KindKey;
+  label: string;
+  snippet?: string;
+  matchSource: MatchSource;
+  rank: 0 | 1 | 2 | 3;
+  archived?: boolean;
+}
+
+export const KIND_LABEL: Record<KindKey, string> = {
+  people: "Person",
+  locations: "Location",
+  quests: "Quest",
+  goals: "Goal",
+  factions: "Faction",
+  items: "Item",
+  lore: "Lore",
+  sessions: "Session",
+  arcs: "Arc",
+  events: "Event",
+};
+
+export interface Indexed {
+  id: string;
+  kind: KindKey;
+  label: string;
+  primary: string;
+  secondary: string;
+  archived?: boolean;
+}
+
+export function joinFields(...parts: Array<string | number | null | undefined>): string {
+  return parts.filter((p) => p !== undefined && p !== null && p !== "").join(" · ");
+}
+
+export function buildIndex(campaign: Campaign): Indexed[] {
+  const out: Indexed[] = [];
+  for (const p of campaign.people) {
+    out.push({
+      id: p.id,
+      kind: "people",
+      label: entityLabel(p),
+      primary: p.name ?? "",
+      secondary: joinFields(p.epithet, p.race, p.role, p.disposition, p.alignment, p.notes),
+      archived: p.archived,
+    });
+  }
+  for (const l of campaign.locations) {
+    out.push({
+      id: l.id,
+      kind: "locations",
+      label: entityLabel(l),
+      primary: l.name ?? "",
+      secondary: joinFields(l.kind, l.region, l.ruler, l.desc, l.notes),
+      archived: l.archived,
+    });
+  }
+  for (const q of campaign.quests) {
+    out.push({
+      id: q.id,
+      kind: "quests",
+      label: entityLabel(q),
+      primary: q.title ?? "",
+      secondary: joinFields(q.status, q.reward, q.desc, q.hooks),
+      archived: q.archived,
+    });
+  }
+  for (const g of campaign.goals) {
+    out.push({
+      id: g.id,
+      kind: "goals",
+      label: entityLabel(g),
+      primary: g.text ?? "",
+      secondary: joinFields(g.owner, g.kind, g.status),
+      archived: g.archived,
+    });
+  }
+  for (const f of campaign.factions) {
+    out.push({
+      id: f.id,
+      kind: "factions",
+      label: entityLabel(f),
+      primary: f.name ?? "",
+      secondary: joinFields(f.sigil, f.desc, f.allegiance),
+      archived: f.archived,
+    });
+  }
+  for (const i of campaign.items) {
+    out.push({
+      id: i.id,
+      kind: "items",
+      label: entityLabel(i),
+      primary: i.name ?? "",
+      secondary: joinFields(i.kind, i.desc),
+      archived: i.archived,
+    });
+  }
+  for (const lo of campaign.lore) {
+    out.push({
+      id: lo.id,
+      kind: "lore",
+      label: entityLabel(lo),
+      primary: lo.title ?? "",
+      secondary: lo.text ?? "",
+      archived: lo.archived,
+    });
+  }
+  for (const s of campaign.sessions) {
+    out.push({
+      id: s.id,
+      kind: "sessions",
+      label: entityLabel(s),
+      primary: s.title ?? "",
+      secondary: joinFields(s.date, s.inGameDate, `Session ${s.num}`, s.summary),
+    });
+  }
+  for (const a of campaign.arcs) {
+    out.push({
+      id: a.id,
+      kind: "arcs",
+      label: entityLabel(a),
+      primary: a.title ?? "",
+      secondary: a.summary ?? "",
+    });
+  }
+  for (const ev of campaign.events) {
+    out.push({
+      id: ev.id,
+      kind: "events",
+      label: entityLabel(ev),
+      primary: ev.title ?? "",
+      secondary: joinFields(ev.inGameDate, ev.summary),
+    });
+  }
+  return out;
+}
+
+export function makeSnippet(source: string, queryLower: string): string {
+  const idx = source.toLowerCase().indexOf(queryLower);
+  if (idx < 0) return source.slice(0, 90);
+  const start = Math.max(0, idx - 30);
+  const end = Math.min(source.length, idx + queryLower.length + 40);
+  const prefix = start > 0 ? "…" : "";
+  const suffix = end < source.length ? "…" : "";
+  const core = source.slice(start, end);
+  const snippet = `${prefix}${core}${suffix}`;
+  return snippet.length > 100 ? `${snippet.slice(0, 97)}…` : snippet;
+}
+
+// Keep only the strongest (lowest-rank) hit per entity id.
+export function keepBest(best: Map<string, RankedHit>, hit: RankedHit) {
+  const prev = best.get(hit.id);
+  if (!prev || hit.rank < prev.rank) best.set(hit.id, hit);
+}
+
+// Tier every entry by its primary field (startsWith → 0, includes → 1) then its
+// secondary field (includes → 2), writing the best hit per id into `best`. The
+// caller owns sorting, slicing, and any extra passes (e.g. party notes).
+export function rankEntities(index: Indexed[], queryLower: string, best: Map<string, RankedHit>) {
+  for (const e of index) {
+    const primary = e.primary.toLowerCase();
+    if (primary.startsWith(queryLower)) {
+      keepBest(best, { id: e.id, kind: e.kind, label: e.label, matchSource: "primary", rank: 0, archived: e.archived });
+      continue;
+    }
+    if (primary.includes(queryLower)) {
+      keepBest(best, { id: e.id, kind: e.kind, label: e.label, matchSource: "primary", rank: 1, archived: e.archived });
+      continue;
+    }
+    const secondary = e.secondary.toLowerCase();
+    if (secondary.includes(queryLower)) {
+      keepBest(best, {
+        id: e.id,
+        kind: e.kind,
+        label: e.label,
+        snippet: makeSnippet(e.secondary, queryLower),
+        matchSource: "secondary",
+        rank: 2,
+        archived: e.archived,
+      });
+    }
+  }
+}
+
+export function sortHits(best: Map<string, RankedHit>, limit: number): RankedHit[] {
+  return Array.from(best.values())
+    .sort((a, b) => a.rank - b.rank || a.label.localeCompare(b.label))
+    .slice(0, limit);
+}
+
+// Combobox ranker: substring tiering over an index, no notes pass. An empty
+// query returns the whole list alphabetically so the popover reads like a
+// normal dropdown before the user types.
+export function rankIndex(index: Indexed[], query: string, limit = 50): RankedHit[] {
+  const q = query.trim().toLowerCase();
+  if (!q) {
+    return index
+      .map((e): RankedHit => ({ id: e.id, kind: e.kind, label: e.label, matchSource: "primary", rank: 0, archived: e.archived }))
+      .sort((a, b) => a.label.localeCompare(b.label))
+      .slice(0, limit);
+  }
+  const best = new Map<string, RankedHit>();
+  rankEntities(index, q, best);
+  return sortHits(best, limit);
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -342,6 +342,95 @@ body {
   flex-shrink: 0;
 }
 
+/* Entity combobox — searchable picker for relations & FK fields. The trigger
+   reads like the dashed edit affordances (EnumSelect/EditableText); the popover
+   is portalled to <body> with fixed coords so it escapes the detail sheet's
+   overflow:auto and the overlay's backdrop-filter, sitting above them all. */
+.entity-combobox-trigger {
+  display: inline-flex; align-items: center; gap: 6px;
+  max-width: 100%;
+  background: transparent;
+  border: 1px dashed var(--ink-faded);
+  border-radius: 3px;
+  font-family: var(--font-fell);
+  font-size: inherit;
+  color: var(--ink);
+  padding: 2px 6px;
+  cursor: pointer;
+  text-align: left;
+}
+.entity-combobox-trigger > svg { flex-shrink: 0; color: var(--ink-faded); }
+.entity-combobox-caret { color: var(--ink-ghost); }
+.entity-combobox-value {
+  flex: 1; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.entity-combobox-value.placeholder { color: var(--ink-ghost); font-style: italic; }
+
+.entity-combobox-pop {
+  z-index: 90;
+  max-height: 320px;
+  display: flex; flex-direction: column;
+  background: var(--vellum-light);
+  border: 1px solid var(--ink-ghost);
+  border-radius: 3px;
+  box-shadow: var(--shadow-deep);
+  overflow: hidden;
+}
+.entity-combobox-input-row {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 10px;
+  color: var(--ink-faded);
+  border-bottom: 1px dashed var(--ink-ghost);
+}
+.entity-combobox-input {
+  flex: 1;
+  background: transparent; border: none; outline: none;
+  font-family: var(--font-fell); font-style: italic;
+  font-size: 14px; color: var(--ink);
+}
+.entity-combobox-input::placeholder { color: var(--ink-ghost); font-style: italic; }
+.entity-combobox-list { flex: 1; overflow-y: auto; padding: 4px 0; }
+.entity-combobox-empty {
+  padding: 12px 14px;
+  font-family: var(--font-fell); font-style: italic;
+  font-size: 13px; color: var(--ink-faded);
+}
+.entity-combobox-row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 6px 12px;
+  cursor: pointer;
+  border-left: 2px solid transparent;
+  font-family: var(--font-fell);
+  font-size: 14px; color: var(--ink);
+}
+.entity-combobox-row.active {
+  background: var(--paper-cream);
+  border-left-color: var(--bloodred);
+}
+.entity-combobox-row > svg { flex-shrink: 0; color: var(--ink-faded); }
+.entity-combobox-row-label {
+  flex: 1; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.entity-combobox-row-label.archived { opacity: .6; }
+.entity-combobox-row.clear .entity-combobox-row-label {
+  font-style: italic;
+  color: var(--ink-faded);
+}
+.entity-combobox-kind {
+  flex-shrink: 0;
+  font-family: var(--font-fell-sc); letter-spacing: .18em;
+  font-size: 10px; color: var(--ink-secondary);
+}
+.entity-combobox-archived {
+  flex-shrink: 0;
+  font-family: var(--font-fell-sc); letter-spacing: .12em;
+  font-size: 9px; color: var(--bloodred);
+  border: 1px solid var(--bloodred); border-radius: 2px;
+  padding: 0 3px;
+}
+
 /* Active-session pin (Topbar) — same chip language as the campaign picker. */
 .session-pin-picker { position: relative; }
 .session-pin {


### PR DESCRIPTION
## What & why

The **"Add Relation"** target picker and every **FK field** on the detail sheet were native `<select>` dropdowns. With a large cast (dozens of people, plus locations/quests/factions/…), that's a flat, unsearchable scroll — you couldn't type to find "Vecna" among 30 people — and the OS-rendered control broke the parchment aesthetic.

This replaces them with a **type-to-filter combobox**, reusing the search engine that already powers the command palette rather than adding a dependency or a second ranker.

## Changes

- **New `src/entitySearch.ts`** — extracts the palette's index + tiered substring ranker (`buildIndex`, `rankEntities`, `rankIndex`, `KIND_LABEL`, `makeSnippet`, `sortHits`) into a shared module so the palette and the picker share one implementation and can't drift. The palette keeps its party-notes pass layered on top; the local `KIND_ICON` dupe is dropped in favor of `kindIcon` from `icons.tsx`.
- **`EntityCombobox`** (`components.tsx`) — searchable popover: per-kind icons, kind badges, archived badges, keyboard nav (↑/↓/Enter/Esc), full ARIA (`combobox`/`listbox`/`option`), and `canEdit` gating (read-only viewers see plain text). Portalled to `<body>` and positioned against the trigger rect so it escapes the detail sheet's `overflow:auto` and the overlay's `backdrop-filter`; flips up and caps its height near the viewport edge so it never clips.
- **`EntitySelect`** is now a thin wrapper over `EntityCombobox`; FK option builders (`arcOptions`/`sessionOptions`/`locationOptions`) carry a `kind`.
- **`AddRelationForm`** uses the combobox directly (self-exclusion preserved).
- **`styles.css`** — `.entity-combobox*` styling on theme-aware variables (`--vellum-light`, `--ink`, `--ink-secondary` for the ≤14px contrast floor).

## Reviewer notes

- Filtering matches the approved scope: **self-exclusion only** — archived entities still appear (with a badge), already-connected entities are not hidden.
- Relation search is label-only by design (the combobox is generic over its option list); the command palette remains the place for secondary-field/notes search.
- The write path (`insertConnection`) and realtime flow are untouched — this is purely the picker UI.

## Verification

- `npm run build` (`tsc -b && vite build`) passes.
- Exercised in the browser preview (grimoire theme, editor session): search ranking (starts-with first), select/keyboard, self-exclusion (37 rows = 38 − self), FK field render via the wrapper, popover stays within the viewport at the bottom of the rail, command palette still returns secondary/notes matches with "On board" locate buttons, and read-only viewers get plain text with no picker. No test data was written to the campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)