### PR TITLE
IM Fell contrast: lift ink tiers a notch, theme the last hardcoded colors

### DIFF
--- a/src/board.tsx
+++ b/src/board.tsx
@@ -559,7 +559,7 @@ export function NoticeBoard({
             color: "var(--ink)",
             transform: "rotate(-1deg)",
             boxShadow: "var(--shadow-pin)",
-            border: "1px solid rgba(139,94,40,.4)",
+            border: "1px solid var(--card-edge)",
             zIndex: 5,
             pointerEvents: "none",
           }}>

--- a/src/data.ts
+++ b/src/data.ts
@@ -210,7 +210,7 @@ export function buildKinds(campaign: Campaign): KindDef[] {
     { key: "quests",    label: "Quests",        plural: "quests",    list: () => campaign.quests,    color: "var(--mustard)" },
     { key: "goals",     label: "Goals",         plural: "goals",     list: () => campaign.goals,     color: "var(--forest)" },
     { key: "factions",  label: "Factions",      plural: "factions",  list: () => campaign.factions,  color: "var(--slate)" },
-    { key: "items",     label: "Items",         plural: "items",     list: () => campaign.items,     color: "#8a6a28" },
+    { key: "items",     label: "Items",         plural: "items",     list: () => campaign.items,     color: "var(--gold-antique)" },
     { key: "lore",      label: "Lore",          plural: "lore",      list: () => campaign.lore,      color: "var(--forest-pale)" },
   ];
 }

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -518,7 +518,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                 onClick={() => patch({ pinned: !isPinned(entity) })}
                 title={isPinned(entity) ? "Unpin from top of lists" : "Pin to top of lists"}
                 className="detail-action-btn"
-                style={isPinned(entity) ? { borderColor: "var(--mustard)", color: "#6e5018" } : undefined}
+                style={isPinned(entity) ? { borderColor: "var(--mustard)", color: "var(--mustard-deep)" } : undefined}
               >
                 {isPinned(entity) ? "★ PINNED" : "☆ PIN"}
               </button>

--- a/src/styles.css
+++ b/src/styles.css
@@ -17,10 +17,10 @@
        --ink-faded      de-emphasis only: off-states, hints, decoration —
                         never on sub-15px content text
        --ink-ghost      placeholders and whispers */
-  --ink:           #2a1f14;        /* deepest ink */
-  --ink-body:      #3b2c1c;
-  --ink-secondary: #5a4530;
-  --ink-faded:     #6b533a;
+  --ink:           #1f160e;        /* deepest ink */
+  --ink-body:      #2f2315;
+  --ink-secondary: #4b3926;
+  --ink-faded:     #5c472f;
   --ink-ghost:     #8a7551;
 
   /* Map colors */
@@ -35,6 +35,7 @@
   --mustard:       #b08228;        /* gold leaf */
   --mustard-pale:  #d9b870;
   --mustard-deep:  #6e5018;        /* pursuing-status ink on light paper */
+  --gold-antique:  #8a6a28;        /* items kind — darker gold than quests' mustard */
   --forest:        #3d5536;
   --forest-pale:   #7a8f6c;
   --slate:         #465061;
@@ -67,6 +68,7 @@
   /* Card chrome — themed so dark mode can carry a lighter rim that separates
      card stock from the cork behind it. */
   --card-edge:     rgba(139,94,40,.4);
+  --hairline:      rgba(139,94,40,.15); /* row separators on themed panels */
 }
 
 /* ── Theme variants ───────────────────────── */
@@ -75,12 +77,13 @@
   --vellum-light:  #24253a;
   --vellum-dark:   #13131f;
   --vellum-deep:   #0d0d16;
-  --ink:           #e8dcb5;
-  --ink-body:      #d4c79a;
-  /* Lifted from #9d8f64 / #6a5f3f: secondary text on dark card stock was
-     hovering at ~4.6:1 — too low for 12px serif. These clear ~7:1. */
-  --ink-secondary: #c7b98c;
-  --ink-faded:     #b3a578;
+  --ink:           #f3ecca;
+  --ink-body:      #e2d7ae;
+  /* Lifted twice (from #9d8f64 / #6a5f3f, then again): IM Fell's hairline
+     strokes render lighter than the nominal color, so secondary text on the
+     dark card stock needs ~8:1 to read the way 5:1 would in a sturdier face. */
+  --ink-secondary: #d6c99e;
+  --ink-faded:     #c2b489;
   --ink-ghost:     #7d7050;
   /* Papers lightened a step so cards separate from the cork behind them. */
   --paper-cream:   #262847;
