### PR TITLE
Declutter pass 1: session tags, sidebar sessions, board toolbar

### DIFF
--- a/src/arcs.tsx
+++ b/src/arcs.tsx
@@ -85,9 +85,9 @@ export function ArcsPage({ onOpenEntity }: { onOpenEntity: (id: string) => void 
               )}
               <div style={{ display: "flex", flexDirection: "column", gap: 2, marginTop: 10 }}>
                 {assigned.map((s) => (
-                  <div key={s.id} className="session-chip" onClick={() => onOpenEntity(s.id)}>
-                    <span className="num">SESS {String(s.num).padStart(2, "0")}</span>
-                    <span style={{ flex: 1 }}>{s.title}</span>
+                  <div key={s.id} className="session-chip" onClick={() => onOpenEntity(s.id)} title={s.title}>
+                    <span className="num">S{String(s.num).padStart(2, "0")}</span>
+                    <span className="title">{s.title}</span>
                   </div>
                 ))}
                 {assigned.length === 0 && (
@@ -113,9 +113,9 @@ export function ArcsPage({ onOpenEntity }: { onOpenEntity: (id: string) => void 
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 2, marginTop: 8 }}>
               {unassigned.map((s) => (
-                <div key={s.id} className="session-chip" onClick={() => onOpenEntity(s.id)}>
-                  <span className="num">SESS {String(s.num).padStart(2, "0")}</span>
-                  <span style={{ flex: 1 }}>{s.title}</span>
+                <div key={s.id} className="session-chip" onClick={() => onOpenEntity(s.id)} title={s.title}>
+                  <span className="num">S{String(s.num).padStart(2, "0")}</span>
+                  <span className="title">{s.title}</span>
                 </div>
               ))}
             </div>

--- a/src/arcs.tsx
+++ b/src/arcs.tsx
@@ -1,4 +1,4 @@
-import { type Arc, type Session } from "./data";
+import { sessionLabel, type Arc, type Session } from "./data";
 import { useCampaign } from "./hooks";
 import { useAuth } from "./auth";
 import { createEntity } from "./mutations";
@@ -86,7 +86,7 @@ export function ArcsPage({ onOpenEntity }: { onOpenEntity: (id: string) => void 
               <div style={{ display: "flex", flexDirection: "column", gap: 2, marginTop: 10 }}>
                 {assigned.map((s) => (
                   <div key={s.id} className="session-chip" onClick={() => onOpenEntity(s.id)} title={s.title}>
-                    <span className="num">S{String(s.num).padStart(2, "0")}</span>
+                    <span className="num">{sessionLabel(s.num)}</span>
                     <span className="title">{s.title}</span>
                   </div>
                 ))}
@@ -114,7 +114,7 @@ export function ArcsPage({ onOpenEntity }: { onOpenEntity: (id: string) => void 
             <div style={{ display: "flex", flexDirection: "column", gap: 2, marginTop: 8 }}>
               {unassigned.map((s) => (
                 <div key={s.id} className="session-chip" onClick={() => onOpenEntity(s.id)} title={s.title}>
-                  <span className="num">S{String(s.num).padStart(2, "0")}</span>
+                  <span className="num">{sessionLabel(s.num)}</span>
                   <span className="title">{s.title}</span>
                 </div>
               ))}

--- a/src/board.tsx
+++ b/src/board.tsx
@@ -163,6 +163,15 @@ export function NoticeBoard({
 
   const toggleKind = (k: KindKey) => setFilters((f) => ({ ...f, [k]: !(f as any)[k] }));
 
+  // Alt-click isolates one kind; alt-click the lone survivor to restore all.
+  const soloKind = (k: KindKey) => setFilters((f) => {
+    const keys = kinds.map((x) => x.key);
+    const alreadySolo = keys.every((key) => (f as any)[key] === (key === k));
+    const next = { ...f };
+    keys.forEach((key) => { (next as any)[key] = alreadySolo ? true : key === k; });
+    return next;
+  });
+
   const onDragEnd = (id: string, newPos: { x: number; y: number }) => {
     if (!canEdit) return; // read-only: card snaps back on next render
     const base = positions[id];
@@ -189,6 +198,7 @@ export function NoticeBoard({
   };
 
   const [addMenuOpen, setAddMenuOpen] = useState(false);
+  const [viewMenuOpen, setViewMenuOpen] = useState(false);
 
   const onCreate = async (k: Exclude<KindKey, "sessions" | "arcs" | "events">) => {
     setAddMenuOpen(false);
@@ -429,40 +439,33 @@ export function NoticeBoard({
   return (
     <>
       <div className="board-toolbar">
-        <h1>The Notice Board <em>— last edit: just now, by Kael</em></h1>
+        <h1>The Notice Board</h1>
         <div style={{ flex: 1 }} />
 
-        <div className="filter-group">
-          {kinds.map((k) => (
-            <span
-              key={k.key}
-              className={`filter-pill ${(filters as any)[k.key] ? "active" : ""}`}
-              onClick={() => toggleKind(k.key)}
-            >
-              <span className="swatch" style={{ background: k.color }} />
-              {k.label}
-            </span>
-          ))}
+        <div className="filter-group bare">
+          {(() => {
+            // With every kind on (the rest state) the lit style carries no
+            // information — render all pills quiet, and only light/dim them
+            // once the set is actually filtered.
+            const allOn = kinds.every((k) => (filters as any)[k.key]);
+            return kinds.map((k) => {
+              const on = (filters as any)[k.key];
+              return (
+                <span
+                  key={k.key}
+                  className={`filter-pill ${on && !allOn ? "active" : ""} ${on ? "" : "off"}`}
+                  onClick={(e) => (e.altKey ? soloKind(k.key) : toggleKind(k.key))}
+                  title={`Toggle ${k.label.toLowerCase()} — ⌥-click to solo`}
+                >
+                  <span className="swatch" style={{ background: k.color }} />
+                  {k.label}
+                </span>
+              );
+            });
+          })()}
         </div>
 
-        <div className="filter-group">
-          <span
-            className={`filter-pill ${showArchived ? "active" : ""}`}
-            onClick={() => setShowArchived((v) => !v)}
-            title="Include archived cards on the board"
-          >
-            {showArchived ? "✓ Archived" : "Show archived"}
-          </span>
-          <span
-            className={`filter-pill ${showDerived ? "active" : ""}`}
-            onClick={() => setShowDerived((v) => !v)}
-            title="Show the dashed strings derived from relations (resides at, member of, quest giver)"
-          >
-            {showDerived ? "✓ Derived strings" : "Derived strings"}
-          </span>
-        </div>
-
-        <div className={`filter-group ${filters.sessions !== "all" ? "active" : ""}`}>
+        <div className={`filter-group ${filters.sessions !== "all" ? "active" : "bare"}`}>
           <select
             className="session-focus"
             value={filters.sessions}
@@ -481,8 +484,44 @@ export function NoticeBoard({
           </select>
         </div>
 
+        <div style={{ position: "relative" }}>
+          <button
+            className="btn btn-ghost"
+            onClick={() => setViewMenuOpen((o) => !o)}
+            title="View options: archived cards, derived strings"
+          >
+            <Icon name="eye" size={14} /> View
+          </button>
+          {viewMenuOpen && (
+            <>
+              <div
+                onClick={() => setViewMenuOpen(false)}
+                style={{ position: "fixed", inset: 0, zIndex: 40 }}
+              />
+              <div className="view-menu">
+                <label className="view-menu-row" title="Include archived cards on the board">
+                  <input
+                    type="checkbox"
+                    checked={showArchived}
+                    onChange={(e) => setShowArchived(e.target.checked)}
+                  />
+                  Show archived cards
+                </label>
+                <label className="view-menu-row" title="Show the dashed strings derived from relations (resides at, member of, quest giver)">
+                  <input
+                    type="checkbox"
+                    checked={showDerived}
+                    onChange={(e) => setShowDerived(e.target.checked)}
+                  />
+                  Derived strings
+                </label>
+              </div>
+            </>
+          )}
+        </div>
+
         {canEdit && <button
-          className="btn"
+          className="btn btn-ghost"
           onClick={onTidy}
           disabled={tidying}
           title="Auto-arrange the board: connected cards cluster, same-kind cards group, starred cards stay put"
@@ -491,7 +530,7 @@ export function NoticeBoard({
         </button>}
 
         {canEdit && <button
-          className={`btn ${connectMode ? "btn-primary" : ""}`}
+          className={`btn ${connectMode ? "btn-primary" : "btn-ghost"}`}
           onClick={() => { setConnectMode((m) => !m); setConnectSource(null); }}
           title="Draw a connection between two cards"
         >

--- a/src/board.tsx
+++ b/src/board.tsx
@@ -6,10 +6,10 @@ import {
   isArchivableKind,
 } from "./data";
 import { CompassRose, Icon, kindIcon } from "./icons";
-import { useCampaign, useFindEntity, useKinds } from "./hooks";
+import { useCampaign, useDismiss, useFindEntity, useKinds } from "./hooks";
 import { useAuth } from "./auth";
 import { CardBody, PinnedCard } from "./components";
-import { entityLabel } from "./data";
+import { entityLabel, sessionLabel } from "./data";
 import { computeTidyLayout, cardDims } from "./boardLayout";
 import { deriveRelations } from "./relations";
 import {
@@ -199,6 +199,10 @@ export function NoticeBoard({
 
   const [addMenuOpen, setAddMenuOpen] = useState(false);
   const [viewMenuOpen, setViewMenuOpen] = useState(false);
+  const addMenuRef = useRef<HTMLDivElement>(null);
+  const viewMenuRef = useRef<HTMLDivElement>(null);
+  useDismiss(addMenuRef, addMenuOpen, () => setAddMenuOpen(false));
+  useDismiss(viewMenuRef, viewMenuOpen, () => setViewMenuOpen(false));
 
   const onCreate = async (k: Exclude<KindKey, "sessions" | "arcs" | "events">) => {
     setAddMenuOpen(false);
@@ -436,36 +440,38 @@ export function NoticeBoard({
     if (rafRef.current) cancelAnimationFrame(rafRef.current);
   }, []);
 
+  // With every kind on (the rest state) the lit style carries no information —
+  // pills render quiet, and only light/dim once the set is actually filtered.
+  const allKindsOn = kinds.every((k) => (filters as any)[k.key]);
+  // Non-default view toggles get a dot on the View button so a filtered board
+  // is never silent about it.
+  const viewNonDefault = showArchived || !showDerived;
+
   return (
     <>
       <div className="board-toolbar">
         <h1>The Notice Board</h1>
         <div style={{ flex: 1 }} />
 
-        <div className="filter-group bare">
-          {(() => {
-            // With every kind on (the rest state) the lit style carries no
-            // information — render all pills quiet, and only light/dim them
-            // once the set is actually filtered.
-            const allOn = kinds.every((k) => (filters as any)[k.key]);
-            return kinds.map((k) => {
-              const on = (filters as any)[k.key];
-              return (
-                <span
-                  key={k.key}
-                  className={`filter-pill ${on && !allOn ? "active" : ""} ${on ? "" : "off"}`}
-                  onClick={(e) => (e.altKey ? soloKind(k.key) : toggleKind(k.key))}
-                  title={`Toggle ${k.label.toLowerCase()} — ⌥-click to solo`}
-                >
-                  <span className="swatch" style={{ background: k.color }} />
-                  {k.label}
-                </span>
-              );
-            });
-          })()}
+        <div className="filter-group">
+          {kinds.map((k) => {
+            const on = (filters as any)[k.key];
+            const cls = on ? (allKindsOn ? "" : " active") : " off";
+            return (
+              <span
+                key={k.key}
+                className={`filter-pill${cls}`}
+                onClick={(e) => (e.altKey ? soloKind(k.key) : toggleKind(k.key))}
+                title={`Toggle ${k.label.toLowerCase()} — Alt-click to solo`}
+              >
+                <span className="swatch" style={{ background: k.color }} />
+                {k.label}
+              </span>
+            );
+          })}
         </div>
 
-        <div className={`filter-group ${filters.sessions !== "all" ? "active" : "bare"}`}>
+        <div className={`filter-group${filters.sessions !== "all" ? " active" : ""}`}>
           <select
             className="session-focus"
             value={filters.sessions}
@@ -478,45 +484,40 @@ export function NoticeBoard({
               .sort((a, b) => b.num - a.num)
               .map((s) => (
                 <option key={s.id} value={s.id}>
-                  S{String(s.num).padStart(2, "0")} — {s.title}
+                  {sessionLabel(s.num)} — {s.title}
                 </option>
               ))}
           </select>
         </div>
 
-        <div style={{ position: "relative" }}>
+        <div style={{ position: "relative" }} ref={viewMenuRef}>
           <button
             className="btn btn-ghost"
             onClick={() => setViewMenuOpen((o) => !o)}
             title="View options: archived cards, derived strings"
           >
             <Icon name="eye" size={14} /> View
+            {viewNonDefault && <span className="view-dot" title="View options changed from default" />}
           </button>
           {viewMenuOpen && (
-            <>
-              <div
-                onClick={() => setViewMenuOpen(false)}
-                style={{ position: "fixed", inset: 0, zIndex: 40 }}
-              />
-              <div className="view-menu">
-                <label className="view-menu-row" title="Include archived cards on the board">
-                  <input
-                    type="checkbox"
-                    checked={showArchived}
-                    onChange={(e) => setShowArchived(e.target.checked)}
-                  />
-                  Show archived cards
-                </label>
-                <label className="view-menu-row" title="Show the dashed strings derived from relations (resides at, member of, quest giver)">
-                  <input
-                    type="checkbox"
-                    checked={showDerived}
-                    onChange={(e) => setShowDerived(e.target.checked)}
-                  />
-                  Derived strings
-                </label>
-              </div>
-            </>
+            <div className="view-menu">
+              <label className="view-menu-row" title="Include archived cards on the board">
+                <input
+                  type="checkbox"
+                  checked={showArchived}
+                  onChange={(e) => setShowArchived(e.target.checked)}
+                />
+                Show archived cards
+              </label>
+              <label className="view-menu-row" title="Show the dashed strings derived from relations (resides at, member of, quest giver)">
+                <input
+                  type="checkbox"
+                  checked={showDerived}
+                  onChange={(e) => setShowDerived(e.target.checked)}
+                />
+                Derived strings
+              </label>
+            </div>
           )}
         </div>
 
@@ -537,7 +538,7 @@ export function NoticeBoard({
           <Icon name="link" size={14} /> {connectMode ? "Cancel string" : "Draw string"}
         </button>}
 
-        {canEdit && <div style={{ position: "relative" }}>
+        {canEdit && <div style={{ position: "relative" }} ref={addMenuRef}>
           <button
             className="btn btn-primary"
             onClick={() => setAddMenuOpen((o) => !o)}
@@ -546,40 +547,19 @@ export function NoticeBoard({
             <Icon name="plus" size={14} /> Pin new
           </button>
           {addMenuOpen && (
-            <>
-              <div
-                onClick={() => setAddMenuOpen(false)}
-                style={{ position: "fixed", inset: 0, zIndex: 40 }}
-              />
-              <div
-                style={{
-                  position: "absolute", top: "100%", right: 0, marginTop: 6,
-                  background: "var(--vellum-light)", minWidth: 180,
-                  boxShadow: "0 8px 24px rgba(40,20,5,.25)",
-                  border: "1px solid var(--ink-faded)",
-                  fontFamily: "var(--font-fell)", fontSize: 13,
-                  zIndex: 50,
-                }}
-              >
-                {kinds.map((k) => (
-                  <div
-                    key={k.key}
-                    onClick={() => onCreate(k.key as Exclude<KindKey, "sessions" | "arcs" | "events">)}
-                    style={{
-                      display: "flex", alignItems: "center", gap: 10,
-                      padding: "8px 12px", cursor: "pointer",
-                      borderBottom: "1px solid rgba(40,20,5,.08)",
-                    }}
-                    onMouseEnter={(e) => { (e.currentTarget as HTMLDivElement).style.background = "rgba(40,20,5,.04)"; }}
-                    onMouseLeave={(e) => { (e.currentTarget as HTMLDivElement).style.background = "transparent"; }}
-                  >
-                    <span className="swatch" style={{ background: k.color, width: 10, height: 10, display: "inline-block", borderRadius: 2 }} />
-                    <Icon name={kindIcon[k.key]} size={14} />
-                    New {k.label.toLowerCase()}
-                  </div>
-                ))}
-              </div>
-            </>
+            <div className="view-menu" style={{ minWidth: 180 }}>
+              {kinds.map((k) => (
+                <div
+                  key={k.key}
+                  className="view-menu-row"
+                  onClick={() => onCreate(k.key as Exclude<KindKey, "sessions" | "arcs" | "events">)}
+                >
+                  <span className="swatch" style={{ background: k.color, width: 10, height: 10, display: "inline-block", borderRadius: 2 }} />
+                  <Icon name={kindIcon[k.key]} size={14} />
+                  New {k.label.toLowerCase()}
+                </div>
+              ))}
+            </div>
           )}
         </div>}
       </div>

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -206,7 +206,7 @@ export function PosterCard({ person }: { person: any }) {
         {person.race
           ? <span><strong>Race</strong> · {person.race}</span>
           : <span />}
-        {sess && <span>Sess {sess.num}</span>}
+        {sess && <span>S{sess.num}</span>}
       </div>
     </div>
   );
@@ -335,6 +335,9 @@ export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts 
   const totalArchived = kinds.reduce((sum, k) => sum + (counts[k.key]?.archived ?? 0), 0);
   // View filter, not a write — available to read-only viewers too.
   const [arcFilter, setArcFilter] = useState<string>("all");
+  // Progressive disclosure: the list is recency-biased, so only the newest
+  // few sessions render until expanded.
+  const [showAllSessions, setShowAllSessions] = useState(false);
   const arcsById = new Map(campaign.arcs.map((a) => [a.id, a]));
   // Fall back to "all" if the selected arc was deleted (possibly live, from
   // another tab) so the list and the select never disagree.
@@ -444,15 +447,17 @@ export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts 
           value={effectiveArcFilter}
           onChange={(e) => setArcFilter(e.target.value)}
           title="Filter sessions by arc"
+          // View control, not an edit affordance — dashed borders mean
+          // "editable" everywhere else, so this stays borderless.
           style={{
             margin: "2px 16px 6px",
             background: "transparent",
-            border: "1px dashed var(--ink-faded)",
-            fontFamily: "var(--font-fell)",
-            fontStyle: "italic",
-            fontSize: 12,
+            border: "none",
+            fontFamily: "var(--font-fell-sc)",
+            letterSpacing: ".08em",
+            fontSize: 11,
             color: "var(--ink-secondary)",
-            padding: "2px 6px",
+            padding: "2px 4px 2px 0",
             cursor: "pointer",
           }}
         >
@@ -462,12 +467,32 @@ export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts 
           ))}
         </select>
       )}
-      {visibleSessions.slice().reverse().map((s) => (
-        <div key={s.id} className="session-chip" onClick={() => onOpenEntity(s.id)}>
-          <span className="num">SESS {String(s.num).padStart(2, "0")}</span>
-          <span style={{ flex: 1 }}>{s.title}</span>
-        </div>
-      ))}
+      {(() => {
+        const SESSION_CAP = 8;
+        const newestFirst = visibleSessions.slice().reverse();
+        const shown = showAllSessions ? newestFirst : newestFirst.slice(0, SESSION_CAP);
+        const hidden = newestFirst.length - shown.length;
+        return (
+          <>
+            {shown.map((s) => (
+              <div key={s.id} className="session-chip" onClick={() => onOpenEntity(s.id)} title={s.title}>
+                <span className="num">S{String(s.num).padStart(2, "0")}</span>
+                <span className="title">{s.title}</span>
+              </div>
+            ))}
+            {hidden > 0 && (
+              <div className="session-more" onClick={() => setShowAllSessions(true)}>
+                … {hidden} earlier {hidden === 1 ? "session" : "sessions"}
+              </div>
+            )}
+            {showAllSessions && newestFirst.length > SESSION_CAP && (
+              <div className="session-more" onClick={() => setShowAllSessions(false)}>
+                show fewer
+              </div>
+            )}
+          </>
+        );
+      })()}
 
       <div style={{
         padding: "16px", marginTop: 12, borderTop: "1px dashed var(--vellum-deep)",

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { createPortal } from "react-dom";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { type KindKey, type PresenceUser } from "./data";
+import { sessionLabel, type KindKey, type PresenceUser } from "./data";
 import { Icon, MapScribble, kindIcon } from "./icons";
 import { rankIndex, KIND_LABEL, type Indexed } from "./entitySearch";
 import { useCampaign, useCampaignSwitcher, useKinds } from "./hooks";
@@ -206,7 +206,7 @@ export function PosterCard({ person }: { person: any }) {
         {person.race
           ? <span><strong>Race</strong> · {person.race}</span>
           : <span />}
-        {sess && <span>S{sess.num}</span>}
+        {sess && <span>{sessionLabel(sess.num)}</span>}
       </div>
     </div>
   );
@@ -328,6 +328,9 @@ interface SidebarProps {
   counts: Record<string, { active: number; archived: number }>;
 }
 
+// Sessions rendered before the "… N earlier sessions" fold.
+const SESSION_CAP = 8;
+
 export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts }: SidebarProps) {
   const campaign = useCampaign();
   const kinds = useKinds();
@@ -347,6 +350,19 @@ export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts 
     : campaign.sessions.filter((s) => s.arc === effectiveArcFilter);
   // Roster of people marked seen in the currently-live session.
   const liveSession = campaign.sessions.find((s) => s.id === campaign.activeSessionId);
+  // Newest first by num, not array order — realtime INSERTs append, so
+  // campaign.sessions isn't reliably sorted (same guard as arcs.tsx).
+  const newestFirst = visibleSessions.slice().sort((a, b) => b.num - a.num);
+  let shownSessions = newestFirst;
+  if (!showAllSessions) {
+    shownSessions = newestFirst.slice(0, SESSION_CAP);
+    // The live session stays one click away even when the cap would hide it
+    // (unless the arc filter excludes it — respect that).
+    if (liveSession && newestFirst.includes(liveSession) && !shownSessions.includes(liveSession)) {
+      shownSessions = [...shownSessions, liveSession];
+    }
+  }
+  const hiddenSessions = newestFirst.length - shownSessions.length;
   const seenThisSession = liveSession
     ? (campaign.sessionParticipants[liveSession.id] ?? [])
         .map((pid) => campaign.people.find((p) => p.id === pid))
@@ -467,32 +483,19 @@ export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts 
           ))}
         </select>
       )}
-      {(() => {
-        const SESSION_CAP = 8;
-        const newestFirst = visibleSessions.slice().reverse();
-        const shown = showAllSessions ? newestFirst : newestFirst.slice(0, SESSION_CAP);
-        const hidden = newestFirst.length - shown.length;
-        return (
-          <>
-            {shown.map((s) => (
-              <div key={s.id} className="session-chip" onClick={() => onOpenEntity(s.id)} title={s.title}>
-                <span className="num">S{String(s.num).padStart(2, "0")}</span>
-                <span className="title">{s.title}</span>
-              </div>
-            ))}
-            {hidden > 0 && (
-              <div className="session-more" onClick={() => setShowAllSessions(true)}>
-                … {hidden} earlier {hidden === 1 ? "session" : "sessions"}
-              </div>
-            )}
-            {showAllSessions && newestFirst.length > SESSION_CAP && (
-              <div className="session-more" onClick={() => setShowAllSessions(false)}>
-                show fewer
-              </div>
-            )}
-          </>
-        );
-      })()}
+      {shownSessions.map((s) => (
+        <div key={s.id} className="session-chip" onClick={() => onOpenEntity(s.id)} title={s.title}>
+          <span className="num">{sessionLabel(s.num)}</span>
+          <span className="title">{s.title}</span>
+        </div>
+      ))}
+      {(showAllSessions ? newestFirst.length > SESSION_CAP : hiddenSessions > 0) && (
+        <div className="session-more" onClick={() => setShowAllSessions((v) => !v)}>
+          {showAllSessions
+            ? "show fewer"
+            : `… ${hiddenSessions} earlier ${hiddenSessions === 1 ? "session" : "sessions"}`}
+        </div>
+      )}
 
       <div style={{
         padding: "16px", marginTop: 12, borderTop: "1px dashed var(--vellum-deep)",

--- a/src/data.ts
+++ b/src/data.ts
@@ -228,6 +228,12 @@ export function entityLabel(e: any): string {
   return e?.name || e?.title || e?.text || "—";
 }
 
+// The one place the "S07" session code is spelled — every surface (sidebar,
+// arcs page, board select, cards, detail stats) must agree on the format.
+export function sessionLabel(num: number): string {
+  return `S${String(num).padStart(2, "0")}`;
+}
+
 export function isArchived(e: any): boolean {
   return !!(e && e.archived);
 }

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -592,7 +592,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                     <Stat label="Reward" empty={!(entity as any).reward?.trim()} span={2} valueStyle={{ fontSize: 13 }}><EditableText value={(entity as any).reward ?? ""} onSave={(v) => patch({ reward: v })} placeholder="—" /></Stat>
                     <Stat label="Session" empty={!(entity as any).session}>{(() => {
                       const s = campaign.sessions.find((x) => x.id === (entity as any).session);
-                      return s ? `Sess ${s.num}` : (entity as any).session?.toUpperCase();
+                      return s ? `S${s.num}` : (entity as any).session?.toUpperCase();
                     })()}</Stat>
                     <Stat label="Arc" empty={!(entity as any).arc} span={2} valueStyle={{ fontSize: 13 }}><EntitySelect value={(entity as any).arc} options={arcOptions} allowClear onSave={(id) => patch({ arc: id ?? "" })} /></Stat>
                   </>

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from "react";
-import { type KindKey, entityLabel, isArchivableKind, isArchived, isPinned } from "./data";
+import { type KindKey, entityLabel, isArchivableKind, isArchived, isPinned, sessionLabel } from "./data";
 import { Icon, kindIcon } from "./icons";
 import { StatusChip, EditableText, EditableMarkdown, EnumSelect, EntitySelect, EntityCombobox } from "./components";
 import { useCampaign, useFindEntity } from "./hooks";
@@ -450,7 +450,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
   );
   const sessionOptions = useMemo(
     () => campaign.sessions
-      .map((s) => ({ id: s.id, label: `S${String(s.num).padStart(2, "0")} — ${s.title}`, kind: "sessions" as const })),
+      .map((s) => ({ id: s.id, label: `${sessionLabel(s.num)} — ${s.title}`, kind: "sessions" as const })),
     [campaign.sessions],
   );
   const locationOptions = useMemo(
@@ -592,7 +592,11 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                     <Stat label="Reward" empty={!(entity as any).reward?.trim()} span={2} valueStyle={{ fontSize: 13 }}><EditableText value={(entity as any).reward ?? ""} onSave={(v) => patch({ reward: v })} placeholder="—" /></Stat>
                     <Stat label="Session" empty={!(entity as any).session}>{(() => {
                       const s = campaign.sessions.find((x) => x.id === (entity as any).session);
-                      return s ? `S${s.num}` : (entity as any).session?.toUpperCase();
+                      // Short legacy codes ("s3") still display; a dangling
+                      // UUID FK (session deleted elsewhere) shows as absent
+                      // instead of 36 uppercase characters.
+                      const raw = (entity as any).session as string | undefined;
+                      return s ? sessionLabel(s.num) : raw && raw.length <= 8 ? raw.toUpperCase() : "—";
                     })()}</Stat>
                     <Stat label="Arc" empty={!(entity as any).arc} span={2} valueStyle={{ fontSize: 13 }}><EntitySelect value={(entity as any).arc} options={arcOptions} allowClear onSave={(id) => patch({ arc: id ?? "" })} /></Stat>
                   </>

--- a/src/events.tsx
+++ b/src/events.tsx
@@ -1,4 +1,4 @@
-import { type CampaignEvent } from "./data";
+import { sessionLabel, type CampaignEvent } from "./data";
 import { useCampaign } from "./hooks";
 import { useAuth } from "./auth";
 import { createEntity } from "./mutations";
@@ -82,7 +82,7 @@ export function EventsPage({ onOpenEntity }: { onOpenEntity: (id: string) => voi
                         {ev.title}
                       </h3>
                       <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".1em", fontSize: 10.5, color: "var(--ink-secondary)" }}>
-                        {session && `S${String(session.num).padStart(2, "0")}`}
+                        {session && sessionLabel(session.num)}
                         {location && `${session ? " · " : ""}${location.name}`}
                         {participants > 0 && ` · ${participants} present`}
                       </span>

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from "react";
+import { useContext, useEffect, useMemo, type RefObject } from "react";
 import { CampaignContext } from "./campaignContext";
 import { buildKinds, findEntity, type Campaign, type Entity } from "./data";
 
@@ -32,4 +32,26 @@ export function useFindEntity() {
       findEntity(campaign, id),
     [campaign],
   );
+}
+
+// Dropdown dismissal: outside mousedown or Escape closes. Unlike a fixed
+// backdrop this doesn't swallow the outside click and isn't trapped by the
+// opener's stacking context (the backdrop approach misses clicks on the
+// higher z-index topbar).
+export function useDismiss(ref: RefObject<HTMLElement>, active: boolean, onClose: () => void) {
+  useEffect(() => {
+    if (!active) return;
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [ref, active, onClose]);
 }

--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -5,7 +5,7 @@ type IconName =
   | "people" | "location" | "quest" | "goal" | "faction" | "item" | "lore"
   | "session" | "board" | "share" | "link" | "plus" | "search" | "filter"
   | "close" | "compass" | "sparkle" | "sword" | "scroll" | "layers"
-  | "check" | "chevron" | "trash";
+  | "check" | "chevron" | "trash" | "eye";
 
 interface IconProps extends Omit<SVGProps<SVGSVGElement>, "name"> {
   name: IconName;
@@ -48,6 +48,7 @@ export const Icon = ({ name, size = 16, ...p }: IconProps) => {
     case "check":     return <svg {...common}><path d="M5 12l4 4L19 6"/></svg>;
     case "chevron":   return <svg {...common}><path d="M9 6l6 6-6 6"/></svg>;
     case "trash":     return <svg {...common}><path d="M4 7h16M9 7V4h6v3M6 7l1 13h10l1-13"/></svg>;
+    case "eye":       return <svg {...common}><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6-10-6-10-6z"/><circle cx="12" cy="12" r="2.5"/></svg>;
     default: return null;
   }
 };

--- a/src/styles.css
+++ b/src/styles.css
@@ -656,7 +656,8 @@ button.session-pin { line-height: 1; }
   font-size: 11.5px;
   font-variant-numeric: tabular-nums;
   color: var(--ink-secondary);
-  flex: 0 0 36px;
+  /* Wide enough for 4-glyph codes (S191) so titles keep one left edge. */
+  flex: 0 0 42px;
 }
 .session-chip .title {
   flex: 1;
@@ -665,16 +666,17 @@ button.session-pin { line-height: 1; }
   overflow: hidden;
   text-overflow: ellipsis;
 }
-/* "… N earlier sessions" expander under the capped list. */
+/* "… N earlier sessions" expander under the capped list. Content text at
+   12.5px, so --ink-secondary is the floor (ink-tier rule in :root). */
 .session-more {
-  padding: 5px 16px 5px 64px;
+  padding: 5px 16px 5px 70px;
   font-family: var(--font-fell);
   font-style: italic;
   font-size: 12.5px;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
   cursor: pointer;
 }
-.session-more:hover { color: var(--ink-secondary); }
+.session-more:hover { color: var(--ink); }
 
 /* ── Main content area ───────────────────── */
 .main {
@@ -708,31 +710,14 @@ button.session-pin { line-height: 1; }
   white-space: nowrap;
   flex-shrink: 0;
 }
-.board-toolbar h1 em {
-  font-family: var(--font-fell);
-  font-style: italic;
-  font-weight: 400;
-  font-size: 14px;
-  color: var(--ink-secondary);
-  margin-left: 8px;
-  white-space: nowrap;
-}
-.filter-group { flex-wrap: wrap; }
-
+/* Borderless at rest: grouping comes from spacing, not chrome. The boxed look
+   is reserved for .active — a filter that's actually on. */
 .filter-group {
   display: flex; gap: 4px;
   padding: 3px;
-  background: var(--paper-cream);
-  border: 1px solid var(--vellum-deep);
+  border: 1px solid transparent;
   border-radius: 5px;
-}
-/* Borderless variant: grouping comes from spacing, not chrome. Used for the
-   kind pills (their active states are grouping enough) and the session focus
-   at rest — the boxed look is reserved for a filter that's actually on. */
-.filter-group.bare {
-  background: transparent;
-  border-color: transparent;
-  box-shadow: none;
+  flex-wrap: wrap;
 }
 .filter-pill {
   padding: 4px 10px;
@@ -749,7 +734,9 @@ button.session-pin { line-height: 1; }
 .filter-pill.off { opacity: .45; }
 .filter-pill.off:hover { opacity: .8; }
 .filter-pill.active {
-  background: var(--vellum-light);
+  /* paper-cream, not vellum-light — the pill sits directly on the
+     vellum-light toolbar now that the group box is gone. */
+  background: var(--paper-cream);
   color: var(--ink);
   border-color: var(--vellum-deep);
   box-shadow: 0 1px 2px rgba(40,20,5,.12);
@@ -775,7 +762,7 @@ button.session-pin { line-height: 1; }
 }
 .session-focus:hover { color: var(--ink); }
 .filter-group.active {
-  background: var(--vellum-light);
+  background: var(--paper-cream);
   border-color: var(--vellum-deep);
   box-shadow: 0 1px 2px rgba(40,20,5,.12);
 }
@@ -805,6 +792,12 @@ button.session-pin { line-height: 1; }
 }
 .view-menu-row:hover { background: rgba(139,94,40,.08); }
 .view-menu-row input[type="checkbox"] { accent-color: var(--bloodred); margin: 0; }
+/* Non-default view state marker on the View button. */
+.view-dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--bloodred);
+  flex-shrink: 0;
+}
 
 /* ── Notice board canvas ─────────────────── */
 .board-canvas {

--- a/src/styles.css
+++ b/src/styles.css
@@ -643,22 +643,38 @@ button.session-pin { line-height: 1; }
 /* Session chip in sidebar */
 .session-chip {
   display: flex; align-items: center; gap: 8px;
-  padding: 6px 16px 6px 20px;
+  padding: 5px 16px 5px 20px;
   font-family: var(--font-fell);
   font-size: 14.5px;
   color: var(--ink-body);
   cursor: pointer;
 }
 .session-chip:hover { background: rgba(139,94,40,.06); }
+/* Plain-text number column — no chip chrome, fixed width so titles align. */
 .session-chip .num {
   font-family: var(--font-fell-sc);
   font-size: 11.5px;
-  background: var(--paper-cream);
-  border: 1px solid var(--vellum-deep);
-  padding: 2px 6px;
-  border-radius: 3px;
-  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+  color: var(--ink-secondary);
+  flex: 0 0 36px;
 }
+.session-chip .title {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+/* "… N earlier sessions" expander under the capped list. */
+.session-more {
+  padding: 5px 16px 5px 64px;
+  font-family: var(--font-fell);
+  font-style: italic;
+  font-size: 12.5px;
+  color: var(--ink-faded);
+  cursor: pointer;
+}
+.session-more:hover { color: var(--ink-secondary); }
 
 /* ── Main content area ───────────────────── */
 .main {
@@ -710,17 +726,28 @@ button.session-pin { line-height: 1; }
   border: 1px solid var(--vellum-deep);
   border-radius: 5px;
 }
+/* Borderless variant: grouping comes from spacing, not chrome. Used for the
+   kind pills (their active states are grouping enough) and the session focus
+   at rest — the boxed look is reserved for a filter that's actually on. */
+.filter-group.bare {
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+}
 .filter-pill {
   padding: 4px 10px;
   font-family: var(--font-fell);
   font-size: 12px;
-  color: var(--ink-faded);
+  color: var(--ink-secondary);
   border-radius: 3px;
   cursor: pointer;
   display: inline-flex; align-items: center; gap: 5px;
   border: 1px solid transparent;
 }
 .filter-pill:hover { color: var(--ink); }
+/* Toggled-off kind while the board is filtered: visibly muted. */
+.filter-pill.off { opacity: .45; }
+.filter-pill.off:hover { opacity: .8; }
 .filter-pill.active {
   background: var(--vellum-light);
   color: var(--ink);
@@ -753,6 +780,31 @@ button.session-pin { line-height: 1; }
   box-shadow: 0 1px 2px rgba(40,20,5,.12);
 }
 .filter-group.active .session-focus { color: var(--ink); }
+
+/* View-options popover (board toolbar) — rare toggles live behind one ghost
+   button instead of a permanent pill group. */
+.view-menu {
+  position: absolute;
+  top: 100%; right: 0;
+  margin-top: 6px;
+  min-width: 200px;
+  background: var(--vellum-light);
+  border: 1px solid var(--ink-faded);
+  box-shadow: 0 8px 24px rgba(40,20,5,.25);
+  z-index: 50;
+  padding: 6px 0;
+}
+.view-menu-row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 7px 14px;
+  font-family: var(--font-fell);
+  font-size: 13px;
+  color: var(--ink);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.view-menu-row:hover { background: rgba(139,94,40,.08); }
+.view-menu-row input[type="checkbox"] { accent-color: var(--bloodred); margin: 0; }
 
 /* ── Notice board canvas ─────────────────── */
 .board-canvas {


### PR DESCRIPTION
First of two declutter PRs from the UI assessment. Structure changes only — no features removed, everything re-weighted.

## #48 — Quick wins
- `Sess nnn` / `SESS nnn` → `Snnn` everywhere a session *tag* appears (person cards, sidebar, arcs page, quest detail stat). The topbar LIVE pin keeps the spelled-out "SESSION n" since it's a headline.
- Removed the hardcoded fake byline *"— last edit: just now, by Kael"* from the board title.
- Sidebar session numbers are plain small-caps tabular numerals in a fixed column instead of ~30 bordered mini-chips.

## #49 — Sidebar sessions
- List caps at the 8 newest sessions with an italic *"… N earlier sessions"* expander (and *"show fewer"* to collapse).
- Titles are single-line with ellipsis + tooltip instead of wrapping to two lines.
- The arc filter loses its dashed border — dashed means "editable" everywhere else in the app; it now reads as the view control it is (small-caps, borderless).

## #50 — Board toolbar
- Kind filter pill group loses its outer border; grouping comes from spacing.
- Pills render quiet when **all** kinds are on (the rest state carries no information); once filtered, active pills light up and off pills dim.
- **Alt-click a pill to solo** that kind; alt-click the lone survivor to restore all.
- "Show archived" + "Derived strings" moved into a **View** popover (eye icon, ghost button) — same state, same semantics, one less permanent pill group.
- Tidy board / Draw string drop to ghost weight; **Pin new stays the only resting primary button**. Draw string still flips to primary while connect mode is armed.
- The session-focus box only shows its frame while a session is actually focused.

## Verification
- `npm run build` passes (tsc + vite).
- Verified in the browser preview against the Fist of Ilmater campaign: cap/expander (8 shown, "… 154 earlier sessions", expand → 162 rows → collapse), View popover toggles, alt-click solo/restore, plain pill toggle, session-focus bare↔active states. No console errors.

Closes #48, closes #49, closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)