### PR TITLE
Faceted people list: name/tier/status/faction/race filters + background reveal

### DIFF
--- a/src/board.tsx
+++ b/src/board.tsx
@@ -2,6 +2,9 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   type KindKey,
   type BoardPosition,
+  PERSON_STATUS_OPTIONS,
+  PERSON_TIER_OPTIONS,
+  personTier,
   sortForDisplay,
   isArchivableKind,
 } from "./data";
@@ -702,23 +705,66 @@ export function NoticeBoard({
   );
 }
 
+const NO_FACETS = { tier: "all", status: "all", faction: "all", race: "all" };
+
 export function KindList({ kind, onOpenEntity }: { kind: string; onOpenEntity: (id: string) => void }) {
   const kinds = useKinds();
   const campaign = useCampaign();
   const [showArchived, setShowArchived] = useState(false);
+  // People facets: view filters, not writes — open to read-only viewers, like
+  // the sidebar arc filter. Background folk hide behind a reveal by default so
+  // a bulk-imported roster doesn't drown the curated cast; picking the tier
+  // facet explicitly bypasses the hide.
+  const isPeople = kind === "people";
+  const [nameQuery, setNameQuery] = useState("");
+  const [facets, setFacets] = useState({ ...NO_FACETS });
+  const [showBackground, setShowBackground] = useState(false);
+  const factionChoices = useMemo(
+    () => campaign.factions.slice().sort((a, b) => a.name.localeCompare(b.name)),
+    [campaign.factions],
+  );
+  // Distinct races from the data itself: dedupe case-insensitively, keep the
+  // first-seen casing as the label and the lowercased key as the match value.
+  const raceChoices = useMemo(() => {
+    const seen = new Map<string, string>();
+    for (const p of campaign.people) {
+      const r = p.race?.trim();
+      if (r && !seen.has(r.toLowerCase())) seen.set(r.toLowerCase(), r);
+    }
+    return Array.from(seen, ([value, label]) => ({ value, label }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [campaign.people]);
   const k = kinds.find((x) => x.key === kind);
   if (!k) return null;
 
   const archivable = isArchivableKind(k.key);
   const all = k.list() as any[];
-  const { archivedCount, sorted } = useMemo(() => {
-    if (!archivable) return { archivedCount: 0, sorted: all };
+  const facetsActive = nameQuery.trim() !== "" || Object.values(facets).some((v) => v !== "all");
+  const { archivedCount, backgroundCount, sorted } = useMemo(() => {
+    if (!archivable) return { archivedCount: 0, backgroundCount: 0, sorted: all };
     const numById = new Map(campaign.sessions.map((s) => [s.id, s.num]));
     const sessionNum = (id: string) => numById.get(id) ?? 0;
     const archived = all.filter((e) => e.archived).length;
-    const visible = showArchived ? all : all.filter((e) => !e.archived);
-    return { archivedCount: archived, sorted: sortForDisplay(visible, { kind: k.key as KindKey, sessionNum }) };
-  }, [all, archivable, showArchived, k.key, campaign.sessions]);
+    let visible = showArchived ? all : all.filter((e) => !e.archived);
+    let background = 0;
+    if (isPeople) {
+      const q = nameQuery.trim().toLowerCase();
+      if (q) visible = visible.filter((e) => `${e.name ?? ""} ${e.epithet ?? ""}`.toLowerCase().includes(q));
+      if (facets.tier !== "all") visible = visible.filter((e) => personTier(e) === facets.tier);
+      if (facets.status !== "all") visible = visible.filter((e) => e.status === facets.status);
+      if (facets.faction !== "all") visible = visible.filter((e) => e.faction === facets.faction);
+      if (facets.race !== "all") visible = visible.filter((e) => e.race?.trim().toLowerCase() === facets.race);
+      if (facets.tier === "all") {
+        background = visible.filter((e) => personTier(e) === "background").length;
+        if (!showBackground) visible = visible.filter((e) => personTier(e) !== "background");
+      }
+    }
+    return {
+      archivedCount: archived,
+      backgroundCount: background,
+      sorted: sortForDisplay(visible, { kind: k.key as KindKey, sessionNum }),
+    };
+  }, [all, archivable, showArchived, k.key, campaign.sessions, isPeople, nameQuery, facets, showBackground]);
 
   return (
     <div style={{ flex: 1, overflow: "auto", padding: "28px 40px 60px", background: "var(--vellum)", position: "relative" }} className="tex-vellum">
@@ -728,16 +774,55 @@ export function KindList({ kind, onOpenEntity }: { kind: string; onOpenEntity: (
           <span style={{ fontFamily: "var(--font-fell)", fontStyle: "italic", fontSize: 16, color: "var(--ink-faded)" }}>
             {sorted.length} {k.plural} of note
           </span>
-          {archivable && archivedCount > 0 && (
-            <button
-              onClick={() => setShowArchived((v) => !v)}
-              className="cleanup-link-btn"
-              style={{ marginLeft: "auto" }}
-            >
-              {showArchived ? `hide ${archivedCount} archived` : `show ${archivedCount} archived`}
-            </button>
-          )}
+          <span style={{ marginLeft: "auto", display: "flex", gap: 14 }}>
+            {isPeople && backgroundCount > 0 && facets.tier === "all" && (
+              <button onClick={() => setShowBackground((v) => !v)} className="cleanup-link-btn">
+                {showBackground ? `hide ${backgroundCount} background` : `show ${backgroundCount} background folk`}
+              </button>
+            )}
+            {archivable && archivedCount > 0 && (
+              <button onClick={() => setShowArchived((v) => !v)} className="cleanup-link-btn">
+                {showArchived ? `hide ${archivedCount} archived` : `show ${archivedCount} archived`}
+              </button>
+            )}
+          </span>
         </div>
+        {isPeople && (
+          <div style={{ display: "flex", alignItems: "center", gap: 14, flexWrap: "wrap", marginBottom: 8 }}>
+            <input
+              className="facet-input"
+              value={nameQuery}
+              onChange={(e) => setNameQuery(e.target.value)}
+              placeholder="filter by name…"
+              title="Filter people by name or epithet"
+            />
+            <select className="facet-select" value={facets.tier} onChange={(e) => setFacets((f) => ({ ...f, tier: e.target.value }))} title="Filter by tier">
+              <option value="all">every tier</option>
+              {PERSON_TIER_OPTIONS.map((t) => <option key={t} value={t}>{t}</option>)}
+            </select>
+            <select className="facet-select" value={facets.status} onChange={(e) => setFacets((f) => ({ ...f, status: e.target.value }))} title="Filter by status">
+              <option value="all">any status</option>
+              {PERSON_STATUS_OPTIONS.map((s) => <option key={s} value={s}>{s}</option>)}
+            </select>
+            {factionChoices.length > 0 && (
+              <select className="facet-select" value={facets.faction} onChange={(e) => setFacets((f) => ({ ...f, faction: e.target.value }))} title="Filter by faction">
+                <option value="all">all factions</option>
+                {factionChoices.map((f) => <option key={f.id} value={f.id}>{f.name}</option>)}
+              </select>
+            )}
+            {raceChoices.length > 0 && (
+              <select className="facet-select" value={facets.race} onChange={(e) => setFacets((f) => ({ ...f, race: e.target.value }))} title="Filter by race">
+                <option value="all">any race</option>
+                {raceChoices.map((r) => <option key={r.value} value={r.value}>{r.label}</option>)}
+              </select>
+            )}
+            {facetsActive && (
+              <button className="cleanup-link-btn" onClick={() => { setFacets({ ...NO_FACETS }); setNameQuery(""); }}>
+                clear filters
+              </button>
+            )}
+          </div>
+        )}
         <div className="scratch-divider"><em>✦ ✦ ✦</em></div>
 
         <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(260px, 1fr))", gap: 20, marginTop: 24 }}>

--- a/src/campaignContext.tsx
+++ b/src/campaignContext.tsx
@@ -46,6 +46,8 @@ const mapPerson = (r: any) => ({
   role: r.role ?? undefined,
   disposition: r.disposition ?? undefined,
   alignment: r.alignment ?? undefined,
+  tier: r.tier ?? undefined,
+  status: r.status ?? undefined,
   location: r.location_id ?? undefined,
   faction: r.faction_id ?? undefined,
   lastSeen: r.last_seen_session_id ?? undefined,

--- a/src/cleanupPanel.tsx
+++ b/src/cleanupPanel.tsx
@@ -7,6 +7,7 @@ import {
   entityLabel,
   isArchived,
   isPinned,
+  personTier,
 } from "./data";
 import { Icon } from "./icons";
 import { bulkArchive } from "./mutations";
@@ -55,6 +56,10 @@ function computeSuggestions(campaign: Campaign, n: number): Suggestion[] {
 
   for (const p of campaign.people) {
     if (skip(p)) continue;
+    // Background folk are already the "not in active rotation" designation —
+    // a bulk-imported roster (mostly session-linkless) would otherwise flood
+    // the panel and drown the real suggestions.
+    if (personTier(p) === "background") continue;
     if (activeByConnection.has(p.id)) continue;
     if (p.lastSeen && !recentSessionIds.has(p.lastSeen)) {
       const sess = sessionsByNum.find((s) => s.id === p.lastSeen);

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -203,7 +203,8 @@ export function PosterCard({ person }: { person: any }) {
           ? <img src={person.imageUrl} alt={person.name} className="portrait-img" />
           : <span className="silhouette" />}
       </div>
-      <div className="name">{person.name}</div>
+      <div className={`name${person.status === "dead" ? " is-dead" : ""}`}>{person.name}</div>
+      {person.status === "dead" && <div className="deceased-tag">† deceased</div>}
       {!!person.epithet?.trim() && <div className="desc">— {person.epithet}</div>}
       <div className="reward">
         {person.race

--- a/src/data.ts
+++ b/src/data.ts
@@ -2,7 +2,7 @@ export type Status = "whispered" | "pursuing" | "resolved" | "lost";
 
 // People-only enums (Status above belongs to quests/goals). Tier is the
 // information-overload valve: background folk stay searchable and connectable
-// but are hidden behind a reveal in the list and get no board card by default.
+// while the list reveal and board-card gating (follow-up PRs) tuck them away.
 export type PersonTier = "major" | "supporting" | "background";
 export type PersonStatus = "alive" | "dead" | "missing" | "unknown";
 export const PERSON_TIER_OPTIONS = ["major", "supporting", "background"] as const;

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,4 +1,12 @@
 export type Status = "whispered" | "pursuing" | "resolved" | "lost";
+
+// People-only enums (Status above belongs to quests/goals). Tier is the
+// information-overload valve: background folk stay searchable and connectable
+// but are hidden behind a reveal in the list and get no board card by default.
+export type PersonTier = "major" | "supporting" | "background";
+export type PersonStatus = "alive" | "dead" | "missing" | "unknown";
+export const PERSON_TIER_OPTIONS = ["major", "supporting", "background"] as const;
+export const PERSON_STATUS_OPTIONS = ["alive", "dead", "missing", "unknown"] as const;
 export type KindKey =
   | "people"
   | "locations"
@@ -60,6 +68,8 @@ export interface Person extends ArchivableFields {
   role?: string;
   disposition?: string;
   alignment?: string;
+  tier?: PersonTier;
+  status?: PersonStatus;
   location?: string;
   faction?: string;
   lastSeen?: string;
@@ -240,6 +250,13 @@ export function isArchived(e: any): boolean {
 
 export function isPinned(e: any): boolean {
   return !!(e && e.pinned);
+}
+
+// Null tier reads as major: existing rows predate the column and every curated
+// person should count as major without a backfill. Always read tier through
+// this helper, never `p.tier` directly.
+export function personTier(p: { tier?: PersonTier }): PersonTier {
+  return p.tier ?? "major";
 }
 
 // Quest/goal status ordering: active work floats up, abandoned sinks. Unknown

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from "react";
-import { type KindKey, entityLabel, isArchivableKind, isArchived, isPinned, sessionLabel } from "./data";
+import { type KindKey, PERSON_STATUS_OPTIONS, PERSON_TIER_OPTIONS, entityLabel, isArchivableKind, isArchived, isPinned, sessionLabel } from "./data";
 import { Icon, kindIcon } from "./icons";
 import { StatusChip, EditableText, EditableMarkdown, EnumSelect, EntitySelect, EntityCombobox } from "./components";
 import { useCampaign, useFindEntity } from "./hooks";
@@ -464,6 +464,10 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
     () => campaign.locations.map((l) => ({ id: l.id, label: l.name, kind: "locations" as const, archived: l.archived })),
     [campaign.locations],
   );
+  const factionOptions = useMemo(
+    () => campaign.factions.map((f) => ({ id: f.id, label: f.name, kind: "factions" as const, archived: f.archived })),
+    [campaign.factions],
+  );
 
   const onDelete = () => {
     if (!entity) return;
@@ -584,6 +588,11 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                     <Stat label="Role" empty={!(entity as any).role?.trim()} valueStyle={{ fontSize: 14 }}><EditableText value={(entity as any).role ?? ""} onSave={(v) => patch({ role: v })} placeholder="—" /></Stat>
                     <Stat label="Disposition" empty={!(entity as any).disposition} valueStyle={{ textTransform: "capitalize" }}><EnumSelect value={(entity as any).disposition} options={DISPOSITION_OPTIONS} allowClear onSave={(v) => patch({ disposition: v })} /></Stat>
                     <Stat label="Alignment" empty={!(entity as any).alignment?.trim()} valueStyle={{ fontSize: 13 }}><EditableText value={(entity as any).alignment ?? ""} onSave={(v) => patch({ alignment: v })} placeholder="—" /></Stat>
+                    {/* No allowClear on tier: null already reads as major (personTier), so a clear would be indistinguishable. */}
+                    <Stat label="Tier" empty={!(entity as any).tier} valueStyle={{ textTransform: "capitalize" }}><EnumSelect value={(entity as any).tier ?? "major"} options={PERSON_TIER_OPTIONS} onSave={(v) => patch({ tier: v })} /></Stat>
+                    <Stat label="Status" empty={!(entity as any).status} valueStyle={{ textTransform: "capitalize" }}><EnumSelect value={(entity as any).status} options={PERSON_STATUS_OPTIONS} allowClear onSave={(v) => patch({ status: v })} /></Stat>
+                    <Stat label="Faction" empty={!(entity as any).faction} valueStyle={{ fontSize: 13 }}><EntitySelect value={(entity as any).faction} options={factionOptions} allowClear onSave={(id) => patch({ faction: id ?? "" })} /></Stat>
+                    <Stat label="Location" empty={!(entity as any).location} valueStyle={{ fontSize: 13 }}><EntitySelect value={(entity as any).location} options={locationOptions} allowClear onSave={(id) => patch({ location: id ?? "" })} /></Stat>
                   </>
                 )}
                 {kind === "locations" && (

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from "react";
-import { type KindKey, PERSON_STATUS_OPTIONS, PERSON_TIER_OPTIONS, entityLabel, isArchivableKind, isArchived, isPinned, sessionLabel } from "./data";
+import { type KindKey, PERSON_STATUS_OPTIONS, PERSON_TIER_OPTIONS, entityLabel, isArchivableKind, isArchived, isPinned, personTier, sessionLabel } from "./data";
 import { Icon, kindIcon } from "./icons";
 import { StatusChip, EditableText, EditableMarkdown, EnumSelect, EntitySelect, EntityCombobox } from "./components";
 import { useCampaign, useFindEntity } from "./hooks";
@@ -588,8 +588,10 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                     <Stat label="Role" empty={!(entity as any).role?.trim()} valueStyle={{ fontSize: 14 }}><EditableText value={(entity as any).role ?? ""} onSave={(v) => patch({ role: v })} placeholder="—" /></Stat>
                     <Stat label="Disposition" empty={!(entity as any).disposition} valueStyle={{ textTransform: "capitalize" }}><EnumSelect value={(entity as any).disposition} options={DISPOSITION_OPTIONS} allowClear onSave={(v) => patch({ disposition: v })} /></Stat>
                     <Stat label="Alignment" empty={!(entity as any).alignment?.trim()} valueStyle={{ fontSize: 13 }}><EditableText value={(entity as any).alignment ?? ""} onSave={(v) => patch({ alignment: v })} placeholder="—" /></Stat>
-                    {/* No allowClear on tier: null already reads as major (personTier), so a clear would be indistinguishable. */}
-                    <Stat label="Tier" empty={!(entity as any).tier} valueStyle={{ textTransform: "capitalize" }}><EnumSelect value={(entity as any).tier ?? "major"} options={PERSON_TIER_OPTIONS} onSave={(v) => patch({ tier: v })} /></Stat>
+                    {/* No allowClear on tier: null already reads as major (personTier), so a clear would be
+                        indistinguishable. The no-op guard keeps re-picking the shown value from writing an
+                        explicit 'major' — that would flip the stat permanently visible to viewers. */}
+                    <Stat label="Tier" empty={!(entity as any).tier} valueStyle={{ textTransform: "capitalize" }}><EnumSelect value={personTier(entity as any)} options={PERSON_TIER_OPTIONS} onSave={(v) => { if (v !== personTier(entity as any)) patch({ tier: v }); }} /></Stat>
                     <Stat label="Status" empty={!(entity as any).status} valueStyle={{ textTransform: "capitalize" }}><EnumSelect value={(entity as any).status} options={PERSON_STATUS_OPTIONS} allowClear onSave={(v) => patch({ status: v })} /></Stat>
                     <Stat label="Faction" empty={!(entity as any).faction} valueStyle={{ fontSize: 13 }}><EntitySelect value={(entity as any).faction} options={factionOptions} allowClear onSave={(id) => patch({ faction: id ?? "" })} /></Stat>
                     <Stat label="Location" empty={!(entity as any).location} valueStyle={{ fontSize: 13 }}><EntitySelect value={(entity as any).location} options={locationOptions} allowClear onSave={(id) => patch({ location: id ?? "" })} /></Stat>

--- a/src/styles.css
+++ b/src/styles.css
@@ -2350,7 +2350,7 @@ button.session-pin { line-height: 1; }
   border-bottom: 1px solid var(--ink-ghost);
   width: 150px;
 }
-.facet-input::placeholder { color: var(--ink-faded); font-style: italic; }
+.facet-input::placeholder { color: var(--ink-ghost); font-style: italic; }
 .facet-input:focus { outline: none; border-bottom-color: var(--ink-secondary); }
 
 .cmdk-hint {

--- a/src/styles.css
+++ b/src/styles.css
@@ -2332,6 +2332,27 @@ button.session-pin { line-height: 1; }
   padding: 0;
 }
 
+/* People facet bar (KindList): view controls, not edit affordances — dashed
+   borders mean "editable" everywhere else, so these stay borderless (the
+   input keeps a ghost hairline for discoverability). */
+.facet-select,
+.facet-input {
+  background: transparent;
+  border: none;
+  font-family: var(--font-fell-sc);
+  letter-spacing: .08em;
+  font-size: 11px;
+  color: var(--ink-secondary);
+  padding: 2px 4px 2px 0;
+}
+.facet-select { cursor: pointer; }
+.facet-input {
+  border-bottom: 1px solid var(--ink-ghost);
+  width: 150px;
+}
+.facet-input::placeholder { color: var(--ink-faded); font-style: italic; }
+.facet-input:focus { outline: none; border-bottom-color: var(--ink-secondary); }
+
 .cmdk-hint {
   display: flex; gap: 16px; justify-content: flex-end;
   padding: 8px 16px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1046,6 +1046,18 @@ button.session-pin { line-height: 1; }
   margin-top: 10px;
   color: var(--ink);
 }
+.card-poster .name.is-dead {
+  text-decoration: line-through;
+  text-decoration-color: var(--bloodred);
+}
+/* Colors follow .status-chip.lost so the mark stays legible on grimoire. */
+.card-poster .deceased-tag {
+  font-family: var(--font-fell-sc);
+  font-size: 10px;
+  letter-spacing: .18em;
+  text-align: center;
+  color: var(--bloodred-deep);
+}
 .card-poster .desc {
   font-family: var(--font-fell);
   font-style: italic; /* epithet — attribution voice, italic on purpose */

--- a/supabase/migrations/0014_person_tier_status.sql
+++ b/supabase/migrations/0014_person_tier_status.sql
@@ -1,0 +1,19 @@
+-- NPC tiers (major/supporting/background) and life status, for bulk rosters.
+-- Both nullable: null tier reads as 'major' in the app; null status is "unset".
+-- RLS from 0003/0006 already covers people; plain column adds need no policy.
+
+alter table public.people
+  add column if not exists tier   text,
+  add column if not exists status text;
+
+alter table public.people
+  drop constraint if exists people_tier_check;
+alter table public.people
+  add constraint people_tier_check
+    check (tier is null or tier in ('major', 'supporting', 'background'));
+
+alter table public.people
+  drop constraint if exists people_status_check;
+alter table public.people
+  add constraint people_status_check
+    check (status is null or status in ('alive', 'dead', 'missing', 'unknown'));


### PR DESCRIPTION
## Summary

PR 2 of the NPC-roster stack (on top of #58). The Known People grid gets the filtering the DM asked for (`>Shields of the Crying God`, `race:halfling`, `status:alive`):

- **Facet row** on the people `KindList`: name/epithet filter input + selects for tier, status, faction (sorted by name, FK match), race (distinct data-derived values, case-insensitive dedupe). AND semantics, view-only state — available to read-only viewers, styled per the sidebar arc-filter precedent (borderless, small-caps, `--ink-secondary`).
- **Background reveal**: background-tier people hidden by default behind a `show N background folk` toggle (archived-toggle precedent); selecting the tier facet explicitly bypasses the hide. Counts respect the other active facets.
- **Cleanup panel** skips background-tier people — they're already the "not in rotation" designation; a bulk import (mostly session-linkless) would otherwise flood the suggestions.
- `clear filters` link when any facet is active; header count reflects the filtered set.

## Verified (dev server, anonymous viewer, grimoire theme)

- Name filter narrows live and composes with facets (`orin` + race Human → 2).
- Faction facet: Falcon Legion → 4 of 16; race options build from the data (`Demon, Doppelganger, Half-elf, Halfling, Human`); clear resets to 16 and the link hides itself.
- Tier/status facets render and match nothing yet (columns land with migration 0014 from #58) — `personTier()` null→major keeps everyone visible by default.
- Zero console errors; `npm run build` passes.

Known v1 edge (noted in plan): a deleted faction leaves a dangling selection matching nothing until cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)