### PR TITLE
Session data layer: session_staging + session_events (#65 + #66)

### DIFF
--- a/src/campaignContext.tsx
+++ b/src/campaignContext.tsx
@@ -13,6 +13,8 @@ import {
   type Connection,
   type KindKey,
   type PartyNote,
+  type SessionEvent,
+  type SessionStagingRow,
 } from "./data";
 
 interface CampaignContextValue {
@@ -171,6 +173,30 @@ const buildSessionParticipants = (rows: any[]): Record<string, string[]> => {
   return bySession;
 };
 
+const mapSessionStaging = (r: any): SessionStagingRow => ({
+  sessionId: r.session_id,
+  entityId: r.entity_id,
+  releasedAt: r.released_at ?? null,
+});
+
+const mapSessionEvent = (r: any): SessionEvent => ({
+  id: r.id,
+  sessionId: r.session_id,
+  type: r.type,
+  author: r.author ?? undefined,
+  entityId: r.entity_id ?? undefined,
+  text: r.text ?? undefined,
+  createdAt: r.created_at,
+});
+
+// Feed order must be stable (created_at, id tiebreak — issue #66) and splice
+// order can't be trusted: bigserial ids are assigned at insert while realtime
+// follows commit order, so two concurrent authors can arrive inverted.
+// Date.parse rather than string compare — PostgREST's timestamptz text isn't
+// guaranteed lexicographically ordered (fractional digits vary).
+const sortSessionEvents = (list: SessionEvent[]): SessionEvent[] =>
+  list.slice().sort((a, b) => (Date.parse(a.createdAt) - Date.parse(b.createdAt)) || (a.id - b.id));
+
 const mapPresence = (r: any) => ({
   id: r.id,
   name: r.name,
@@ -204,6 +230,8 @@ async function fetchCampaign(id: string): Promise<Campaign> {
     eventsRes,
     participantsRes,
     sessionParticipantsRes,
+    sessionStagingRes,
+    sessionEventsRes,
     peopleRes,
     locationsRes,
     questsRes,
@@ -222,6 +250,8 @@ async function fetchCampaign(id: string): Promise<Campaign> {
     supabase.from("events").select("*").eq("campaign_id", id).order("order_num"),
     supabase.from("event_participants").select("*").eq("campaign_id", id),
     supabase.from("session_participants").select("*").eq("campaign_id", id),
+    supabase.from("session_staging").select("*").eq("campaign_id", id),
+    supabase.from("session_events").select("*").eq("campaign_id", id).order("created_at").order("id"),
     supabase.from("people").select("*").eq("campaign_id", id),
     supabase.from("locations").select("*").eq("campaign_id", id),
     supabase.from("quests").select("*").eq("campaign_id", id),
@@ -237,7 +267,7 @@ async function fetchCampaign(id: string): Promise<Campaign> {
 
   const first = [
     campaignRes, sessionsRes, arcsRes, eventsRes, participantsRes,
-    sessionParticipantsRes, peopleRes,
+    sessionParticipantsRes, sessionStagingRes, sessionEventsRes, peopleRes,
     locationsRes, questsRes, goalsRes, factionsRes, itemsRes, loreRes,
     connectionsRes, boardRes, presenceRes, notesRes,
   ].find((r) => r.error);
@@ -258,6 +288,8 @@ async function fetchCampaign(id: string): Promise<Campaign> {
     events: (eventsRes.data ?? []).map(mapEvent),
     eventParticipants: buildParticipants(participantsRes.data ?? []),
     sessionParticipants: buildSessionParticipants(sessionParticipantsRes.data ?? []),
+    sessionStaging: (sessionStagingRes.data ?? []).map(mapSessionStaging),
+    sessionEvents: (sessionEventsRes.data ?? []).map(mapSessionEvent),
     activeSessionId: campaignRes.data.active_session_id ?? undefined,
     dmUserId: campaignRes.data.dm_user_id ?? undefined,
     people: (peopleRes.data ?? []).map(mapPerson),
@@ -275,7 +307,8 @@ async function fetchCampaign(id: string): Promise<Campaign> {
 }
 
 // Splice a realtime change into an array-valued campaign field keyed by id.
-function applyArrayChange<T extends { id: string }>(
+// id is string for entity tables, number for bigserial ones (session_events).
+function applyArrayChange<T extends { id: string | number }>(
   list: T[],
   event: "INSERT" | "UPDATE" | "DELETE",
   newRow: T | null,
@@ -490,6 +523,29 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
               if (cancelled) return;
               setCampaign((c) => c && c.id === campaignId ? { ...c, sessionParticipants: buildSessionParticipants(data ?? []) } : c);
             });
+          },
+        );
+        channel.on(
+          "postgres_changes" as any,
+          { event: "*", schema: "public", table: "session_staging", filter },
+          () => {
+            // Composite PK, no client-side id — refetch, same as session_participants.
+            supabase.from("session_staging").select("*").eq("campaign_id", campaignId).then(({ data }) => {
+              if (cancelled) return;
+              setCampaign((c) => c && c.id === campaignId ? { ...c, sessionStaging: (data ?? []).map(mapSessionStaging) } : c);
+            });
+          },
+        );
+        channel.on(
+          "postgres_changes" as any,
+          { event: "*", schema: "public", table: "session_events", filter },
+          (payload: any) => {
+            // Append-only in policy, but subscribe to "*": a session delete
+            // cascades DELETEs for its feed rows, and those must be applied or
+            // ghost events linger until reload. (DELETE payloads carry only
+            // the PK and bypass the campaign_id filter — harmless, the splice
+            // just filters on an id that isn't present.)
+            setCampaign((c) => c && c.id === campaignId ? { ...c, sessionEvents: sortSessionEvents(applyArrayChange(c.sessionEvents, payload.eventType, payload.new?.id != null ? mapSessionEvent(payload.new) : null, payload.old?.id != null ? mapSessionEvent(payload.old) : null)) } : c);
           },
         );
         channel.on(

--- a/src/campaignContext.tsx
+++ b/src/campaignContext.tsx
@@ -540,11 +540,15 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
           "postgres_changes" as any,
           { event: "*", schema: "public", table: "session_events", filter },
           (payload: any) => {
-            // Append-only in policy, but subscribe to "*": a session delete
-            // cascades DELETEs for its feed rows, and those must be applied or
-            // ghost events linger until reload. (DELETE payloads carry only
-            // the PK and bypass the campaign_id filter — harmless, the splice
-            // just filters on an id that isn't present.)
+            // INSERT is the live path (the feed is append-only — no UPDATE and
+            // no manual DELETE policy exist). We still subscribe to "*" and
+            // handle the DELETE splice defensively so that if a delete ever is
+            // delivered (e.g. a future REPLICA IDENTITY FULL) it's applied
+            // rather than ignored. Note the practical limit: session-delete
+            // cascades emit DELETEs whose old-row (default replica identity)
+            // carries only the PK, so Supabase can't match the campaign_id
+            // filter and drops them — a reload is the backstop for the rare
+            // "session deleted mid-feed" case, not this handler.
             setCampaign((c) => c && c.id === campaignId ? { ...c, sessionEvents: sortSessionEvents(applyArrayChange(c.sessionEvents, payload.eventType, payload.new?.id != null ? mapSessionEvent(payload.new) : null, payload.old?.id != null ? mapSessionEvent(payload.old) : null)) } : c);
           },
         );

--- a/src/data.ts
+++ b/src/data.ts
@@ -162,6 +162,32 @@ export interface PartyNote {
 
 export type Connection = [string, string, string];
 
+// A DM-staged entity queued for a session (session_staging junction). Rows
+// with releasedAt null are "queued"; PR 3's one-click release stamps it.
+export interface SessionStagingRow {
+  sessionId: string;
+  entityId: string;
+  releasedAt: string | null;
+}
+
+export type SessionEventType = "note" | "reveal" | "start" | "end";
+
+// One row of the append-only live-session feed (session_events). INSERT-only
+// by construction — rows are never edited, so one author per row and inserts
+// commute across clients.
+export interface SessionEvent {
+  id: number;
+  sessionId: string;
+  type: SessionEventType;
+  author?: string;
+  // Cross-kind entity ref with no FK; events outlive entity deletion (the
+  // feed is history), so this may dangle — renderers must findEntity and
+  // tolerate null.
+  entityId?: string;
+  text?: string;
+  createdAt: string;
+}
+
 export type Entity =
   & (Person | Location | Quest | Goal | Faction | Item | Lore | Session | Arc | CampaignEvent)
   & { _kind?: KindKey; _kindLabel?: string };
@@ -177,6 +203,10 @@ export interface Campaign {
   eventParticipants: Record<string, string[]>;
   // session id → person ids seen in that session (session_participants junction).
   sessionParticipants: Record<string, string[]>;
+  // DM prep queue (session_staging). Projected to [] for non-DM viewers.
+  sessionStaging: SessionStagingRow[];
+  // Append-only live feed (session_events), sorted by (createdAt, id).
+  sessionEvents: SessionEvent[];
   // The shared "we're live in session N" pin (campaigns.active_session_id).
   activeSessionId?: string;
   // The campaign's DM (campaigns.dm_user_id, an auth user id). One DM per
@@ -285,10 +315,12 @@ export function projectCampaignForViewers(c: Campaign): Campaign {
   const factions = keep(c.factions);
   const items = keep(c.items);
   const lore = keep(c.lore);
-  // Identity fast path: when nothing is hidden, return the original object so
-  // downstream memos keep their referential equality. (The seven filter passes
-  // above still run — what's saved is the memo invalidation, not the scan.)
-  if (hiddenIds.size === 0) return c;
+  // Identity fast path: when nothing is hidden AND nothing is staged, return
+  // the original object so downstream memos keep their referential equality.
+  // (The seven filter passes above still run — what's saved is the memo
+  // invalidation, not the scan.) Staging must be part of the condition: a
+  // staged-but-visible entity would otherwise leak the DM's prep to viewers.
+  if (hiddenIds.size === 0 && c.sessionStaging.length === 0) return c;
   const dropHiddenValues = (rec: Record<string, string[]>): Record<string, string[]> =>
     Object.fromEntries(
       Object.entries(rec).map(([k, ids]) => [k, ids.filter((id) => !hiddenIds.has(id))]),
@@ -303,6 +335,13 @@ export function projectCampaignForViewers(c: Campaign): Campaign {
     eventParticipants: dropHiddenValues(c.eventParticipants),
     sessionParticipants: dropHiddenValues(c.sessionParticipants),
     notes: dropHiddenKeys(c.notes),
+    // The whole prep queue is DM-only ("staged-but-unreleased items are
+    // visible only to the DM", #65) — nothing player-facing consumes it, the
+    // player surface is the feed, so viewers get none of it.
+    sessionStaging: [],
+    // Defensive: a reveal event normally implies its entity was just unhidden,
+    // but a re-hidden entity must not leak back through old feed rows.
+    sessionEvents: c.sessionEvents.filter((e) => !e.entityId || !hiddenIds.has(e.entityId)),
   };
 }
 

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -13,6 +13,8 @@ import {
   removeEventParticipant,
   markSeen,
   unmarkSeen,
+  stageEntity,
+  unstageEntity,
   upsertBoardPosition,
   deleteBoardPosition,
 } from "./mutations";
@@ -545,6 +547,41 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                   {isHidden(entity) ? "◈ UNREVEALED" : "◇ HIDE"}
                 </button>
               )}
+              {/* DM prep queue (issue #65) — link this entity to the pinned
+                  session so PR 3's live panel can release it one click at a
+                  time. Ignores released_at on purpose: for PR 2, "in the
+                  queue" is the only state this button knows. */}
+              {isDm && campaign.activeSessionId && (() => {
+                const activeNum = campaign.sessions.find((s) => s.id === campaign.activeSessionId)?.num;
+                const code = activeNum != null ? sessionLabel(activeNum) : "";
+                const staged = campaign.sessionStaging.some(
+                  (r) => r.sessionId === campaign.activeSessionId && r.entityId === entityId,
+                );
+                return (
+                  <button
+                    onClick={() => {
+                      if (staged) {
+                        unstageEntity(campaign.activeSessionId!, entityId).catch(console.error);
+                        return;
+                      }
+                      // Staging happens either way — the confirm is only the
+                      // hide offer (default yes), so Cancel truthfully means
+                      // "stage it, but leave it visible".
+                      if (!isHidden(entity) && window.confirm(`Hide “${entityLabel(entity)}” from the party until released?`)) {
+                        patch({ hidden: true });
+                      }
+                      stageEntity(campaign.activeSessionId!, entityId).catch(console.error);
+                    }}
+                    title={staged
+                      ? `Remove from the session ${code} queue`
+                      : `Stage for session ${code} — queued for one-click release from the live panel`}
+                    className="detail-action-btn"
+                    style={staged ? { borderColor: "var(--mustard)", color: "var(--mustard-deep)" } : undefined}
+                  >
+                    {staged ? `⧉ STAGED ${code}` : `⧉ STAGE ${code}`}
+                  </button>
+                );
+              })()}
               {/* Board membership is a positions row, independent of tier/archive.
                   Not worded "PIN" — that already means pinned-to-top above. */}
               <button

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -1,7 +1,7 @@
 import { supabase } from "./utils/supabase";
 import { getActiveCampaignId } from "./activeCampaign";
 import { getActiveSessionId } from "./activeSession";
-import { type KindKey, type PartyNote, type BoardPosition } from "./data";
+import { type KindKey, type PartyNote, type BoardPosition, type SessionEventType } from "./data";
 
 // Realtime subscriptions in campaignContext.tsx reflect writes back into UI
 // state, so callers do not need to patch local state (fire-and-forget is fine).
@@ -230,6 +230,69 @@ export async function unmarkSeen(personId: string) {
   if (error) throw error;
 }
 
+// ===== Live session: staging queue + feed (M5 PR 2, issues #65/#66) ========
+
+export async function stageEntity(sessionId: string, entityId: string) {
+  // Merge (NOT ignoreDuplicates, unlike markSeen): re-staging a previously
+  // released row must reset released_at to null — "staged" always means
+  // queued-and-unreleased. The staging UPDATE policy permits the merge path.
+  const { error } = await supabase.from("session_staging").upsert(
+    {
+      campaign_id: getActiveCampaignId(),
+      session_id: sessionId,
+      entity_id: entityId,
+      released_at: null,
+    },
+    { onConflict: "session_id,entity_id" },
+  );
+  if (error) throw error;
+}
+
+export async function unstageEntity(sessionId: string, entityId: string) {
+  const { error } = await supabase
+    .from("session_staging")
+    .delete()
+    .eq("campaign_id", getActiveCampaignId())
+    .eq("session_id", sessionId)
+    .eq("entity_id", entityId);
+  if (error) throw error;
+}
+
+// The feed is append-only: INSERT is the only verb (no update/delete policies
+// exist on session_events). `author` is the caller's display name, same
+// signing as party_notes; `entityId` rides on reveal events, `text` carries
+// note bodies / reveal flair.
+export async function insertSessionEvent(ev: {
+  type: SessionEventType;
+  sessionId: string;
+  author?: string;
+  entityId?: string;
+  text?: string;
+}) {
+  const { error } = await supabase.from("session_events").insert({
+    campaign_id: getActiveCampaignId(),
+    session_id: ev.sessionId,
+    type: ev.type,
+    author: ev.author ?? null,
+    entity_id: ev.entityId ?? null,
+    text: ev.text ?? null,
+  });
+  if (error) throw error;
+}
+
+// session_staging.entity_id spans seven tables so it has no FK (like
+// connections) — swept here. session_events rows are deliberately NOT swept:
+// the feed is append-only history and reveals should outlive their entity
+// (renderers tolerate a dangling entity_id).
+async function deleteSessionStagingFor(entityId: string) {
+  const { error } = await supabase
+    .from("session_staging")
+    .delete()
+    .eq("campaign_id", getActiveCampaignId())
+    .eq("entity_id", entityId);
+  if (error) throw error;
+}
+
 // ===== Entity CRUD ==========================================================
 
 export async function createEntity(
@@ -287,6 +350,7 @@ export async function deleteEntity(kind: KindKey, id: string) {
     deleteBoardPosition(id).catch(() => {}),
     deleteConnectionsFor(id),
     deletePartyNotesFor(id),
+    deleteSessionStagingFor(id),
   ]);
   const { error } = await supabase
     .from(kind)

--- a/supabase/migrations/0016_session_staging_and_events.sql
+++ b/supabase/migrations/0016_session_staging_and_events.sql
@@ -1,0 +1,103 @@
+-- M5 Live Session Mode, PR 2 (issues #65 + #66): the session data layer.
+--
+-- session_staging — the DM's prep queue: hidden entities linked to a session,
+-- each one click from live. Mirrors the session_participants junction (0013):
+-- composite PK, campaign/session FKs cascade. entity_id is a cross-kind text
+-- ref spanning seven tables (like connections.from_id/to_id) so it carries no
+-- FK — deleteEntity sweeps it app-side. released_at is written by PR 3's
+-- one-click release; staged rows with released_at null are "queued".
+--
+-- session_events — the append-only live feed (notes + reveals + start/end
+-- brackets). One author per row, INSERT-only: no UPDATE/DELETE policies exist,
+-- which is what makes the log append-only at the DB layer (the session-delete
+-- FK cascade still wipes rows — cascades are system actions that bypass RLS).
+-- This table is the persistent backing for every reveal notification: a toast
+-- is never the only place a reveal lives, late joiners replay the feed.
+--
+-- Like 0015, DM-only visibility of staged rows is CLIENT-gated in V1: rows
+-- transit realtime to every client including anonymous viewers (the central
+-- projection strips them for non-DM users). RLS enforcement via
+-- campaign_members is issue #73.
+
+-- ==========================================================================
+-- Staging queue
+-- ==========================================================================
+
+create table if not exists public.session_staging (
+  campaign_id text not null references public.campaigns(id) on delete cascade,
+  session_id  text not null references public.sessions(id)  on delete cascade,
+  entity_id   text not null,
+  released_at timestamptz,
+  primary key (session_id, entity_id)
+);
+create index if not exists session_staging_campaign_idx on public.session_staging (campaign_id);
+create index if not exists session_staging_entity_idx on public.session_staging (entity_id);
+
+alter table public.session_staging enable row level security;
+
+drop policy if exists "session_staging is readable by anyone" on public.session_staging;
+create policy "session_staging is readable by anyone"
+  on public.session_staging for select
+  using (true);
+
+-- One whole-row write policy (0006 style) instead of per-command: staging
+-- needs INSERT (stage), DELETE (unstage) and UPDATE (PR 3's release sets
+-- released_at; the stage upsert's merge path also relies on it).
+drop policy if exists "non-anonymous users can manage session staging" on public.session_staging;
+create policy "non-anonymous users can manage session staging"
+  on public.session_staging for all
+  to authenticated
+  using ((auth.jwt() ->> 'is_anonymous')::boolean is not true)
+  with check ((auth.jwt() ->> 'is_anonymous')::boolean is not true);
+
+-- ==========================================================================
+-- Session feed
+-- ==========================================================================
+
+create table if not exists public.session_events (
+  id          bigserial primary key,
+  campaign_id text not null references public.campaigns(id) on delete cascade,
+  session_id  text not null references public.sessions(id)  on delete cascade,
+  type        text not null check (type in ('note', 'reveal', 'start', 'end')),
+  author      text,
+  entity_id   text,
+  text        text,
+  created_at  timestamptz not null default now()
+);
+create index if not exists session_events_campaign_idx on public.session_events (campaign_id);
+create index if not exists session_events_session_idx on public.session_events (session_id, id);
+
+alter table public.session_events enable row level security;
+
+drop policy if exists "session_events are readable by anyone" on public.session_events;
+create policy "session_events are readable by anyone"
+  on public.session_events for select
+  using (true);
+
+drop policy if exists "non-anonymous users can append session events" on public.session_events;
+create policy "non-anonymous users can append session events"
+  on public.session_events for insert
+  to authenticated
+  with check ((auth.jwt() ->> 'is_anonymous')::boolean is not true);
+
+-- ==========================================================================
+-- Realtime: both tables must be published or nothing syncs. Guarded for
+-- re-runs (ALTER PUBLICATION ... ADD TABLE errors on duplicates).
+-- ==========================================================================
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime' and schemaname = 'public' and tablename = 'session_staging'
+  ) then
+    alter publication supabase_realtime add table public.session_staging;
+  end if;
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime' and schemaname = 'public' and tablename = 'session_events'
+  ) then
+    alter publication supabase_realtime add table public.session_events;
+  end if;
+end;
+$$;


### PR DESCRIPTION
M5 PR group 2 — the persistent data layer behind live session mode. Closes #65 and #66. Builds on PR 1 (#76: DM role + hidden flag).

## What ships

**Migration `0016_session_staging_and_events.sql`** (file only — Kris applies via the Supabase dashboard):
- `session_staging` — the DM's prep queue. Composite PK `(session_id, entity_id)`, `campaign_id` for the realtime filter, cascade FKs on campaign/session, and `released_at` (written by PR 3's one-click release). `entity_id` is a cross-kind text ref with **no FK** (like `connections`), swept app-side. One `for all` write policy covers stage/unstage/release.
- `session_events` — the append-only feed (`note`/`reveal`/`start`/`end`). SELECT + INSERT policies only; the **absence** of UPDATE/DELETE policies is what makes the log append-only at the DB layer. Session-delete FK cascade still wipes rows (cascades bypass RLS).
- Both tables added to the `supabase_realtime` publication via the guarded do-block (0013 pattern).

**Client:**
- `data.ts` — `SessionStagingRow` / `SessionEvent` types + `Campaign` fields. `projectCampaignForViewers` strips the whole prep queue for non-DM viewers (`sessionStaging: []`) and drops reveal events for still-hidden entities. The identity fast path now also guards on `sessionStaging`, closing a leak where staging a *visible* entity would expose the DM's prep to players.
- `campaignContext.tsx` — parallel fetch of both tables; `session_staging` refetches on change (junction pattern), `session_events` splices incrementally and **re-sorts by `(createdAt, id)`** because realtime commit order can invert bigserial ids across concurrent authors (the M2 sort-after-splice gotcha). `applyArrayChange` id widened to `string | number`.
- `mutations.ts` — `stageEntity` (merge-upsert, resets `released_at`), `unstageEntity`, `insertSessionEvent` (INSERT-only), and `deleteSessionStagingFor` added to the `deleteEntity` sweep.
- `detail.tsx` — DM-only **`⧉ STAGE Sxx`** toggle on the detail sheet, gated on the active session pin. Staging a not-yet-hidden entity offers hiding via `window.confirm` (Cancel stages it visible; unstage never unhides).

## Design principles (from the milestone)
- **Append-only log, not a co-edited doc** ✓ — INSERT-only policies, one author per row.
- **Push + persist** ✓ — `session_events` is the persistent backing for every reveal; late joiners replay from rows.
- **Rows + postgres_changes only, no broadcast channels** ✓.

## Not in this PR (deviations, stated up front)
- Staging **requires** the active session pin (minimal reading of "defaults to the active session pin" — no session picker yet).
- Viewers get `sessionStaging: []` — slightly stricter than the AC; nothing player-facing consumes staging.
- `session_events` rows are **not** swept on entity delete — reveals outlive their entity (dangling `entityId` tolerated; renderers null-check).
- `start`/`end` events are supported by the schema + mutation but nothing inserts them yet (PR 3's live panel does).
- The live panel + one-click release are **PR group 3**.

## Verification
- `npm run build` — clean.
- **Migrations** — 0001→0016 apply in order on docker Postgres 16 (+ Supabase shim); 0016 re-applies twice as a no-op; FK cascade wipes both tables on session delete; the `type` check constraint rejects bad values.
- **Live realtime round-trip** — against the real DB with 0016 applied: both tables round-trip through the app's own campaign channel — `session_events` live INSERT arrives sorted (an out-of-order-timestamp insert correctly sorts to the front), `session_staging` refetches on stage/unstage, and reload reconstructs the full feed from rows. Exercised via a service-role writer + an anonymous viewer tab; temporary console instrumentation was removed before commit.
- The DM `STAGE` button's write path (`stageEntity`/`unstageEntity`) and realtime echo are proven; the literal click under a magic-link DM session wasn't exercised (the in-app browser is anonymous-only), but every dependency it relies on was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)