@@ -104,8 +107,10 @@
   --bloodred-deep: #ee7d68;
   --mustard:       #d4a728;
   --mustard-deep:  #d9b870;        /* dark stock flips this to a pale ink */
+  --gold-antique:  #b6923e;        /* lifted so the items swatch doesn't sink into the dark topbar */
   /* Light rim + deeper drop shadow: card-to-board separation in the dark. */
   --card-edge:     rgba(220,205,160,.32);
+  --hairline:      rgba(220,205,160,.14);
   --shadow-card:   0 0 0 1px rgba(232,220,181,.05), 0 1px 0 rgba(255,255,255,.06) inset, 0 10px 22px rgba(0,0,0,.6), 0 2px 3px rgba(0,0,0,.55);
 }
 [data-theme="modern"] {
@@ -113,10 +118,10 @@
   --vellum-light:  #fafaf5;
   --vellum-dark:   #ebe5d8;
   --vellum-deep:   #d6cdb9;
-  --ink:           #1a1a1a;
-  --ink-body:      #2e2e2e;
-  --ink-secondary: #4a4a4a;
-  --ink-faded:     #5e5e5e;
+  --ink:           #101010;
+  --ink-body:      #232323;
+  --ink-secondary: #3c3c3c;
+  --ink-faded:     #505050;
   --ink-ghost:     #9a9a9a;
   --paper-cream:   #ffffff;
   --paper-tan:     #f0ece3;
@@ -1609,7 +1614,7 @@ button.session-pin { line-height: 1; }
   position: relative;
   padding: 14px 18px 16px;
   background: var(--paper-note);
-  border: 1px solid rgba(139,94,40,.3);
+  border: 1px solid var(--card-edge);
   box-shadow: 0 1px 0 rgba(255,255,255,.3) inset, 0 3px 6px rgba(40,20,5,.15);
   font-family: var(--font-hand);
   font-size: 17px;
@@ -2294,7 +2299,7 @@ button.session-pin { line-height: 1; }
 .cleanup-row {
   display: flex; align-items: center; gap: 12px;
   padding: 7px 6px;
-  border-bottom: 1px solid rgba(139,94,40,.15);
+  border-bottom: 1px solid var(--hairline);
   cursor: pointer;
   font-family: var(--font-fell);
   font-size: 14px;


### PR DESCRIPTION
## Summary
- Lift the four content ink tiers (`--ink`, `--ink-body`, `--ink-secondary`, `--ink-faded`) one notch in all three themes. IM Fell English's hairline strokes render optically lighter than their nominal color, so small serif text needs roughly a level more contrast than a sturdy sans. All content text now clears WCAG AAA (7:1) on every paper stock: grimoire body 8.6–10.5:1, secondary floor 7.47:1 (note paper); vellum secondary 8.1:1; modern ≥9.8:1. `--ink-ghost` (placeholders/whispers) is deliberately untouched.
- Fix the stragglers that bypassed theme variables:
  - **PINNED button** ([detail.tsx](src/detail.tsx)) hardcoded `#6e5018` — the *light-theme* value of `--mustard-deep` — making it near-invisible on grimoire card stock. Now `var(--mustard-deep)` (pixel-identical on vellum, flips to pale gold on grimoire).
  - **Items kind color** ([data.ts](src/data.ts)) was the only kind with a hardcoded color; its legend swatch stayed dark on grimoire while all six siblings brightened. New themed `--gold-antique` (root `#8a6a28`, grimoire `#b6923e`), still distinguishable from quests' brighter mustard.
  - **Notice-board banner + `.note-scrap` borders** hardcoded the light-paper brown rim on themed paper — now `var(--card-edge)`.
  - **`.cleanup-row` separators** (Tidy the Codex) used a 15%-alpha dark brown, invisible on grimoire — new themed `--hairline` token next to `--card-edge`.

Deliberate "physical prop" palettes (sticky note, wax seal, tape, wooden board frame, bloodred primary button) hardcode background + ink together and are self-consistent in every theme; left as-is.

## Test plan
- [x] `npm run build` typechecks clean
- [x] Verified all three themes in the browser (Known People roster, Items cards, Notice Board, Tidy the Codex panel)
- [x] Computed WCAG ratios for every ink tier × paper stock combination; content floor ≥7.47:1
- [x] Confirmed legend swatches, banner border, and cleanup separators resolve to the lifted grimoire values via computed styles
- [x] Grepped for remaining hardcoded text/border colors — none outside self-consistent props

🤖 Generated with [Claude Code](https://claude.com/claude-code)