### PR TITLE
Person tier & status: migration 0014, detail-sheet fields, dead marker

### DIFF
--- a/src/campaignContext.tsx
+++ b/src/campaignContext.tsx
@@ -46,6 +46,8 @@ const mapPerson = (r: any) => ({
   role: r.role ?? undefined,
   disposition: r.disposition ?? undefined,
   alignment: r.alignment ?? undefined,
+  tier: r.tier ?? undefined,
+  status: r.status ?? undefined,
   location: r.location_id ?? undefined,
   faction: r.faction_id ?? undefined,
   lastSeen: r.last_seen_session_id ?? undefined,

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -203,7 +203,8 @@ export function PosterCard({ person }: { person: any }) {
           ? <img src={person.imageUrl} alt={person.name} className="portrait-img" />
           : <span className="silhouette" />}
       </div>
-      <div className="name">{person.name}</div>
+      <div className={`name${person.status === "dead" ? " is-dead" : ""}`}>{person.name}</div>
+      {person.status === "dead" && <div className="deceased-tag">† deceased</div>}
       {!!person.epithet?.trim() && <div className="desc">— {person.epithet}</div>}
       <div className="reward">
         {person.race

--- a/src/data.ts
+++ b/src/data.ts
@@ -2,7 +2,7 @@ export type Status = "whispered" | "pursuing" | "resolved" | "lost";
 
 // People-only enums (Status above belongs to quests/goals). Tier is the
 // information-overload valve: background folk stay searchable and connectable
-// but are hidden behind a reveal in the list and get no board card by default.
+// while the list reveal and board-card gating (follow-up PRs) tuck them away.
 export type PersonTier = "major" | "supporting" | "background";
 export type PersonStatus = "alive" | "dead" | "missing" | "unknown";
 export const PERSON_TIER_OPTIONS = ["major", "supporting", "background"] as const;

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,4 +1,12 @@
 export type Status = "whispered" | "pursuing" | "resolved" | "lost";
+
+// People-only enums (Status above belongs to quests/goals). Tier is the
+// information-overload valve: background folk stay searchable and connectable
+// but are hidden behind a reveal in the list and get no board card by default.
+export type PersonTier = "major" | "supporting" | "background";
+export type PersonStatus = "alive" | "dead" | "missing" | "unknown";
+export const PERSON_TIER_OPTIONS = ["major", "supporting", "background"] as const;
+export const PERSON_STATUS_OPTIONS = ["alive", "dead", "missing", "unknown"] as const;
 export type KindKey =
   | "people"
   | "locations"
@@ -60,6 +68,8 @@ export interface Person extends ArchivableFields {
   role?: string;
   disposition?: string;
   alignment?: string;
+  tier?: PersonTier;
+  status?: PersonStatus;
   location?: string;
   faction?: string;
   lastSeen?: string;
@@ -240,6 +250,13 @@ export function isArchived(e: any): boolean {
 
 export function isPinned(e: any): boolean {
   return !!(e && e.pinned);
+}
+
+// Null tier reads as major: existing rows predate the column and every curated
+// person should count as major without a backfill. Always read tier through
+// this helper, never `p.tier` directly.
+export function personTier(p: { tier?: PersonTier }): PersonTier {
+  return p.tier ?? "major";
 }
 
 // Quest/goal status ordering: active work floats up, abandoned sinks. Unknown

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from "react";
-import { type KindKey, entityLabel, isArchivableKind, isArchived, isPinned, sessionLabel } from "./data";
+import { type KindKey, PERSON_STATUS_OPTIONS, PERSON_TIER_OPTIONS, entityLabel, isArchivableKind, isArchived, isPinned, sessionLabel } from "./data";
 import { Icon, kindIcon } from "./icons";
 import { StatusChip, EditableText, EditableMarkdown, EnumSelect, EntitySelect, EntityCombobox } from "./components";
 import { useCampaign, useFindEntity } from "./hooks";
@@ -464,6 +464,10 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
     () => campaign.locations.map((l) => ({ id: l.id, label: l.name, kind: "locations" as const, archived: l.archived })),
     [campaign.locations],
   );
+  const factionOptions = useMemo(
+    () => campaign.factions.map((f) => ({ id: f.id, label: f.name, kind: "factions" as const, archived: f.archived })),
+    [campaign.factions],
+  );
 
   const onDelete = () => {
     if (!entity) return;
@@ -584,6 +588,11 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                     <Stat label="Role" empty={!(entity as any).role?.trim()} valueStyle={{ fontSize: 14 }}><EditableText value={(entity as any).role ?? ""} onSave={(v) => patch({ role: v })} placeholder="—" /></Stat>
                     <Stat label="Disposition" empty={!(entity as any).disposition} valueStyle={{ textTransform: "capitalize" }}><EnumSelect value={(entity as any).disposition} options={DISPOSITION_OPTIONS} allowClear onSave={(v) => patch({ disposition: v })} /></Stat>
                     <Stat label="Alignment" empty={!(entity as any).alignment?.trim()} valueStyle={{ fontSize: 13 }}><EditableText value={(entity as any).alignment ?? ""} onSave={(v) => patch({ alignment: v })} placeholder="—" /></Stat>
+                    {/* No allowClear on tier: null already reads as major (personTier), so a clear would be indistinguishable. */}
+                    <Stat label="Tier" empty={!(entity as any).tier} valueStyle={{ textTransform: "capitalize" }}><EnumSelect value={(entity as any).tier ?? "major"} options={PERSON_TIER_OPTIONS} onSave={(v) => patch({ tier: v })} /></Stat>
+                    <Stat label="Status" empty={!(entity as any).status} valueStyle={{ textTransform: "capitalize" }}><EnumSelect value={(entity as any).status} options={PERSON_STATUS_OPTIONS} allowClear onSave={(v) => patch({ status: v })} /></Stat>
+                    <Stat label="Faction" empty={!(entity as any).faction} valueStyle={{ fontSize: 13 }}><EntitySelect value={(entity as any).faction} options={factionOptions} allowClear onSave={(id) => patch({ faction: id ?? "" })} /></Stat>
+                    <Stat label="Location" empty={!(entity as any).location} valueStyle={{ fontSize: 13 }}><EntitySelect value={(entity as any).location} options={locationOptions} allowClear onSave={(id) => patch({ location: id ?? "" })} /></Stat>
                   </>
                 )}
                 {kind === "locations" && (

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from "react";
-import { type KindKey, PERSON_STATUS_OPTIONS, PERSON_TIER_OPTIONS, entityLabel, isArchivableKind, isArchived, isPinned, sessionLabel } from "./data";
+import { type KindKey, PERSON_STATUS_OPTIONS, PERSON_TIER_OPTIONS, entityLabel, isArchivableKind, isArchived, isPinned, personTier, sessionLabel } from "./data";
 import { Icon, kindIcon } from "./icons";
 import { StatusChip, EditableText, EditableMarkdown, EnumSelect, EntitySelect, EntityCombobox } from "./components";
 import { useCampaign, useFindEntity } from "./hooks";
@@ -588,8 +588,10 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                     <Stat label="Role" empty={!(entity as any).role?.trim()} valueStyle={{ fontSize: 14 }}><EditableText value={(entity as any).role ?? ""} onSave={(v) => patch({ role: v })} placeholder="—" /></Stat>
                     <Stat label="Disposition" empty={!(entity as any).disposition} valueStyle={{ textTransform: "capitalize" }}><EnumSelect value={(entity as any).disposition} options={DISPOSITION_OPTIONS} allowClear onSave={(v) => patch({ disposition: v })} /></Stat>
                     <Stat label="Alignment" empty={!(entity as any).alignment?.trim()} valueStyle={{ fontSize: 13 }}><EditableText value={(entity as any).alignment ?? ""} onSave={(v) => patch({ alignment: v })} placeholder="—" /></Stat>
-                    {/* No allowClear on tier: null already reads as major (personTier), so a clear would be indistinguishable. */}
-                    <Stat label="Tier" empty={!(entity as any).tier} valueStyle={{ textTransform: "capitalize" }}><EnumSelect value={(entity as any).tier ?? "major"} options={PERSON_TIER_OPTIONS} onSave={(v) => patch({ tier: v })} /></Stat>
+                    {/* No allowClear on tier: null already reads as major (personTier), so a clear would be
+                        indistinguishable. The no-op guard keeps re-picking the shown value from writing an
+                        explicit 'major' — that would flip the stat permanently visible to viewers. */}
+                    <Stat label="Tier" empty={!(entity as any).tier} valueStyle={{ textTransform: "capitalize" }}><EnumSelect value={personTier(entity as any)} options={PERSON_TIER_OPTIONS} onSave={(v) => { if (v !== personTier(entity as any)) patch({ tier: v }); }} /></Stat>
                     <Stat label="Status" empty={!(entity as any).status} valueStyle={{ textTransform: "capitalize" }}><EnumSelect value={(entity as any).status} options={PERSON_STATUS_OPTIONS} allowClear onSave={(v) => patch({ status: v })} /></Stat>
                     <Stat label="Faction" empty={!(entity as any).faction} valueStyle={{ fontSize: 13 }}><EntitySelect value={(entity as any).faction} options={factionOptions} allowClear onSave={(id) => patch({ faction: id ?? "" })} /></Stat>
                     <Stat label="Location" empty={!(entity as any).location} valueStyle={{ fontSize: 13 }}><EntitySelect value={(entity as any).location} options={locationOptions} allowClear onSave={(id) => patch({ location: id ?? "" })} /></Stat>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1046,6 +1046,18 @@ button.session-pin { line-height: 1; }
   margin-top: 10px;
   color: var(--ink);
 }
+.card-poster .name.is-dead {
+  text-decoration: line-through;
+  text-decoration-color: var(--bloodred);
+}
+/* Colors follow .status-chip.lost so the mark stays legible on grimoire. */
+.card-poster .deceased-tag {
+  font-family: var(--font-fell-sc);
+  font-size: 10px;
+  letter-spacing: .18em;
+  text-align: center;
+  color: var(--bloodred-deep);
+}
 .card-poster .desc {
   font-family: var(--font-fell);
   font-style: italic; /* epithet — attribution voice, italic on purpose */

--- a/supabase/migrations/0014_person_tier_status.sql
+++ b/supabase/migrations/0014_person_tier_status.sql
@@ -1,0 +1,19 @@
+-- NPC tiers (major/supporting/background) and life status, for bulk rosters.
+-- Both nullable: null tier reads as 'major' in the app; null status is "unset".
+-- RLS from 0003/0006 already covers people; plain column adds need no policy.
+
+alter table public.people
+  add column if not exists tier   text,
+  add column if not exists status text;
+
+alter table public.people
+  drop constraint if exists people_tier_check;
+alter table public.people
+  add constraint people_tier_check
+    check (tier is null or tier in ('major', 'supporting', 'background'));
+
+alter table public.people
+  drop constraint if exists people_status_check;
+alter table public.people
+  add constraint people_status_check
+    check (status is null or status in ('alive', 'dead', 'missing', 'unknown'));


### PR DESCRIPTION
## Summary

First PR of the NPC-roster feature (DM wants to bulk-add 100+ NPCs without information overload). One `people` kind, categorized by metadata — no new entity kind.

- **Migration 0014**: nullable `people.tier` (`major|supporting|background`) and `people.status` (`alive|dead|missing|unknown`), with check constraints. Purely additive; RLS untouched.
- **`personTier()` helper**: null tier reads as `major` — no backfill needed; bulk imports will set `background` explicitly.
- **Detail sheet**: Tier + Status `EnumSelect` stats; **Faction + Location `EntitySelect` stats** — these FK columns already drive the derived "member of"/"resides at" board strings but previously had no edit surface at all (seed-only).
- **Dead marker**: struck-through name + `† deceased` caption on `PosterCard` (board card + grid card), colors per the `.status-chip.lost` precedent.

## Sequencing

Apply `supabase/migrations/0014_person_tier_status.sql` **before** deploying this. Old code + new columns is safe; new code + missing columns reads safely but tier/status writes would be dropped (PGRST204, caught by the existing fire-and-forget catch).

## Verified

- `npm run build` passes.
- Dev server as anonymous viewer: person sheet renders the new Location stat as plain text where `location_id` is set (King Barillon → Spireholm); empty Tier/Status/Faction stats correctly hidden for viewers; zero console errors.
- **Pending editor + migration**: setting tier/status from the sheet, realtime propagation to a second tab, dead-marker with real data — will verify after 0014 is applied.

## Next PRs

Faceted people list + background reveal → board decoupling (ON/OFF BOARD, create-without-pinning) → optional `race:halfling` palette operators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)