### PR TITLE
DM role + hidden entities: migration 0015, isDm, filter-everywhere via central projection (#63, #64)

### DIFF
--- a/src/campaignContext.tsx
+++ b/src/campaignContext.tsx
@@ -1,10 +1,12 @@
-import { createContext, useCallback, useEffect, useState, type ReactNode } from "react";
+import { createContext, useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import type { RealtimeChannel } from "@supabase/supabase-js";
 import { supabase } from "./utils/supabase";
+import { useAuth } from "./auth";
 import { setActiveCampaignId } from "./activeCampaign";
 import { setActiveSessionId } from "./activeSession";
 import { parseHash, writeCampaignHash } from "./route";
 import {
+  projectCampaignForViewers,
   type Campaign,
   type CampaignSummary,
   type BoardPosition,
@@ -20,6 +22,10 @@ interface CampaignContextValue {
   campaigns: CampaignSummary[];
   activeCampaignId: string | null;
   switchCampaign: (id: string) => void;
+  // True when the signed-in editor is this campaign's DM (campaigns.dm_user_id).
+  // Derived fresh every render, so it tracks campaign switches and realtime
+  // changes of the campaigns row automatically. V1: client-side gate only.
+  isDm: boolean;
 }
 
 export const CampaignContext = createContext<CampaignContextValue>({
@@ -29,12 +35,14 @@ export const CampaignContext = createContext<CampaignContextValue>({
   campaigns: [],
   activeCampaignId: null,
   switchCampaign: () => {},
+  isDm: false,
 });
 
 // Map a DB row (snake_case, `desc`) to the app's object shape (camelCase).
 const archiveFields = (r: any) => ({
   archived: !!r.archived,
   pinned: !!r.pinned,
+  hidden: !!r.hidden,
   updatedAt: r.updated_at ?? undefined,
 });
 
@@ -251,6 +259,7 @@ async function fetchCampaign(id: string): Promise<Campaign> {
     eventParticipants: buildParticipants(participantsRes.data ?? []),
     sessionParticipants: buildSessionParticipants(sessionParticipantsRes.data ?? []),
     activeSessionId: campaignRes.data.active_session_id ?? undefined,
+    dmUserId: campaignRes.data.dm_user_id ?? undefined,
     people: (peopleRes.data ?? []).map(mapPerson),
     locations: (locationsRes.data ?? []).map(mapLocation),
     quests: (questsRes.data ?? []).map(mapQuest),
@@ -279,6 +288,7 @@ function applyArrayChange<T extends { id: string }>(
 }
 
 export function CampaignProvider({ children }: { children: ReactNode }) {
+  const { user, canEdit } = useAuth();
   const [campaign, setCampaign] = useState<Campaign | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -386,7 +396,7 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
             if (cancelled) return;
             const next = payload.new?.active_session_id ?? undefined;
             setActiveSessionId(next ?? null);
-            setCampaign((c) => c && c.id === campaignId ? { ...c, activeSessionId: next, title: payload.new?.title ?? c.title, subtitle: payload.new?.subtitle ?? c.subtitle } : c);
+            setCampaign((c) => c && c.id === campaignId ? { ...c, activeSessionId: next, dmUserId: payload.new?.dm_user_id ?? undefined, title: payload.new?.title ?? c.title, subtitle: payload.new?.subtitle ?? c.subtitle } : c);
           },
         );
         channel.on(
@@ -540,8 +550,18 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
     };
   }, [campaignId]);
 
+  const isDm = !!campaign && canEdit && !!campaign.dmUserId && user?.id === campaign.dmUserId;
+
+  // The single hidden-entity funnel: non-DM users get a projected campaign
+  // with hidden rows (and every reference to them) stripped, so no downstream
+  // surface — lists, board, yarn, ⌘K, rails, counts, deep links — can leak one.
+  const visibleCampaign = useMemo(
+    () => (campaign && !isDm ? projectCampaignForViewers(campaign) : campaign),
+    [campaign, isDm],
+  );
+
   return (
-    <CampaignContext.Provider value={{ campaign, loading, error, campaigns, activeCampaignId: campaignId, switchCampaign }}>
+    <CampaignContext.Provider value={{ campaign: visibleCampaign, loading, error, campaigns, activeCampaignId: campaignId, switchCampaign, isDm }}>
       {children}
     </CampaignContext.Provider>
   );

--- a/src/commandPalette.tsx
+++ b/src/commandPalette.tsx
@@ -47,6 +47,7 @@ function searchHits(fullIndex: Indexed[], campaign: Campaign, query: string): Ra
           matchSource: "note",
           rank: 3,
           archived: parent.archived,
+          hidden: parent.hidden,
         });
         break;
       }
