### PR TITLE
Fix stale unstage in live-session DM queue: filterless session_staging realtime sub

### DIFF
--- a/src/campaignContext.tsx
+++ b/src/campaignContext.tsx
@@ -527,7 +527,16 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
         );
         channel.on(
           "postgres_changes" as any,
-          { event: "*", schema: "public", table: "session_staging", filter },
+          // NO server-side campaign_id filter here (unlike the other tables).
+          // unstageEntity() is a hard DELETE, and session_staging has no
+          // REPLICA IDENTITY FULL, so a DELETE's old-row payload carries only
+          // the composite PK (session_id, entity_id) — not campaign_id. A
+          // `campaign_id=eq.<id>` filter can't match that, so Supabase drops
+          // the event and the unstaged row lingers on other clients until a
+          // reload. The handler already refetches campaign-scoped and guards on
+          // the campaign id, so a filterless subscription is safe: the worst a
+          // cross-campaign event does is trigger one redundant scoped refetch.
+          { event: "*", schema: "public", table: "session_staging" },
           () => {
             // Composite PK, no client-side id — refetch, same as session_participants.
             supabase.from("session_staging").select("*").eq("campaign_id", campaignId).then(({ data }) => {


### PR DESCRIPTION
## Problem

In live-session mode, the DM staging queue could show a **stale row** after another client unstaged an entity, until a manual reload.

`unstageEntity()` in [src/mutations.ts](src/mutations.ts) is a hard `DELETE` on `session_staging`. The realtime subscription in [src/campaignContext.tsx](src/campaignContext.tsx) used a server-side `campaign_id=eq.<id>` filter and refetches the whole table on any change. But migration [0016](supabase/migrations/0016_session_staging_and_events.sql) sets **no `REPLICA IDENTITY FULL`** on the table, so under default replica identity a DELETE's old-row payload carries only the composite PK (`session_id`, `entity_id`) — **not `campaign_id`**. Supabase can't match the filter, so it drops the event. The refetch never fires, and with no optimistic UI the unstaged row lingers in the live panel's DM queue and the detail-sheet STAGE toggle recomputes as still-staged until reload.

This is the same dropped-DELETE mechanism already documented for `session_events` (~lines 543–551), but that table is append-only so it was harmless there; `session_staging` genuinely deletes rows. Surfaced at the table in PR #78 (live session mode, group 3).

## Fix

Drop the `campaign_id` filter on **just** the `session_staging` subscription. The handler already refetches campaign-scoped (`.eq("campaign_id", campaignId)`) and guards on the campaign id + `cancelled` flag, so a filterless subscription is correct — the same refetch-on-any-change pattern the `connections` / `board_positions` / `party_notes` handlers use. Worst case a cross-campaign event triggers one redundant scoped refetch. **No migration needed.**

## Verification

Against **real Supabase realtime** (test-campaingn only; fendwick untouched): two anon subscribers on `session_staging`, one filtered + one filterless, while a row is inserted then deleted.

```
INSERT  → both subscriptions receive it
DELETE  → FILTERED drops it (the bug) · FILTERLESS delivers it (the fix)
✅ filterless delivers the DELETE → the scoped refetch fires → stale row clears
```

Also: `npm run build` (tsc + vite) passes; app smoke-loads `test-campaingn` in the preview with the filterless channel subscribing and **zero console errors**.

## Follow-up (out of scope, noted)

The `connections` and `board_positions` handlers still use the `campaign_id` filter and also delete rows, so they likely share this dropped-DELETE class of bug. Not addressed here to keep the fix scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)