### PR TITLE
Live session panel + one-click release (#67 + #68)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CampaignProvider } from "./campaignContext";
 import { AuthProvider, DisplayNameGate } from "./auth";
-import { useCampaign, useCampaignStatus, useFindEntity, useKinds } from "./hooks";
+import { useCampaign, useCampaignStatus, useFindEntity, useIsDm, useKinds } from "./hooks";
+import { entityLabel } from "./data";
 import { campaignHash, parseHash, writeCampaignHash } from "./route";
 import { Icon } from "./icons";
 import { Sidebar, Topbar } from "./components";
@@ -9,6 +10,7 @@ import { NoticeBoard, KindList } from "./board";
 import { ArcsPage } from "./arcs";
 import { EventsPage } from "./events";
 import { DetailSheet } from "./detail";
+import { LivePanel } from "./livePanel";
 import { CommandPalette, useCommandPaletteHotkey } from "./commandPalette";
 import { CleanupPanel } from "./cleanupPanel";
 
@@ -78,6 +80,61 @@ function AppLoaded() {
   // doesn't re-pan. This is a UI intent, not mirrored DB state.
   const [locate, setLocate] = useState<{ id: string; seq: number } | null>(null);
   const locateSeq = useRef(0);
+  const isDm = useIsDm();
+  // Reveal reactions (issue #68): the transient push half of a release. Both
+  // are UI intents derived from session_events arriving over realtime — the
+  // feed row is the persistent half and always exists first (push + persist).
+  const [revealToast, setRevealToast] = useState<{ eventId: number; entityId: string; label: string } | null>(null);
+  const [revealFlash, setRevealFlash] = useState<{ id: string; seq: number } | null>(null);
+  const revealSeq = useRef(0);
+  // Ids of feed rows already seen, lazily seeded from the mount-time array so
+  // a reload/late-join replays the feed without replaying toasts. A Set diff,
+  // NOT a max-id watermark: bigserial ids are assigned at insert while realtime
+  // follows commit order, so a reveal can arrive carrying a lower id than an
+  // already-seen note — a watermark would silently drop it.
+  const seenEventsRef = useRef<Set<number> | null>(null);
+
+  const sessionEvents = campaign.sessionEvents;
+  const activeSessionId = campaign.activeSessionId;
+  useEffect(() => {
+    if (seenEventsRef.current === null) {
+      seenEventsRef.current = new Set(sessionEvents.map((e) => e.id));
+      return;
+    }
+    const seen = seenEventsRef.current;
+    const fresh = sessionEvents.filter((e) => !seen.has(e.id));
+    if (fresh.length === 0) return;
+    fresh.forEach((e) => seen.add(e.id));
+    // The active-session filter is load-bearing, not tidiness: viewers'
+    // projection drops reveal events pointing at hidden entities, so
+    // re-releasing a once-revealed-then-re-hidden entity makes its OLD
+    // sessions' reveal rows reappear in the projected array — the diff sees
+    // them as new, and only this filter keeps stale ceremonies from toasting.
+    const reveals = fresh.filter(
+      (e) => e.type === "reveal" && e.sessionId === activeSessionId && e.entityId,
+    );
+    if (reveals.length === 0) return;
+    const last = reveals[reveals.length - 1];
+    setRevealFlash({ id: last.entityId!, seq: ++revealSeq.current });
+    if (!isDm) {
+      // The releasing DM's feedback is the queue row flipping to "released".
+      const ent = findEntity(last.entityId);
+      setRevealToast({
+        eventId: last.id,
+        entityId: last.entityId!,
+        label: ent ? entityLabel(ent) : last.text || "something",
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionEvents]);
+
+  // Auto-dismiss keyed on eventId so re-revealing the same entity restarts the
+  // timer. Longer than shareToast's 2.2s — this one carries an action.
+  useEffect(() => {
+    if (!revealToast) return;
+    const t = window.setTimeout(() => setRevealToast(null), 6000);
+    return () => window.clearTimeout(t);
+  }, [revealToast?.eventId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const togglePalette = useCallback(() => setPaletteOpen((o) => !o), []);
   useCommandPaletteHotkey(togglePalette);
@@ -154,12 +211,14 @@ function AppLoaded() {
               onOpenEntity={setOpenId}
               locateRequest={locate}
               onLocated={() => setLocate(null)}
+              revealFlash={revealFlash}
             />
           )}
           {view === "arcs" && <ArcsPage onOpenEntity={setOpenId} />}
           {view === "events" && <EventsPage onOpenEntity={setOpenId} />}
           {!["board", "arcs", "events"].includes(view) && <KindList kind={view} onOpenEntity={setOpenId} />}
         </main>
+        <LivePanel onOpenEntity={setOpenId} />
       </div>
 
       {openId && (
@@ -195,6 +254,34 @@ function AppLoaded() {
           zIndex: 70, borderRadius: 2,
         }}>
           <Icon name="check" size={14} /> Share link copied — anyone with the link may read.
+        </div>
+      )}
+
+      {/* The transient half of a reveal (issue #68) — same dress as the share
+          toast. Single slot: a newer reveal replaces this one; the feed row in
+          the live panel is the recovery path, never this toast. */}
+      {revealToast && (
+        <div style={{
+          position: "fixed", bottom: 26, left: "50%", transform: "translateX(-50%)",
+          background: "var(--ink)", color: "var(--vellum-light)",
+          padding: "10px 14px",
+          fontFamily: "var(--font-fell)", fontStyle: "italic", fontSize: 14,
+          boxShadow: "0 6px 20px rgba(40,20,5,.45)",
+          display: "flex", alignItems: "center", gap: 12,
+          zIndex: 70, borderRadius: 2,
+        }}>
+          <span>🕯 The DM revealed <strong style={{ fontStyle: "normal" }}>{revealToast.label}</strong></span>
+          <button
+            onClick={() => { setOpenId(revealToast.entityId); setRevealToast(null); }}
+            style={{
+              background: "transparent", color: "var(--vellum-light)",
+              border: "1px solid var(--vellum-deep)", borderRadius: 2,
+              fontFamily: "var(--font-fell-sc)", letterSpacing: ".16em", fontSize: 10,
+              padding: "4px 10px", cursor: "pointer", flexShrink: 0,
+            }}
+          >
+            VIEW
+          </button>
         </div>
       )}
 

--- a/src/board.tsx
+++ b/src/board.tsx
@@ -52,10 +52,15 @@ export function NoticeBoard({
   onOpenEntity,
   locateRequest,
   onLocated,
+  revealFlash,
 }: {
   onOpenEntity: (id: string) => void;
   locateRequest?: { id: string; seq: number } | null;
   onLocated?: () => void;
+  // One-shot "this card was just revealed" pulse (issue #68): flash only, no
+  // pan/zoom, no filter changes — pulling every player's view to the card is
+  // the follow-the-DM spotlight (#75), deliberately not this.
+  revealFlash?: { id: string; seq: number } | null;
 }) {
   const campaign = useCampaign();
   const findEntity = useFindEntity();
@@ -122,6 +127,10 @@ export function NoticeBoard({
   const [tidying, setTidying] = useState(false);
   const canvasRef = useRef<HTMLDivElement>(null);
   const lastLocateSeq = useRef(-1);
+  // Seeded from the incoming prop, NOT -1: the board unmounts on other views,
+  // so a reveal that landed there would otherwise flash minutes later when the
+  // user returns — a stale ceremony. Only seq changes while mounted flash.
+  const lastRevealSeq = useRef(revealFlash?.seq ?? -1);
   const rafRef = useRef<number | null>(null);
   // The final rounded target of an in-flight tidy; kept until campaign.board
   // reflects it so cards don't flash back to their old spots between the write
@@ -300,6 +309,18 @@ export function NoticeBoard({
     setFlash({ id, n: seq });
     onLocated?.();
   }, [locateRequest]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Reveal pulse: reuse the locate flash (and its dim-the-rest treatment — the
+  // whole point is drawing every eye to the new card) but with none of the
+  // locate side effects: no pan/zoom, no filter/archived overrides, and no
+  // open-the-sheet fallback. Guarded by visible(): a card whose kind filter is
+  // off (or that isn't on the board at all) must not dim the board for nothing.
+  useEffect(() => {
+    if (!revealFlash || revealFlash.seq === lastRevealSeq.current) return;
+    lastRevealSeq.current = revealFlash.seq;
+    if (!visible(revealFlash.id)) return;
+    setFlash({ id: revealFlash.id, n: revealFlash.seq });
+  }, [revealFlash]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Decay the flash: end the glide, then clear the flash. Keyed on the flash
   // state (not locateRequest), so it re-derives its timers from state on every

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -5,8 +5,8 @@ import remarkGfm from "remark-gfm";
 import { sessionLabel, type KindKey, type PresenceUser } from "./data";
 import { Icon, MapScribble, kindIcon } from "./icons";
 import { rankIndex, KIND_LABEL, type Indexed } from "./entitySearch";
-import { useCampaign, useCampaignSwitcher, useKinds } from "./hooks";
-import { createEntity, setActiveSession } from "./mutations";
+import { useCampaign, useCampaignSwitcher, useIsDm, useKinds } from "./hooks";
+import { createEntity, endLiveSession, setActiveSession, startLiveSession, switchLiveSession } from "./mutations";
 import { SignInDialog, useAuth } from "./auth";
 
 interface Position {
@@ -599,7 +599,8 @@ function CampaignPicker() {
 // campaign-wide and synced to every client via realtime.
 function SessionPin() {
   const campaign = useCampaign();
-  const { canEdit } = useAuth();
+  const { canEdit, displayName } = useAuth();
+  const isDm = useIsDm();
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
 
@@ -635,8 +636,21 @@ function SessionPin() {
     );
   }
 
+  // When the DM moves the pin, the feed gets its start/end brackets too; other
+  // editors keep the plain pin move (the markers are the DM's ceremony).
+  // Switching A→B goes through switchLiveSession so the pin never passes
+  // through null — that would flicker "not live" across every client.
   const pick = (id: string | null) => {
-    setActiveSession(id).catch(console.error);
+    const prev = campaign.activeSessionId ?? null;
+    const author = displayName || undefined;
+    const op = !isDm || id === prev
+      ? setActiveSession(id)
+      : id && prev
+        ? switchLiveSession(prev, id, author)
+        : id
+          ? startLiveSession(id, author)
+          : endLiveSession(prev!, author);
+    op.catch(console.error);
     setOpen(false);
   };
   // Newest sessions first — that's the one you're most likely going live on.

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -15,6 +15,7 @@ import {
   unmarkSeen,
   stageEntity,
   unstageEntity,
+  releaseEntity,
   upsertBoardPosition,
   deleteBoardPosition,
 } from "./mutations";
@@ -359,6 +360,9 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
 
   const [draft, setDraft] = useState("");
   const [saving, setSaving] = useState(false);
+  // Double-click guard for the RELEASE button: the reveal event insert isn't
+  // idempotent and realtime won't flip the staging row fast enough.
+  const [releasing, setReleasing] = useState(false);
   const draftRef = useRef<HTMLDivElement>(null);
 
   // Manual strings + FK relations (resides at / member of / quest giver /
@@ -554,32 +558,58 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
               {isDm && campaign.activeSessionId && (() => {
                 const activeNum = campaign.sessions.find((s) => s.id === campaign.activeSessionId)?.num;
                 const code = activeNum != null ? sessionLabel(activeNum) : "";
-                const staged = campaign.sessionStaging.some(
+                const stagingRow = campaign.sessionStaging.find(
                   (r) => r.sessionId === campaign.activeSessionId && r.entityId === entityId,
                 );
+                const staged = !!stagingRow;
                 return (
-                  <button
-                    onClick={() => {
-                      if (staged) {
-                        unstageEntity(campaign.activeSessionId!, entityId).catch(console.error);
-                        return;
-                      }
-                      // Staging happens either way — the confirm is only the
-                      // hide offer (default yes), so Cancel truthfully means
-                      // "stage it, but leave it visible".
-                      if (!isHidden(entity) && window.confirm(`Hide “${entityLabel(entity)}” from the party until released?`)) {
-                        patch({ hidden: true });
-                      }
-                      stageEntity(campaign.activeSessionId!, entityId).catch(console.error);
-                    }}
-                    title={staged
-                      ? `Remove from the session ${code} queue`
-                      : `Stage for session ${code} — queued for one-click release from the live panel`}
-                    className="detail-action-btn"
-                    style={staged ? { borderColor: "var(--mustard)", color: "var(--mustard-deep)" } : undefined}
-                  >
-                    {staged ? `⧉ STAGED ${code}` : `⧉ STAGE ${code}`}
-                  </button>
+                  <>
+                    <button
+                      onClick={() => {
+                        if (staged) {
+                          unstageEntity(campaign.activeSessionId!, entityId).catch(console.error);
+                          return;
+                        }
+                        // Staging happens either way — the confirm is only the
+                        // hide offer (default yes), so Cancel truthfully means
+                        // "stage it, but leave it visible".
+                        if (!isHidden(entity) && window.confirm(`Hide “${entityLabel(entity)}” from the party until released?`)) {
+                          patch({ hidden: true });
+                        }
+                        stageEntity(campaign.activeSessionId!, entityId).catch(console.error);
+                      }}
+                      title={staged
+                        ? `Remove from the session ${code} queue`
+                        : `Stage for session ${code} — queued for one-click release from the live panel`}
+                      className="detail-action-btn"
+                      style={staged ? { borderColor: "var(--mustard)", color: "var(--mustard-deep)" } : undefined}
+                    >
+                      {staged ? `⧉ STAGED ${code}` : `⧉ STAGE ${code}`}
+                    </button>
+                    {/* One-click release from the sheet (issue #68) — the same
+                        verb as the live panel's queue button. Unhiding via
+                        ◈ UNREVEALED is not a release: no feed event, no
+                        released_at stamp, no seen-mark. */}
+                    {staged && !stagingRow!.releasedAt && isHidden(entity) && (
+                      <button
+                        disabled={releasing}
+                        onClick={() => {
+                          setReleasing(true);
+                          releaseEntity(kind, entityId, campaign.activeSessionId!, {
+                            author: displayName || undefined,
+                            label: entityLabel(entity),
+                          })
+                            .catch((e) => console.error("releaseEntity failed", e))
+                            .finally(() => setReleasing(false));
+                        }}
+                        title={`Reveal to the party now — unhides it, stamps the ${code} queue, and lands in the session feed`}
+                        className="detail-action-btn"
+                        style={{ borderColor: "var(--bloodred)", color: "var(--bloodred)" }}
+                      >
+                        {releasing ? "🕯 …" : "🕯 RELEASE"}
+                      </button>
+                    )}
+                  </>
                 );
               })()}
               {/* Board membership is a positions row, independent of tier/archive.

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -599,8 +599,11 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                             author: displayName || undefined,
                             label: entityLabel(entity),
                           })
-                            .catch((e) => console.error("releaseEntity failed", e))
-                            .finally(() => setReleasing(false));
+                            // Clear ONLY on failure (for retry). On success the
+                            // button unmounts once realtime flips hidden/
+                            // released_at; resetting here would re-enable it in
+                            // the echo gap and allow a duplicate release.
+                            .catch((e) => { console.error("releaseEntity failed", e); setReleasing(false); });
                         }}
                         title={`Reveal to the party now — unhides it, stamps the ${code} queue, and lands in the session feed`}
                         className="detail-action-btn"

--- a/src/livePanel.tsx
+++ b/src/livePanel.tsx
@@ -178,8 +178,11 @@ export function LivePanel({ onOpenEntity }: { onOpenEntity: (id: string) => void
   }
 
   const send = () => {
-    const el = composerRef.current;
-    const text = (el?.textContent || "").trim();
+    // Read the body from `draft` (set only by real typing), NOT el.textContent:
+    // the placeholder is a real DOM child while empty, so textContent would
+    // submit "Note for the record…" as a note on a bare Enter. Same guard as
+    // the party-notes composer's addNote.
+    const text = draft.trim();
     if (!text) return;
     insertSessionEvent({
       type: "note",
@@ -187,6 +190,7 @@ export function LivePanel({ onOpenEntity }: { onOpenEntity: (id: string) => void
       author: displayName || "Anonymous",
       text,
     }).catch(console.error);
+    const el = composerRef.current;
     if (el) el.textContent = "";
     setDraft("");
   };

--- a/src/livePanel.tsx
+++ b/src/livePanel.tsx
@@ -1,0 +1,247 @@
+import { useEffect, useRef, useState } from "react";
+import { entityLabel, isHidden, type KindKey, type SessionEvent } from "./data";
+import { Icon, kindIcon } from "./icons";
+import { useCampaign, useFindEntity, useIsDm } from "./hooks";
+import { useAuth } from "./auth";
+import { endLiveSession, insertSessionEvent, releaseEntity } from "./mutations";
+
+// The at-the-table surface (issue #67): a docked right panel that opens when a
+// session is live (campaigns.active_session_id) and closes when it isn't. It
+// occupies its own grid column in .app — shrinking .main rather than overlaying
+// it, so the board's pan/zoom yarn coordinates stay correct. Everything here
+// reads from useCampaign() and writes through mutations; there is no local
+// mirror of any DB state (collapse, draft and in-flight release are UI-only).
+
+const fmtTime = (iso: string) =>
+  new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+
+function FeedRow({ ev, onOpenEntity }: { ev: SessionEvent; onOpenEntity: (id: string) => void }) {
+  const findEntity = useFindEntity();
+  if (ev.type === "start" || ev.type === "end") {
+    return (
+      <div className="live-marker">
+        ✦ the session {ev.type === "start" ? "begins" : "ends"} · {fmtTime(ev.createdAt)} ✦
+      </div>
+    );
+  }
+  if (ev.type === "reveal") {
+    // The ceremonial row. entityId may dangle (feed rows outlive entity
+    // deletion by design) — fall back to the label snapshotted in `text`.
+    const ent = findEntity(ev.entityId);
+    const label = ent ? entityLabel(ent) : ev.text || "something struck from the codex";
+    return (
+      <div
+        className={`live-reveal${ent ? " linked" : ""}`}
+        onClick={ent ? () => onOpenEntity(ent.id) : undefined}
+        title={ent ? "Open in the codex" : undefined}
+      >
+        <div>🕯 The DM revealed <em>{label}</em></div>
+        <div className="live-meta"><span>{ev.author ? `by ${ev.author}` : ""}</span><span>{fmtTime(ev.createdAt)}</span></div>
+      </div>
+    );
+  }
+  return (
+    <div className="live-note">
+      <div>{ev.text}</div>
+      <div className="live-meta"><span>— {ev.author || "Anonymous"}</span><span>{fmtTime(ev.createdAt)}</span></div>
+    </div>
+  );
+}
+
+// The DM's release desk: tonight's staged queue, each row one click from live,
+// plus the end-of-session control. Released rows stay listed (tonight's
+// record), marked with their release time.
+function DmSection({ sessionId, onOpenEntity }: { sessionId: string; onOpenEntity: (id: string) => void }) {
+  const campaign = useCampaign();
+  const findEntity = useFindEntity();
+  const { displayName } = useAuth();
+  // In-flight releases: insertSessionEvent is not idempotent, and realtime lag
+  // means released_at won't disable the button in time — guard double-clicks
+  // locally. Cleared on failure so the button comes back.
+  const [releasing, setReleasing] = useState<ReadonlySet<string>>(new Set());
+
+  const rows = campaign.sessionStaging
+    .filter((r) => r.sessionId === sessionId)
+    // A staging row can transiently dangle between an entity delete and the
+    // staging sweep landing — skip rather than render a ghost.
+    .flatMap((r) => {
+      const ent = findEntity(r.entityId);
+      return ent ? [{ row: r, ent }] : [];
+    })
+    .sort((a, b) =>
+      (a.row.releasedAt ? 1 : 0) - (b.row.releasedAt ? 1 : 0)
+      || entityLabel(a.ent).localeCompare(entityLabel(b.ent)),
+    );
+
+  const author = displayName || undefined;
+
+  const onRelease = (kind: KindKey, entityId: string, label: string) => {
+    setReleasing((prev) => new Set(prev).add(entityId));
+    releaseEntity(kind, entityId, sessionId, { author, label }).catch((e) => {
+      console.error("releaseEntity failed", e);
+      setReleasing((prev) => {
+        const next = new Set(prev);
+        next.delete(entityId);
+        return next;
+      });
+    });
+  };
+
+  return (
+    <div className="live-dm">
+      <div className="live-dm-head">
+        <span style={{ flex: 1 }}>✦ THE DM'S DESK ✦</span>
+        <button
+          className="live-end-btn"
+          title="End the session — stamps the feed and stands the pin down"
+          onClick={() => endLiveSession(sessionId, author).catch(console.error)}
+        >
+          END SESSION
+        </button>
+      </div>
+      {rows.length === 0 && (
+        <div className="live-dm-empty">Nothing staged. Stage entities from their detail sheets.</div>
+      )}
+      {rows.map(({ row, ent }) => {
+        const kind = ent._kind as KindKey;
+        const label = entityLabel(ent);
+        return (
+          <div className="live-stage-row" key={row.entityId}>
+            <Icon name={kindIcon[kind]} size={13} />
+            <span className="lbl" onClick={() => onOpenEntity(row.entityId)} title={label}>
+              {label}
+              {/* Staged-but-visible is legal (the sheet's STAGE flow allows it)
+                  — surface it so a "reveal" of something the party already
+                  sees is deliberate, not a surprise. */}
+              {!row.releasedAt && !isHidden(ent) && <span className="live-visible-hint">visible</span>}
+            </span>
+            {row.releasedAt ? (
+              <span className="live-released" title="Released this session">✓ {fmtTime(row.releasedAt)}</span>
+            ) : (
+              <button
+                className="release-btn"
+                disabled={releasing.has(row.entityId)}
+                onClick={() => onRelease(kind, row.entityId, label)}
+                title={`Reveal “${label}” to the party — unhides it, stamps the queue, and lands in the feed`}
+              >
+                {releasing.has(row.entityId) ? "…" : "RELEASE"}
+              </button>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function LivePanel({ onOpenEntity }: { onOpenEntity: (id: string) => void }) {
+  const campaign = useCampaign();
+  const isDm = useIsDm();
+  const { canEdit, displayName } = useAuth();
+  const [collapsed, setCollapsed] = useState(false);
+  const [draft, setDraft] = useState("");
+  const composerRef = useRef<HTMLDivElement>(null);
+  const feedRef = useRef<HTMLDivElement>(null);
+  // Chat-style stickiness: follow new rows only while the reader is already at
+  // the bottom; never yank someone who scrolled up to reread.
+  const nearBottomRef = useRef(true);
+
+  const sessionId = campaign.activeSessionId ?? null;
+  const events = campaign.sessionEvents.filter((e) => e.sessionId === sessionId);
+
+  // Going live (or switching sessions) re-opens a collapsed panel — the state
+  // change is the moment the panel earns attention again.
+  useEffect(() => {
+    if (sessionId) setCollapsed(false);
+  }, [sessionId]);
+
+  useEffect(() => {
+    const el = feedRef.current;
+    if (el && nearBottomRef.current) el.scrollTop = el.scrollHeight;
+  }, [events.length, collapsed]);
+
+  if (!sessionId) return null;
+
+  const session = campaign.sessions.find((s) => s.id === sessionId);
+  // Tolerate a session deleted while pinned — the pin may briefly dangle.
+  const code = session ? String(session.num) : "—";
+
+  if (collapsed) {
+    return (
+      <aside className="live-panel is-collapsed">
+        <button className="live-expand" onClick={() => setCollapsed(false)} title="Open the session panel">
+          <span className="pin-dot live" />
+          <span className="live-vertical">✦ LIVE · SESSION {code} ✦</span>
+        </button>
+      </aside>
+    );
+  }
+
+  const send = () => {
+    const el = composerRef.current;
+    const text = (el?.textContent || "").trim();
+    if (!text) return;
+    insertSessionEvent({
+      type: "note",
+      sessionId,
+      author: displayName || "Anonymous",
+      text,
+    }).catch(console.error);
+    if (el) el.textContent = "";
+    setDraft("");
+  };
+
+  return (
+    <aside className="live-panel">
+      <header className="live-head">
+        <span className="pin-dot live" />
+        <span style={{ flex: 1 }}>LIVE · SESSION {code}</span>
+        <button className="live-collapse" onClick={() => setCollapsed(true)} title="Collapse the session panel">
+          <Icon name="chevron" size={12} />
+        </button>
+      </header>
+
+      <div
+        className="live-feed"
+        ref={feedRef}
+        onScroll={(e) => {
+          const el = e.currentTarget;
+          nearBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 60;
+        }}
+      >
+        {events.length === 0 && (
+          <div className="live-empty">The table is quiet. The record waits.</div>
+        )}
+        {events.map((ev) => (
+          <FeedRow key={ev.id} ev={ev} onOpenEntity={onOpenEntity} />
+        ))}
+      </div>
+
+      {isDm && <DmSection sessionId={sessionId} onOpenEntity={onOpenEntity} />}
+
+      {canEdit && (
+        <div className="live-composer">
+          <div
+            className="add-note live-input"
+            contentEditable
+            suppressContentEditableWarning
+            ref={composerRef}
+            onInput={(e) => setDraft(e.currentTarget.textContent || "")}
+            onKeyDown={(e) => {
+              // Enter sends (one-line chat rows, issue #67). Deliberately no
+              // send-on-blur, unlike the party-notes composer: the feed is
+              // append-only — clicking away must keep the draft, never commit
+              // a half-typed note nobody can edit or delete.
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                send();
+              }
+            }}
+          >
+            {draft ? null : "Note for the record… (↵ to send)"}
+          </div>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -280,6 +280,61 @@ export async function insertSessionEvent(ev: {
   if (error) throw error;
 }
 
+// ===== Live session: one-click release + start/end markers (PR 3, #67/#68) =
+
+// The centerpiece verb: permanent unlock + transient push, one click.
+// Ordering is load-bearing: the unhide must COMMIT before the reveal event is
+// inserted. All of a campaign's realtime rides one channel in commit order, so
+// every client processes the entity UPDATE before the session_events INSERT —
+// and the viewer projection (which drops reveal events pointing at still-hidden
+// entities) keeps the event by construction. Swap the order and player clients
+// could project the reveal away, killing the toast.
+export async function releaseEntity(
+  kind: KindKey,
+  entityId: string,
+  sessionId: string,
+  opts: { author?: string; label?: string } = {},
+) {
+  await updateEntity(kind, entityId, { hidden: false });
+  const stamp = supabase
+    .from("session_staging")
+    .update({ released_at: new Date().toISOString() })
+    .eq("campaign_id", getActiveCampaignId())
+    .eq("session_id", sessionId)
+    .eq("entity_id", entityId)
+    .then(({ error }) => { if (error) throw error; });
+  await Promise.all([
+    stamp,
+    insertSessionEvent({ type: "reveal", sessionId, author: opts.author, entityId, text: opts.label }),
+  ]);
+  // A released person has, by definition, shown up on screen. Idempotent and
+  // non-fatal — the release itself already succeeded.
+  if (kind === "people") markSeen(entityId).catch(console.error);
+}
+
+// DM ceremony around the shared pin: moving it also brackets the feed with
+// start/end markers. `author` comes from the caller (mutations can't reach
+// React context). Non-DM editors keep calling plain setActiveSession — the
+// markers are the DM's to write.
+export async function startLiveSession(sessionId: string, author?: string) {
+  await setActiveSession(sessionId);
+  await insertSessionEvent({ type: "start", sessionId, author });
+}
+
+export async function endLiveSession(sessionId: string, author?: string) {
+  await insertSessionEvent({ type: "end", sessionId, author });
+  await setActiveSession(null);
+}
+
+// Switching sessions while live must never route the pin through null — that
+// would broadcast a transient "not live", closing every client's panel and
+// resetting board session-focus for a frame.
+export async function switchLiveSession(fromId: string, toId: string, author?: string) {
+  await insertSessionEvent({ type: "end", sessionId: fromId, author });
+  await setActiveSession(toId);
+  await insertSessionEvent({ type: "start", sessionId: toId, author });
+}
+
 // session_staging.entity_id spans seven tables so it has no FK (like
 // connections) — swept here. session_events rows are deliberately NOT swept:
 // the feed is append-only history and reveals should outlive their entity

--- a/src/styles.css
+++ b/src/styles.css
@@ -235,7 +235,11 @@ body {
 /* ── App shell ────────────────────────────── */
 .app {
   display: grid;
-  grid-template-columns: 260px 1fr;
+  /* Third column is the live session panel (auto → 0 when no session is
+     live). The panel shrinks .main via grid reflow rather than overlaying it,
+     so the board's pan/zoom yarn coordinates stay correct. .main's
+     overflow:hidden zeroes its min-content, so 1fr can't blow out. */
+  grid-template-columns: 260px 1fr auto;
   grid-template-rows: 56px 1fr;
   height: 100vh;
   background: var(--vellum);
@@ -2454,3 +2458,230 @@ button.session-pin { line-height: 1; }
   background: color-mix(in srgb, var(--mustard) 12%, transparent);
   border-bottom: 1px solid var(--mustard);
 }
+
+/* ── Live session panel (M5 PR 3, issues #67/#68) ──────────────────────────
+   Docked right column of .app. All ≤14px content text sits at the
+   --ink-secondary floor per the ink-tier rules; --ink-faded/--ink-ghost only
+   on placeholders and off-states. Theme-aware variables throughout. */
+.live-panel {
+  width: 320px;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--vellum-light);
+  border-left: 1px solid var(--vellum-deep);
+  box-shadow: -2px 0 10px rgba(40,20,5,.10);
+}
+.live-panel.is-collapsed { width: 34px; }
+.live-expand {
+  flex: 1;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 0;
+  color: var(--ink-secondary);
+}
+.live-expand:hover { background: rgba(139,94,40,.08); }
+.live-vertical {
+  writing-mode: vertical-rl;
+  font-family: var(--font-fell-sc);
+  letter-spacing: .24em;
+  font-size: 10px;
+  white-space: nowrap;
+}
+
+.live-head {
+  display: flex; align-items: center; gap: 8px;
+  padding: 11px 12px;
+  border-bottom: 1px solid var(--vellum-deep);
+  font-family: var(--font-fell-sc);
+  letter-spacing: .16em;
+  font-size: 11px;
+  color: var(--ink-secondary);
+}
+/* Same pulsing dot as the Topbar SessionPin — the panel echoes the ambient
+   LIVE signal, it doesn't invent a new one. */
+.live-panel .pin-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--ink-ghost);
+  flex-shrink: 0;
+}
+.live-panel .pin-dot.live {
+  background: var(--bloodred);
+  box-shadow: 0 0 0 2px rgba(138,42,31,.25);
+  animation: pin-pulse 2s ease-in-out infinite;
+}
+.live-collapse {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--ink-faded);
+  padding: 2px;
+  display: grid; place-items: center;
+}
+.live-collapse:hover { color: var(--ink); }
+
+.live-feed {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.live-empty {
+  font-family: var(--font-fell);
+  font-style: italic;
+  font-size: 13px;
+  color: var(--ink-secondary);
+  text-align: center;
+  margin-top: 24px;
+}
+/* Note rows: small siblings of the detail sheet's .note-scrap. */
+.live-note {
+  background: var(--paper-note);
+  border: 1px solid var(--card-edge);
+  box-shadow: 0 1px 0 rgba(255,255,255,.3) inset, 0 2px 4px rgba(40,20,5,.12);
+  padding: 8px 10px 9px;
+  font-family: var(--font-hand);
+  font-size: 16px;
+  line-height: 1.2;
+  color: var(--ink);
+}
+.live-meta {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  color: var(--ink-secondary);
+  margin-top: 5px;
+  display: flex; justify-content: space-between; gap: 8px;
+}
+/* Reveal rows: the ceremonial entries — gold-washed, deep-linked. */
+.live-reveal {
+  background: color-mix(in srgb, var(--mustard) 14%, var(--vellum-light));
+  border: 1px solid var(--mustard);
+  padding: 9px 10px;
+  font-family: var(--font-fell);
+  font-style: italic;
+  font-size: 14px;
+  line-height: 1.35;
+  color: var(--ink-body);
+}
+.live-reveal em {
+  font-style: normal;
+  font-family: var(--font-fell-sc);
+  letter-spacing: .04em;
+}
+.live-reveal.linked { cursor: pointer; }
+.live-reveal.linked:hover {
+  background: color-mix(in srgb, var(--mustard) 22%, var(--vellum-light));
+}
+.live-marker {
+  text-align: center;
+  font-family: var(--font-fell-sc);
+  letter-spacing: .2em;
+  font-size: 10px;
+  color: var(--ink-secondary);
+  margin: 4px 0;
+}
+
+/* DM's desk: tonight's staged queue + end-session control. */
+.live-dm {
+  border-top: 1px solid var(--vellum-deep);
+  background: var(--vellum);
+  padding: 10px 12px;
+  max-height: 38%;
+  overflow-y: auto;
+  flex-shrink: 0;
+}
+.live-dm-head {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--font-fell-sc);
+  letter-spacing: .18em;
+  font-size: 10px;
+  color: var(--ink-secondary);
+  margin-bottom: 8px;
+}
+.live-dm-empty {
+  font-family: var(--font-fell);
+  font-style: italic;
+  font-size: 12px;
+  color: var(--ink-secondary);
+}
+.live-end-btn {
+  background: transparent;
+  border: 1px solid var(--vellum-deep);
+  border-radius: 2px;
+  font-family: var(--font-fell-sc);
+  letter-spacing: .14em;
+  font-size: 9px;
+  color: var(--ink-secondary);
+  padding: 3px 8px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.live-end-btn:hover { border-color: var(--bloodred); color: var(--bloodred); }
+.live-stage-row {
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 0;
+  border-bottom: 1px dashed var(--hairline);
+  font-family: var(--font-fell);
+  font-size: 13px;
+  color: var(--ink-body);
+}
+.live-stage-row:last-child { border-bottom: none; }
+.live-stage-row > svg { flex-shrink: 0; color: var(--ink-secondary); }
+.live-stage-row .lbl {
+  flex: 1;
+  min-width: 0;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.live-stage-row .lbl:hover { color: var(--ink); text-decoration: underline; }
+.live-visible-hint {
+  margin-left: 6px;
+  font-family: var(--font-fell-sc);
+  letter-spacing: .14em;
+  font-size: 9px;
+  color: var(--ink-secondary);
+  border: 1px dashed var(--ink-secondary);
+  padding: 1px 5px;
+  border-radius: 2px;
+}
+.release-btn {
+  background: var(--bloodred);
+  color: var(--vellum-light);
+  border: none;
+  border-radius: 2px;
+  font-family: var(--font-fell-sc);
+  letter-spacing: .14em;
+  font-size: 10px;
+  padding: 4px 10px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.release-btn:hover:not(:disabled) { background: var(--bloodred-deep); }
+.release-btn:disabled { opacity: .5; cursor: default; }
+.live-released {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: .06em;
+  color: var(--ink-secondary);
+  flex-shrink: 0;
+}
+
+.live-composer {
+  border-top: 1px solid var(--vellum-deep);
+  padding: 10px 12px;
+  flex-shrink: 0;
+}
+/* Reuses .add-note's dress; the composer sits flush in its own footer. */
+.live-composer .live-input { margin-top: 0; }


### PR DESCRIPTION
PR group 3 of **M5 — Live Session Mode**: the centerpiece UI, consuming the PR2 data layer. **No migrations.**

Closes #67. Closes #68.

## What's here

### Right sidepanel (#67)
- A docked **third grid column** of `.app` that opens while `campaigns.active_session_id` is set and **shrinks `.main` via grid reflow** rather than overlaying it — so the board's pan/zoom yarn coordinates stay correct. Collapsible to a slim vertical LIVE strip; re-opens when a session goes live.
- **Feed** interleaves `session_events`: author-signed note scraps, ceremonial gold **reveal rows** that deep-link to the detail sheet (tolerating a dangling `entity_id` via the snapshotted label), and **start/end session markers**. Auto-scrolls only when already at the bottom.
- **Composer** — one-line contentEditable, `canEdit`-gated, **Enter sends**. No send-on-blur (deliberate deviation from the party-notes composer): the feed is append-only, so clicking away keeps the draft rather than committing a half-typed note.
- **DM desk** (`isDm` only): tonight's staged queue with per-item **RELEASE** and an **End session** control; released rows stay as tonight's record; staged-but-visible rows get a "visible" hint.

### One-click release (#68)
- `releaseEntity` couples the two verbs with **no dialogs**: unhide + stamp `released_at` + insert a `reveal` event, all fire-and-forget; realtime brings it back. The unhide is **awaited before** the reveal event so every client processes the unlock first and the viewer projection keeps the reveal by construction. People are auto-marked seen.
- **Player reaction**: toast (copied from `shareToast`, with a **View** action) + board card **flash** if pinned. The DM sees no toast — their feedback is the queue row flipping to released. Toast is single-slot (never stacks); the feed row is the recovery path (push + persist).
- Also released from a hidden entity's **detail sheet** (unhide via ◈ UNREVEALED is *not* a release — no event, no stamp, no seen-mark).
- **Edges to still-hidden entities stay filtered** after a partial reveal — guaranteed by the existing central projection, no new code.

### Session markers
- When the DM moves the SessionPin, the feed is bracketed with start/end events; switching sessions routes through `switchLiveSession` so the pin **never passes through null** (no "not live" flicker across clients). Non-DM editors keep the plain pin move.

## Verification
- `npm run build` (tsc + vite) passes.
- **Two-context live run-through** (signed-in DM + anonymous viewer): DM stages and releases; viewer sees the panel, a live note within ~1s, the reveal toast + board flash + the entity becoming visible, and the edge to a still-hidden entity staying filtered; reload replays the feed **without** replaying the toast; end/start markers land and the panel closes/reopens following the pin.

## Notes
- **#66 is still OPEN on GitHub** though PR #77 shipped it — worth closing manually.
- Deferred per the milestone plan: auto-pin-on-release (optional; a per-release dialog would violate one-click), view-as-player (#69/#71), show-now takeover (#69).

🤖 Generated with [Claude Code](https://claude.com/claude-code)