@@ -211,6 +212,7 @@ export function CommandPalette({ open, onClose, onOpenEntity, onLocate }: Comman
               </div>
               <span className="cmdk-kind">{KIND_LABEL[hit.kind]}</span>
               {hit.archived && <span className="cmdk-kind-archived">archived</span>}
+              {hit.hidden && <span className="cmdk-kind-veiled">unrevealed</span>}
               {canLocate(hit) && (
                 <button
                   type="button"

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -166,16 +166,27 @@ export function PinnedCard({
 }
 
 export function CardBody({ entity, kind }: { entity: any; kind: KindKey }) {
+  let body: React.ReactNode;
   switch (kind) {
-    case "people":    return <PosterCard person={entity} />;
-    case "locations": return <LocationCard loc={entity} />;
-    case "quests":    return <QuestCard quest={entity} />;
-    case "goals":     return <GoalCard goal={entity} />;
-    case "factions":  return <FactionCard f={entity} />;
-    case "items":     return <ItemCard i={entity} />;
-    case "lore":      return <LoreCard l={entity} />;
+    case "people":    body = <PosterCard person={entity} />; break;
+    case "locations": body = <LocationCard loc={entity} />; break;
+    case "quests":    body = <QuestCard quest={entity} />; break;
+    case "goals":     body = <GoalCard goal={entity} />; break;
+    case "factions":  body = <FactionCard f={entity} />; break;
+    case "items":     body = <ItemCard i={entity} />; break;
+    case "lore":      body = <LoreCard l={entity} />; break;
     default: return null;
   }
+  // Hidden rows never reach non-DM users (projected out in campaignContext),
+  // so this badge needs no role check — if it renders, the viewer is the DM.
+  // One insertion covers both board cards and kind-list cards.
+  if (!entity.hidden) return body;
+  return (
+    <>
+      <span className="veil-badge">unrevealed</span>
+      {body}
+    </>
+  );
 }
 
 export function PosterCard({ person }: { person: any }) {
@@ -1062,6 +1073,7 @@ export interface EntityOption {
   label: string;
   kind: KindKey;
   archived?: boolean;
+  hidden?: boolean;
 }
 
 interface EntityComboboxProps {
@@ -1105,7 +1117,7 @@ export function EntityCombobox({
   const [rect, setRect] = useState<{ left: number; top: number; width: number; flip: boolean; maxHeight: number } | null>(null);
 
   const index = useMemo<Indexed[]>(
-    () => options.map((o) => ({ id: o.id, kind: o.kind, label: o.label, primary: o.label, secondary: "", archived: o.archived })),
+    () => options.map((o) => ({ id: o.id, kind: o.kind, label: o.label, primary: o.label, secondary: "", archived: o.archived, hidden: o.hidden })),
     [options],
   );
   const results = useMemo(() => rankIndex(index, query), [index, query]);
@@ -1289,6 +1301,7 @@ export function EntityCombobox({
                   <span className={`entity-combobox-row-label${hit.archived ? " archived" : ""}`}>{hit.label}</span>
                   <span className="entity-combobox-kind">{KIND_LABEL[hit.kind]}</span>
                   {hit.archived && <span className="entity-combobox-archived">archived</span>}
+                  {hit.hidden && <span className="entity-combobox-veiled">unrevealed</span>}
                 </div>
               );
             })}

--- a/src/data.ts
+++ b/src/data.ts
@@ -285,8 +285,9 @@ export function projectCampaignForViewers(c: Campaign): Campaign {
   const factions = keep(c.factions);
   const items = keep(c.items);
   const lore = keep(c.lore);
-  // Identity fast path: campaigns that never use the flag pay nothing and
-  // downstream memos keep their referential equality.
+  // Identity fast path: when nothing is hidden, return the original object so
+  // downstream memos keep their referential equality. (The seven filter passes
+  // above still run — what's saved is the memo invalidation, not the scan.)
   if (hiddenIds.size === 0) return c;
   const dropHiddenValues = (rec: Record<string, string[]>): Record<string, string[]> =>
     Object.fromEntries(

--- a/src/data.ts
+++ b/src/data.ts
@@ -57,6 +57,10 @@ export interface CampaignEvent {
 export interface ArchivableFields {
   archived?: boolean;
   pinned?: boolean;
+  // DM-only visibility (issue #64): unlike archived (a declutter flag, still
+  // readable by everyone), hidden rows are projected out of the campaign
+  // object entirely for non-DM users — see projectCampaignForViewers.
+  hidden?: boolean;
   updatedAt?: string;
 }
 
@@ -175,6 +179,9 @@ export interface Campaign {
   sessionParticipants: Record<string, string[]>;
   // The shared "we're live in session N" pin (campaigns.active_session_id).
   activeSessionId?: string;
+  // The campaign's DM (campaigns.dm_user_id, an auth user id). One DM per
+  // campaign; V1 gating is client-side only.
+  dmUserId?: string;
   people: Person[];
   locations: Location[];
   quests: Quest[];
@@ -250,6 +257,52 @@ export function isArchived(e: any): boolean {
 
 export function isPinned(e: any): boolean {
   return !!(e && e.pinned);
+}
+
+export function isHidden(e: any): boolean {
+  return !!(e && e.hidden);
+}
+
+// Player-facing projection: strips DM-hidden entities and every reference to
+// them (connections, board positions, participant ids, party notes), so every
+// downstream surface — findEntity (deep links, detail sheet, relation rails),
+// buildKinds (lists, counts), buildIndex (⌘K, comboboxes), deriveRelations
+// (board yarn), rosters — is clean by construction rather than by per-surface
+// filtering. FK fields on visible entities (e.g. a person whose faction is
+// hidden) are left alone: consumers resolve them via findEntity and skip
+// nulls, and rewriting them here would risk write-back corruption.
+export function projectCampaignForViewers(c: Campaign): Campaign {
+  const hiddenIds = new Set<string>();
+  const keep = <T extends { id: string; hidden?: boolean }>(list: T[]): T[] =>
+    list.filter((e) => {
+      if (e.hidden) hiddenIds.add(e.id);
+      return !e.hidden;
+    });
+  const people = keep(c.people);
+  const locations = keep(c.locations);
+  const quests = keep(c.quests);
+  const goals = keep(c.goals);
+  const factions = keep(c.factions);
+  const items = keep(c.items);
+  const lore = keep(c.lore);
+  // Identity fast path: campaigns that never use the flag pay nothing and
+  // downstream memos keep their referential equality.
+  if (hiddenIds.size === 0) return c;
+  const dropHiddenValues = (rec: Record<string, string[]>): Record<string, string[]> =>
+    Object.fromEntries(
+      Object.entries(rec).map(([k, ids]) => [k, ids.filter((id) => !hiddenIds.has(id))]),
+    );
+  const dropHiddenKeys = <V>(rec: Record<string, V>): Record<string, V> =>
+    Object.fromEntries(Object.entries(rec).filter(([id]) => !hiddenIds.has(id)));
+  return {
+    ...c,
+    people, locations, quests, goals, factions, items, lore,
+    connections: c.connections.filter(([a, b]) => !hiddenIds.has(a) && !hiddenIds.has(b)),
+    board: dropHiddenKeys(c.board),
+    eventParticipants: dropHiddenValues(c.eventParticipants),
+    sessionParticipants: dropHiddenValues(c.sessionParticipants),
+    notes: dropHiddenKeys(c.notes),
+  };
 }
 
 // Null tier reads as major: existing rows predate the column and every curated

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useRef, useState } from "react";
-import { type KindKey, PERSON_STATUS_OPTIONS, PERSON_TIER_OPTIONS, entityLabel, isArchivableKind, isArchived, isPinned, personTier, sessionLabel } from "./data";
+import { type KindKey, PERSON_STATUS_OPTIONS, PERSON_TIER_OPTIONS, entityLabel, isArchivableKind, isArchived, isHidden, isPinned, personTier, sessionLabel } from "./data";
 import { Icon, kindIcon } from "./icons";
 import { StatusChip, EditableText, EditableMarkdown, EnumSelect, EntitySelect, EntityCombobox } from "./components";
-import { useCampaign, useFindEntity } from "./hooks";
+import { useCampaign, useFindEntity, useIsDm } from "./hooks";
 import { useAuth } from "./auth";
 import {
   insertPartyNote,
@@ -185,13 +185,13 @@ function AddRelationForm({ fromId }: { fromId: string }) {
 
   const allOptions = useMemo(
     () => [
-      ...campaign.people.map((p) => ({ id: p.id, label: p.name, kind: "people" as const, archived: p.archived })),
-      ...campaign.locations.map((l) => ({ id: l.id, label: l.name, kind: "locations" as const, archived: l.archived })),
-      ...campaign.quests.map((q) => ({ id: q.id, label: q.title, kind: "quests" as const, archived: q.archived })),
-      ...campaign.goals.map((g) => ({ id: g.id, label: g.text, kind: "goals" as const, archived: g.archived })),
-      ...campaign.factions.map((f) => ({ id: f.id, label: f.name, kind: "factions" as const, archived: f.archived })),
-      ...campaign.items.map((i) => ({ id: i.id, label: i.name, kind: "items" as const, archived: i.archived })),
-      ...campaign.lore.map((l) => ({ id: l.id, label: l.title, kind: "lore" as const, archived: l.archived })),
+      ...campaign.people.map((p) => ({ id: p.id, label: p.name, kind: "people" as const, archived: p.archived, hidden: p.hidden })),
+      ...campaign.locations.map((l) => ({ id: l.id, label: l.name, kind: "locations" as const, archived: l.archived, hidden: l.hidden })),
+      ...campaign.quests.map((q) => ({ id: q.id, label: q.title, kind: "quests" as const, archived: q.archived, hidden: q.hidden })),
+      ...campaign.goals.map((g) => ({ id: g.id, label: g.text, kind: "goals" as const, archived: g.archived, hidden: g.hidden })),
+      ...campaign.factions.map((f) => ({ id: f.id, label: f.name, kind: "factions" as const, archived: f.archived, hidden: f.hidden })),
+      ...campaign.items.map((i) => ({ id: i.id, label: i.name, kind: "items" as const, archived: i.archived, hidden: i.hidden })),
+      ...campaign.lore.map((l) => ({ id: l.id, label: l.title, kind: "lore" as const, archived: l.archived, hidden: l.hidden })),
       ...campaign.sessions.map((s) => ({ id: s.id, label: s.title, kind: "sessions" as const })),
       ...campaign.arcs.map((a) => ({ id: a.id, label: a.title, kind: "arcs" as const })),
       ...campaign.events.map((e) => ({ id: e.id, label: e.title, kind: "events" as const })),
@@ -351,6 +351,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
   const findEntity = useFindEntity();
   const entity = findEntity(entityId);
   const { displayName, canEdit } = useAuth();
+  const isDm = useIsDm();
 
   const notes = campaign.notes[entityId] || [];
 
@@ -464,11 +465,11 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
     [campaign.sessions],
   );
   const locationOptions = useMemo(
-    () => campaign.locations.map((l) => ({ id: l.id, label: l.name, kind: "locations" as const, archived: l.archived })),
+    () => campaign.locations.map((l) => ({ id: l.id, label: l.name, kind: "locations" as const, archived: l.archived, hidden: l.hidden })),
     [campaign.locations],
   );
   const factionOptions = useMemo(
-    () => campaign.factions.map((f) => ({ id: f.id, label: f.name, kind: "factions" as const, archived: f.archived })),
+    () => campaign.factions.map((f) => ({ id: f.id, label: f.name, kind: "factions" as const, archived: f.archived, hidden: f.hidden })),
     [campaign.factions],
   );
 
@@ -509,7 +510,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
 
   return (
     <div className="detail-overlay" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}>
-      <div className={`detail-sheet tex-vellum ${isArchived(entity) ? "is-archived" : ""}`}>
+      <div className={`detail-sheet tex-vellum ${isArchived(entity) ? "is-archived" : ""} ${isHidden(entity) ? "is-veiled" : ""}`}>
         <button className="detail-close" onClick={onClose}><Icon name="close" size={16} /></button>
         {canEdit && <div style={{ position: "absolute", top: 14, right: 54, display: "flex", gap: 6, zIndex: 2 }}>
           {isArchivableKind(kind) && (
@@ -530,6 +531,20 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
               >
                 {isArchived(entity) ? "⤴ UNARCHIVE" : "⤵ ARCHIVE"}
               </button>
+              {/* DM-only party visibility — distinct from ARCHIVE, which
+                  declutters but stays readable by everyone. */}
+              {isDm && (
+                <button
+                  onClick={() => patch({ hidden: !isHidden(entity) })}
+                  title={isHidden(entity)
+                    ? "Reveal to the party"
+                    : "Hide from the party — only the DM sees it"}
+                  className="detail-action-btn"
+                  style={isHidden(entity) ? { borderColor: "var(--ink-secondary)", color: "var(--ink-secondary)", borderStyle: "dashed" } : undefined}
+                >
+                  {isHidden(entity) ? "◈ UNREVEALED" : "◇ HIDE"}
+                </button>
+              )}
               {/* Board membership is a positions row, independent of tier/archive.
                   Not worded "PIN" — that already means pinned-to-top above. */}
               <button

--- a/src/entitySearch.ts
+++ b/src/entitySearch.ts
@@ -16,6 +16,7 @@ export interface RankedHit {
   matchSource: MatchSource;
   rank: 0 | 1 | 2 | 3;
   archived?: boolean;
+  hidden?: boolean;
 }
 
 export const KIND_LABEL: Record<KindKey, string> = {
@@ -38,6 +39,9 @@ export interface Indexed {
   primary: string;
   secondary: string;
   archived?: boolean;
+  // DM-only flag: non-DM users never index hidden rows (projected out of the
+  // campaign upstream), so this is only ever true for the DM's own view.
+  hidden?: boolean;
   // Structured facet values for palette operators (people only, all
   // lowercased). Entries without facets never match an operator query.
   facets?: { tier: string; status?: string; race?: string; factionName?: string };
@@ -67,6 +71,7 @@ export function buildIndex(campaign: Campaign): Indexed[] {
         p.status, p.notes,
       ),
       archived: p.archived,
+      hidden: p.hidden,
       facets: {
         tier: personTier(p),
         status: p.status,
@@ -83,6 +88,7 @@ export function buildIndex(campaign: Campaign): Indexed[] {
       primary: l.name ?? "",
       secondary: joinFields(l.kind, l.region, l.ruler, l.desc, l.notes),
       archived: l.archived,
+      hidden: l.hidden,
     });
   }
   for (const q of campaign.quests) {
@@ -93,6 +99,7 @@ export function buildIndex(campaign: Campaign): Indexed[] {
       primary: q.title ?? "",
       secondary: joinFields(q.status, q.reward, q.desc, q.hooks),
       archived: q.archived,
+      hidden: q.hidden,
     });
   }
   for (const g of campaign.goals) {
@@ -103,6 +110,7 @@ export function buildIndex(campaign: Campaign): Indexed[] {
       primary: g.text ?? "",
       secondary: joinFields(g.owner, g.kind, g.status),
       archived: g.archived,
+      hidden: g.hidden,
     });
   }
   for (const f of campaign.factions) {
@@ -113,6 +121,7 @@ export function buildIndex(campaign: Campaign): Indexed[] {
       primary: f.name ?? "",
       secondary: joinFields(f.sigil, f.desc, f.allegiance),
       archived: f.archived,
+      hidden: f.hidden,
     });
   }
   for (const i of campaign.items) {
@@ -123,6 +132,7 @@ export function buildIndex(campaign: Campaign): Indexed[] {
       primary: i.name ?? "",
       secondary: joinFields(i.kind, i.desc),
       archived: i.archived,
+      hidden: i.hidden,
     });
   }
   for (const lo of campaign.lore) {
@@ -133,6 +143,7 @@ export function buildIndex(campaign: Campaign): Indexed[] {
       primary: lo.title ?? "",
       secondary: lo.text ?? "",
       archived: lo.archived,
+      hidden: lo.hidden,
     });
   }
   for (const s of campaign.sessions) {
@@ -190,11 +201,11 @@ export function rankEntities(index: Indexed[], queryLower: string, best: Map<str
   for (const e of index) {
     const primary = e.primary.toLowerCase();
     if (primary.startsWith(queryLower)) {
-      keepBest(best, { id: e.id, kind: e.kind, label: e.label, matchSource: "primary", rank: 0, archived: e.archived });
+      keepBest(best, { id: e.id, kind: e.kind, label: e.label, matchSource: "primary", rank: 0, archived: e.archived, hidden: e.hidden });
       continue;
     }
     if (primary.includes(queryLower)) {
-      keepBest(best, { id: e.id, kind: e.kind, label: e.label, matchSource: "primary", rank: 1, archived: e.archived });
+      keepBest(best, { id: e.id, kind: e.kind, label: e.label, matchSource: "primary", rank: 1, archived: e.archived, hidden: e.hidden });
       continue;
     }
     const secondary = e.secondary.toLowerCase();
@@ -207,6 +218,7 @@ export function rankEntities(index: Indexed[], queryLower: string, best: Map<str
         matchSource: "secondary",
         rank: 2,
         archived: e.archived,
+        hidden: e.hidden,
       });
     }
   }
@@ -267,7 +279,7 @@ export function matchesOps(e: Indexed, ops: FacetOp[]): boolean {
 // shared by the combobox dropdown and the palette's pure-operator results.
 export function listAlphabetical(index: Indexed[], limit: number): RankedHit[] {
   return index
-    .map((e): RankedHit => ({ id: e.id, kind: e.kind, label: e.label, matchSource: "primary", rank: 0, archived: e.archived }))
+    .map((e): RankedHit => ({ id: e.id, kind: e.kind, label: e.label, matchSource: "primary", rank: 0, archived: e.archived, hidden: e.hidden }))
     .sort((a, b) => a.label.localeCompare(b.label))
     .slice(0, limit);
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -15,6 +15,12 @@ export function useCampaignStatus() {
   return { campaign, loading, error };
 }
 
+// The DM gate for edit affordances that go beyond canEdit (hide/reveal,
+// staging, release). False for viewers, non-DM editors, and DM-less campaigns.
+export function useIsDm(): boolean {
+  return useContext(CampaignContext).isDm;
+}
+
 export function useCampaignSwitcher() {
   const { campaigns, activeCampaignId, switchCampaign } = useContext(CampaignContext);
   return { campaigns, activeCampaignId, switchCampaign };

--- a/src/styles.css
+++ b/src/styles.css
@@ -2204,6 +2204,73 @@ button.session-pin { line-height: 1; }
   opacity: .6;
 }
 
+/* ── DM-hidden ("unrevealed") badges ───────
+   Only ever rendered for the DM — hidden rows are projected out of the
+   campaign for everyone else. Dashed strokes read as "not yet in the world",
+   distinct from archived's solid ink stamp. --ink-secondary is the contrast
+   floor for ≤14px text (never --ink-faded/--ink-ghost on these labels). */
+
+/* Board cards + kind-list cards. A real element, not ::before — the card
+   pseudo-elements are already claimed by .archived and .is-pinned. */
+.veil-badge {
+  position: absolute;
+  top: -10px; right: 8px;
+  background: var(--vellum-light);
+  color: var(--ink-secondary);
+  border: 1px dashed var(--ink-secondary);
+  font-family: var(--font-fell-sc);
+  letter-spacing: .2em;
+  font-size: 9px;
+  padding: 2px 6px;
+  border-radius: 2px;
+  z-index: 5;
+  pointer-events: none;
+}
+
+/* Detail sheet banner — reuses the .statblock::after slot exactly like the
+   archived banner (the base ::after is a display:none fleuron, so display
+   and bottom must be overridden here too). Declared after the archived rule,
+   so when both flags are set the dashed veiled treatment wins and the
+   combined rule below merges the wording. */
+.detail-sheet.is-veiled .statblock::after {
+  content: "UNREVEALED";
+  display: block;
+  position: absolute;
+  /* Left corner, not centered like the archived banner — centered would sit
+     right under the action-button row and bleed through between buttons. */
+  top: 14px; left: 24px;
+  bottom: auto;
+  transform: none;
+  background: var(--vellum-light);
+  color: var(--ink-secondary);
+  border: 1px dashed var(--ink-secondary);
+  font-family: var(--font-fell-sc);
+  letter-spacing: .3em;
+  font-size: 10px;
+  padding: 2px 12px;
+  border-radius: 2px;
+  /* No z-index: the action-button row (z-index 2) must stay clickable above
+     the banner, same layering as the archived banner. */
+  pointer-events: none;
+}
+.detail-sheet.is-archived.is-veiled .statblock::after {
+  content: "ARCHIVED · UNREVEALED";
+}
+
+/* Command palette + entity combobox tags, matching the archived tag metrics */
+.cmdk-kind-veiled,
+.entity-combobox-veiled {
+  margin-left: 6px;
+  font-family: var(--font-fell-sc);
+  letter-spacing: .2em;
+  font-size: 9px;
+  color: var(--ink-secondary);
+  border: 1px dashed var(--ink-secondary);
+  background: var(--vellum-light);
+  padding: 1px 5px;
+  border-radius: 2px;
+}
+
 /* ── Cleanup panel (Tidy the Codex) ─────── */
 .cleanup-overlay {
   position: fixed;

--- a/supabase/migrations/0015_dm_and_hidden.sql
+++ b/supabase/migrations/0015_dm_and_hidden.sql
@@ -1,0 +1,41 @@
+-- M5 Live Session Mode, PR 1 (issues #63 + #64).
+-- DM role: one DM per campaign via campaigns.dm_user_id (nullable, assigned
+-- manually through the dashboard/SQL — no assignment UI yet).
+-- Hidden entities: a coarse party-wide `hidden` flag on the 7 archivable
+-- kinds (sessions/arcs/events are permanent history, excluded per 0005).
+-- V1 is client-gated only: the client filters hidden rows for non-DM users;
+-- RLS enforcement via campaign_members is deferred (issue #73). The 0003/0006
+-- write policies are whole-row gates and already cover the new columns, the
+-- touch_updated_at triggers (0005) fire on any update, and campaigns is
+-- already in the realtime publication (0013) — no other plumbing needed.
+
+-- ==========================================================================
+-- DM role
+-- ==========================================================================
+
+alter table public.campaigns
+  add column if not exists dm_user_id text;
+
+-- ==========================================================================
+-- Hidden flag
+-- ==========================================================================
+
+alter table public.people    add column if not exists hidden boolean not null default false;
+alter table public.locations add column if not exists hidden boolean not null default false;
+alter table public.quests    add column if not exists hidden boolean not null default false;
+alter table public.goals     add column if not exists hidden boolean not null default false;
+alter table public.factions  add column if not exists hidden boolean not null default false;
+alter table public.items     add column if not exists hidden boolean not null default false;
+alter table public.lore      add column if not exists hidden boolean not null default false;
+
+-- ==========================================================================
+-- Partial indexes on the player-visible path (matches 0005's style)
+-- ==========================================================================
+
+create index if not exists idx_people_revealed    on public.people(campaign_id)    where hidden = false;
+create index if not exists idx_locations_revealed on public.locations(campaign_id) where hidden = false;
+create index if not exists idx_quests_revealed    on public.quests(campaign_id)    where hidden = false;
+create index if not exists idx_goals_revealed     on public.goals(campaign_id)     where hidden = false;
+create index if not exists idx_factions_revealed  on public.factions(campaign_id)  where hidden = false;
+create index if not exists idx_items_revealed     on public.items(campaign_id)     where hidden = false;
+create index if not exists idx_lore_revealed      on public.lore(campaign_id)      where hidden = false;


### PR DESCRIPTION
Closes #63, closes #64. **M5 — Live Session Mode, PR 1 of 5.**

## What

- **Migration [0015_dm_and_hidden.sql](../blob/claude/m5-live-session-pr1-326a7b/supabase/migrations/0015_dm_and_hidden.sql)**: `campaigns.dm_user_id text` (nullable, one DM per campaign, assigned via dashboard/SQL — no UI yet) + `hidden boolean not null default false` on the 7 archivable kinds (sessions/arcs/events excluded, 0005 precedent) + partial `where hidden = false` indexes.
- **`isDm`**: derived in `CampaignProvider` (`auth uid === campaign.dmUserId`, `canEdit` required), exposed on the campaign context + `useIsDm()`. Tracks campaign switches and realtime `campaigns`-row updates automatically (pure derived state, nothing cached).
- **Hidden entities, filtered everywhere via one funnel**: instead of patching ~14 read sites, non-DM users get `projectCampaignForViewers(campaign)` — hidden rows **and every reference to them** (connections with a hidden endpoint, board positions, event/session participant ids, party-note buckets) are stripped at the provider. Kind lists, faceted people list, board cards **and yarn**, ⌘K (incl. facet operators and the party-notes pass), relation rails, FK/relation pickers, sidebar counts, session roster, cleanup panel, and entity deep links are clean **by construction** — including any future surface. Identity fast path returns the original object when nothing is hidden.
- **DM view**: hidden entities render everywhere with a dashed "unrevealed" treatment — card badge (board + lists), palette/combobox tags, detail-sheet banner — and a `◇ HIDE` / `◈ UNREVEALED` toggle beside PIN/ARCHIVE (writes via `updateEntity`, no `fieldAlias` needed). All colors are theme-aware ink tiers; `--ink-secondary` respected as the ≤14px contrast floor.

## Design principles (milestone)

Default-hidden/reveal-forward ✓ (flag defaults false, DM toggles) · one coarse party-wide flag, no ACLs ✓ · **V1 client-gated only** ✓ (trust-based; RLS enforcement is #73) · rows + postgres_changes only ✓ (`hidden`/`dm_user_id` ride the existing mappers/handlers; `archiveFields` carries `hidden` through all 7 mappers and realtime splices).

**Deviation from #64's letter, deliberately**: the issue implies a per-surface sweep; this ships a central projection instead — same observable result, structurally leak-proof.

## Migration status

⚠️ **Not applied** — the Supabase MCP is permission-blocked for this project, so please apply 0015 via the dashboard SQL editor. Validated locally on Postgres 16 (shim + 0001→0015 in order, 0015 re-applied twice → idempotent, schema verified). The app runs safely against the pre-migration schema in the meantime (verified in browser: `!!r.hidden` → false, `dm_user_id` → undefined, projection takes the identity fast path).

## Verified

- `npm run build` clean.
- Browser, player view (hidden person simulated via doctored REST responses): sidebar count 16→15, board card gone, yarn edges 174→162, absent from kind list/faceted list/⌘K/relation rails, deep link `#/c/fendwick/e/p1` silently no-ops and normalizes the hash.
- Browser, DM view (session doctored to `canEdit` + mocked `dm_user_id`): entity visible everywhere with the unrevealed badge (board card, list card, ⌘K tag), detail sheet gets the dashed banner + `◈ UNREVEALED` toggle; grimoire (dark) theme contrast verified.

## Known trade-offs (V1, accepted)

- Any signed-in editor can technically UPDATE `campaigns.dm_user_id` (same trust model as `setActiveSession`); real enforcement is #73.
- Toggling hidden bumps `updated_at` (0005 trigger) → recency-sort jump for the DM, same as archive.
- A non-DM editor re-picking an FK whose current value is hidden sees "—" and can overwrite the DM's link.
- `findFreeSpot` sees the projected board, so a non-DM editor's new card may overlap a hidden entity's card (DM-only visual quirk).
- Prose mentions of a hidden entity's name inside *other* entities' hand-written text are not redacted (inherent to free text; the entity itself is unreachable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)