### PR TITLE
Tag event chips in the relations rail with their session

### DIFF
--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -339,6 +339,8 @@ interface DetailSheetProps {
 interface Related {
   entity: any;
   rel: string;
+  // Optional context tag shown after the relation verb (e.g. an event's session).
+  tag?: string;
 }
 
 export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
@@ -424,13 +426,18 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
             ? (ev: any) => ev.session === entityId && "during this session"
             : null;
     if (eventRel) {
+      const sessionsById = new Map(campaign.sessions.map((s) => [s.id, s]));
       // Array order isn't trustworthy after realtime splices — sort by orderNum.
       campaign.events.slice().sort((a, b) => a.orderNum - b.orderNum).forEach((ev) => {
         const rel = eventRel(ev);
         if (!rel) return;
         related.events = related.events || [];
         if (!related.events.find((r) => r.entity.id === ev.id)) {
-          related.events.push({ entity: findEntity(ev.id), rel });
+          // Tag the chip with the event's session (its temporal anchor), the way
+          // the Chronicle page labels each event — skip on a session's own sheet
+          // where every chip would restate that session.
+          const sess = kind !== "sessions" && ev.session ? sessionsById.get(ev.session) : undefined;
+          related.events.push({ entity: findEntity(ev.id), rel, tag: sess ? sessionLabel(sess.num) : undefined });
         }
       });
     }
@@ -820,7 +827,10 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                         <div className="rc-icon"><Icon name={kindIcon[k]} size={14} /></div>
                         <div style={{ flex: 1 }}>
                           <div className="rc-name">{entityLabel(r.entity)}</div>
-                          <div className="rc-rel">{r.rel}</div>
+                          <div className="rc-rel">
+                            {r.rel}
+                            {r.tag && <span className="rc-tag">{r.tag}</span>}
+                          </div>
                         </div>
                         <Icon name="chevron" size={12} />
                       </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1683,6 +1683,15 @@ button.session-pin { line-height: 1; }
   letter-spacing: .08em;
   color: var(--ink-secondary);
 }
+.rail-chip .rc-rel .rc-tag {
+  margin-left: 6px;
+  padding: 0 5px;
+  border-radius: 3px;
+  background: var(--paper-note);
+  border: 1px solid var(--ink-ghost);
+  color: var(--ink-secondary);
+  letter-spacing: .06em;
+}
 .rail-chip.people  { border-left-color: var(--bloodred); }
 .rail-chip.locations { border-left-color: var(--teal-deep); }
 .rail-chip.quests  { border-left-color: var(--mustard); }


### PR DESCRIPTION
## What

Event chips in the detail sheet's **Relations** rail now carry a small session pill after the relation verb — e.g. `TOOK PART IN · S57`. On a person's sheet you can now see *which session* each event happened in without opening it.

## Why

Every event has a dedicated `session_id` ([0009_events.sql:9](supabase/migrations/0009_events.sql)) — it's already surfaced on the Chronicle page ([events.tsx:85](src/events.tsx)) but the relations rail only showed the event title + relation verb, dropping the temporal anchor. This closes that gap and keeps the two surfaces consistent.

## How

- Added an optional `tag` to the `Related` type and populated it with `sessionLabel(ev.session…)` when building `related.events`, via a `sessionsById` map at render time.
- Rendered it as a `.rc-tag` span inside `.rc-rel`.
- **Suppressed on a session's own sheet** (`kind !== "sessions"`) — there every event shares that one session, so a tag would just restate the sheet you're on.

Display-only: the relations projection ([relations.ts](src/relations.ts)) and the DB are untouched. The `.rc-tag` pill uses theme-aware CSS variables (`--paper-note`, `--ink-ghost`, `--ink-secondary`) so it holds up on both grimoire and vellum.

## Notes for reviewer

- Session chips themselves are intentionally **not** tagged — a chip in the "Sessions" group *is* a session, so a tag would be redundant. (Separately, those chips still show only the session title, not its `Snn` number — left out of scope.)
- Verified in the browser against the Fist of Ilmater campaign: Mort's sheet shows 20 event chips each tagged with the correct session (`S35`, `S44`, `S57`…); a session sheet shows its event chip with no tag. `npm run build` passes.