### PR TITLE
Declutter pass 2: grimoire background, color discipline, card tweaks

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -185,12 +185,15 @@ export function PosterCard({ person }: { person: any }) {
   // itself lives on the detail sheet.
   const seenLive = !!campaign.activeSessionId
     && (campaign.sessionParticipants[campaign.activeSessionId] ?? []).includes(person.id);
+  // Allies dominate the board, so their band is noise — a band's presence is
+  // the signal (Wanted / Of Note), plain allies go headerless. Headerless
+  // cards get top clearance so the portrait sits below the pin-head and the
+  // seen-live dot instead of flush under them.
+  const headerless = person.disposition === "ally";
   return (
-    <div className="card-poster">
+    <div className={`card-poster${headerless ? " headerless" : ""}`}>
       {seenLive && <span className="seen-live-dot" title="Seen this session" />}
-      {/* Allies dominate the board, so their band is noise — a band's presence
-          is the signal (Wanted / Of Note), plain allies go headerless. */}
-      {person.disposition !== "ally" && (
+      {!headerless && (
         <div className="wanted">
           {person.disposition === "hostile" ? "✦ Wanted ✦" : "✦ Of Note ✦"}
         </div>

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -188,13 +188,13 @@ export function PosterCard({ person }: { person: any }) {
   return (
     <div className="card-poster">
       {seenLive && <span className="seen-live-dot" title="Seen this session" />}
-      <div className="wanted">
-        {person.disposition === "hostile"
-          ? "✦ Wanted ✦"
-          : person.disposition === "ally"
-          ? "✦ Known Ally ✦"
-          : "✦ Of Note ✦"}
-      </div>
+      {/* Allies dominate the board, so their band is noise — a band's presence
+          is the signal (Wanted / Of Note), plain allies go headerless. */}
+      {person.disposition !== "ally" && (
+        <div className="wanted">
+          {person.disposition === "hostile" ? "✦ Wanted ✦" : "✦ Of Note ✦"}
+        </div>
+      )}
       <div className="portrait">
         {person.imageUrl
           ? <img src={person.imageUrl} alt={person.name} className="portrait-img" />
@@ -401,13 +401,13 @@ export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts 
             key={k.key}
             className={`nav-item ${active === k.key ? "active" : ""}`}
             onClick={() => onSelect(k.key)}
+            // One number per row — the archive story lives in the tooltip and
+            // in "Tidy the Codex" below.
+            title={c.archived > 0 ? `${c.active} active · ${c.archived} archived` : undefined}
           >
             <span className="icon"><Icon name={kindIcon[k.key]} /></span>
             {k.label}
             <span className="count">{c.active}</span>
-            {c.archived > 0 && (
-              <span className="count-archived" title={`${c.archived} archived`}>+{c.archived}</span>
-            )}
           </div>
         );
       })}
@@ -692,8 +692,10 @@ export function Topbar({ onShare }: { onShare: () => void }) {
         <button className="btn" onClick={onShare}><Icon name="share" size={14} /> Share link</button>
         {canEdit ? (
           <>
+            {/* Functional micro-text, not flavor — the UI face reads better
+                than 12px italic serif. */}
             <span style={{
-              fontFamily: "var(--font-fell)", fontStyle: "italic",
+              fontFamily: "var(--font-ui)",
               fontSize: 12, color: "var(--ink-secondary)",
             }}>
               {displayName}

--- a/src/styles.css
+++ b/src/styles.css
@@ -88,8 +88,10 @@
   --paper-grey:    #23243c;
   --paper-scroll:  #2e2a48;
   --paper-note:    #363052;
-  --cork:          #3a2a40;
-  --cork-deep:     #241828;
+  /* A step darker than the card papers (#262847…#363052) so cards separate
+     from the board by luminance instead of chrome. */
+  --cork:          #332438;
+  --cork-deep:     #1f1522;
   --board-bg:      #1a1120;
   --teal-oxidized: #6bb5a5;
   /* These read as text/borders on dark card stock — the light-theme values
@@ -178,6 +180,18 @@ body {
   opacity: .45;
   mix-blend-mode: multiply;
   pointer-events: none;
+}
+
+/* Grimoire: the dot layers above are browns tuned for light cork — on the dark
+   board they read as high-frequency speckle that competes with the cards. Keep
+   only the low-frequency vignette and a whisper of noise; content, not the
+   background, should carry the contrast. */
+[data-theme="grimoire"] .tex-cork {
+  background-image: radial-gradient(ellipse at center, var(--cork) 0%, var(--cork-deep) 100%);
+  background-size: 100% 100%;
+}
+[data-theme="grimoire"] .tex-cork::after {
+  opacity: .18;
 }
 
 /* Paper stock: torn edges via clip-path */
@@ -475,7 +489,7 @@ button.session-pin { line-height: 1; }
   cursor: pointer;
   clip-path: polygon(4px 0, 100% 0, calc(100% - 4px) 100%, 0 100%);
 }
-.seen-toggle:hover { border-color: var(--bloodred); color: var(--bloodred); }
+.seen-toggle:hover { border-color: var(--mustard); color: var(--mustard-deep); }
 .seen-toggle.seen {
   background: var(--bloodred);
   border-color: var(--bloodred);
@@ -507,7 +521,9 @@ button.session-pin { line-height: 1; }
   cursor: pointer;
   white-space: nowrap;
 }
-.roster-chip:hover { border-color: var(--bloodred); color: var(--bloodred); }
+/* Hover is emphasis, not selection — mustard, so bloodred keeps meaning
+   "current/live/selected". */
+.roster-chip:hover { border-color: var(--mustard); color: var(--mustard-deep); }
 .session-roster-empty {
   padding: 0 16px 4px;
   font-family: var(--font-fell);
@@ -595,11 +611,6 @@ button.session-pin { line-height: 1; }
   padding: 8px 16px 4px;
   display: flex; align-items: center; justify-content: space-between;
 }
-.sidebar-label::before {
-  content: ''; flex: 0 0 14px; height: 1px;
-  background: var(--ink-faded);
-  margin-right: 8px; opacity: .4;
-}
 .sidebar-label span { flex: 1; }
 .sidebar-label::after {
   content: ''; flex: 1; height: 1px;
@@ -623,15 +634,13 @@ button.session-pin { line-height: 1; }
   border-left-color: var(--bloodred);
   color: var(--ink);
 }
+/* Plain text, no pill chrome — counts are reference info, not buttons. */
 .nav-item .count {
   margin-left: auto;
   font-family: var(--font-ui);
+  font-variant-numeric: tabular-nums;
   font-size: 11px;
   color: var(--ink-secondary);
-  background: var(--vellum-dark);
-  padding: 1px 7px;
-  border-radius: 10px;
-  border: 1px solid var(--vellum-deep);
 }
 .nav-item .icon {
   width: 16px; height: 16px;
@@ -841,6 +850,9 @@ button.session-pin { line-height: 1; }
   opacity: .3;
   transition: opacity .18s ease;
 }
+/* Resting strings only need to hint that a connection exists — on the dark
+   board the hover-lit behavior carries the focus, so rest even quieter. */
+[data-theme="grimoire"] .yarn-layer .yarn { opacity: .22; }
 .yarn-layer .yarn.lit { opacity: 1; }
 .yarn-layer .yarn.faded { opacity: .12; }
 .yarn-path {
@@ -992,7 +1004,12 @@ button.session-pin { line-height: 1; }
 }
 .card-poster .portrait {
   width: 100%; aspect-ratio: 1 / 1;
-  background: linear-gradient(135deg, var(--vellum-dark) 25%, var(--vellum) 50%, var(--vellum-dark) 75%);
+  /* Blended toward the card stock so portrait-less cards recede — cards with
+     real art should be the bright ones. */
+  background: linear-gradient(135deg,
+    color-mix(in srgb, var(--vellum-dark) 55%, var(--paper-scroll)) 25%,
+    color-mix(in srgb, var(--vellum) 45%, var(--paper-scroll)) 50%,
+    color-mix(in srgb, var(--vellum-dark) 55%, var(--paper-scroll)) 75%);
   background-size: 6px 6px;
   border: 1px solid var(--ink-faded);
   display: grid; place-items: center;
@@ -1006,7 +1023,7 @@ button.session-pin { line-height: 1; }
   position: absolute; bottom: 0; left: 50%;
   transform: translateX(-50%);
   background: var(--ink);
-  opacity: .8;
+  opacity: .45;
   -webkit-mask: radial-gradient(circle at 50% 22%, #000 17%, transparent 17.5%) no-repeat,
                 radial-gradient(ellipse 60% 80% at 50% 90%, #000 55%, transparent 56%) no-repeat;
           mask: radial-gradient(circle at 50% 22%, #000 17%, transparent 17.5%) no-repeat,
@@ -1402,7 +1419,7 @@ button.session-pin { line-height: 1; }
   width: 70%; height: 80%;
   transform: translateX(-50%);
   background: var(--ink);
-  opacity: .75;
+  opacity: .5;
   -webkit-mask: radial-gradient(circle at 50% 22%, #000 17%, transparent 17.5%) no-repeat,
                 radial-gradient(ellipse 60% 80% at 50% 90%, #000 55%, transparent 56%) no-repeat;
           mask: radial-gradient(circle at 50% 22%, #000 17%, transparent 17.5%) no-repeat,
@@ -1799,6 +1816,7 @@ button.session-pin { line-height: 1; }
 .board-zoom button:hover { background: var(--vellum-light); }
 .board-zoom .zoom-val {
   font-family: var(--font-ui);
+  font-variant-numeric: tabular-nums;
   font-size: 11px;
   text-align: center;
   padding: 4px 0;

--- a/src/styles.css
+++ b/src/styles.css
@@ -850,9 +850,6 @@ button.session-pin { line-height: 1; }
   opacity: .3;
   transition: opacity .18s ease;
 }
-/* Resting strings only need to hint that a connection exists — on the dark
-   board the hover-lit behavior carries the focus, so rest even quieter. */
-[data-theme="grimoire"] .yarn-layer .yarn { opacity: .22; }
 .yarn-layer .yarn.lit { opacity: 1; }
 .yarn-layer .yarn.faded { opacity: .12; }
 .yarn-path {
@@ -985,6 +982,9 @@ button.session-pin { line-height: 1; }
   position: relative;
   border: 1px solid var(--card-edge);
 }
+/* Headerless (ally) cards have no band to sit under the pin-head / seen dot,
+   so add the clearance the band used to provide before the portrait. */
+.card-poster.headerless { padding-top: 22px; }
 .card-poster::before {
   /* torn top edge */
   content: '';
@@ -1005,7 +1005,9 @@ button.session-pin { line-height: 1; }
 .card-poster .portrait {
   width: 100%; aspect-ratio: 1 / 1;
   /* Blended toward the card stock so portrait-less cards recede — cards with
-     real art should be the bright ones. */
+     real art should be the bright ones. Plain-gradient fallback first so
+     engines without color-mix() still get a placeholder (not a void). */
+  background: linear-gradient(135deg, var(--vellum-dark) 25%, var(--vellum) 50%, var(--vellum-dark) 75%);
   background: linear-gradient(135deg,
     color-mix(in srgb, var(--vellum-dark) 55%, var(--paper-scroll)) 25%,
     color-mix(in srgb, var(--vellum) 45%, var(--paper-scroll)) 50%,
@@ -1419,7 +1421,9 @@ button.session-pin { line-height: 1; }
   width: 70%; height: 80%;
   transform: translateX(-50%);
   background: var(--ink);
-  opacity: .5;
+  /* Kept fairly present — on the detail sheet the silhouette is the
+     "upload a portrait" affordance, not board clutter to recede. */
+  opacity: .65;
   -webkit-mask: radial-gradient(circle at 50% 22%, #000 17%, transparent 17.5%) no-repeat,
                 radial-gradient(ellipse 60% 80% at 50% 90%, #000 55%, transparent 56%) no-repeat;
           mask: radial-gradient(circle at 50% 22%, #000 17%, transparent 17.5%) no-repeat,


### PR DESCRIPTION
Second declutter PR (structure pass merged in #54). Rebased onto `main` after #54 squash-merged.

## #51 — Grimoire board background
- Grimoire cork drops the five brown dot layers (light-cork speckle on the dark board), keeping only the low-frequency vignette plus a whisper of noise.
- Grimoire `--cork`/`--cork-deep` darkened a step so cards separate by luminance.
- (Grimoire resting-yarn tweak was reverted per code review — it compressed the hover-dim wayfinding gap.)

## #52 — Color & typography readability
- roster-chip / seen-toggle hovers move from bloodred to mustard, so bloodred keeps meaning *current / live / selected*.
- Topbar display name uses the UI face at `--ink-secondary` instead of 12px italic serif.
- Empty portraits recede (card silhouette .45; placeholder blended toward card stock, with a plain-gradient fallback for engines without `color-mix()`); detail-sheet silhouette kept at .65 as the upload affordance.
- Tabular numerals on sidebar counts and the zoom readout.

## #53 — Misc declutter
- Sidebar counts lose the pill chrome and the always-visible `+N` archived tag (archive info in the row tooltip; Tidy the Codex panel still lists per-kind archived).
- Section labels keep only the trailing rule.
- Person cards show a disposition band only for Wanted / Of Note; ally cards go headerless with top clearance so the pin-head/seen-dot clear the portrait.

## Verification
- `npm run build` passes.
- Browser-verified on grimoire (calm background, card separation, headerless allies clear the pin-head) and default parchment (unchanged). No console errors.

Closes #51, closes #52, closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)