### PR TITLE
Discord OAuth sign-in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,17 +27,17 @@ Practical implication: if you find yourself adding `useState` to mirror DB state
 
 ### Auth
 
-**Two tiers** (issue #4): anonymous sessions are read-only **viewers**; email magic-link sessions are **editors**.
+**Two tiers** (issue #4): anonymous sessions are read-only **viewers**; email magic-link or Discord OAuth sessions are **editors**.
 
-[src/auth.tsx](src/auth.tsx) runs `signInAnonymously()` on first load if there's no session — every visitor always has a session. Anonymous users skip the display-name gate and land straight in the journal read-only. "Sign in to edit" in the Topbar opens `SignInDialog` → `signInWithOtp` (magic link, `emailRedirectTo: window.location.origin`; the client's default `detectSessionInUrl` consumes the link token). Editors' display name comes from `user_metadata.display_name`, falling back to their email prefix; it signs `party_notes`. `signOut` drops back to a fresh anonymous session, not a blank screen.
+[src/auth.tsx](src/auth.tsx) runs `signInAnonymously()` on first load if there's no session — every visitor always has a session. Anonymous users skip the display-name gate and land straight in the journal read-only. "Sign in to edit" in the Topbar opens `SignInDialog`, which offers two paths: `signInWithOAuth({ provider: "discord", options: { redirectTo: window.location.origin } })` and `signInWithOtp` (magic link, `emailRedirectTo: window.location.origin`); the client's default `detectSessionInUrl` consumes the callback token for both. A failed OAuth redirect lands back with `#error_description=…` and no session — `AuthProvider` strips it from the hash (before [src/route.ts](src/route.ts) can misparse it) and shows a dismissible `AuthNotice` banner. Editors' display name comes from `user_metadata.display_name`, falling back to their email prefix; it signs `party_notes`. Discord editors hit the `DisplayNameGate` with the input prefilled from Discord metadata (`custom_claims.global_name` → `full_name` → `name`), and their `user_metadata.avatar_url` shows as a small round avatar in the Topbar. `signOut` drops back to a fresh anonymous session, not a blank screen.
 
 `useAuth().canEdit` (`!!user && !user.is_anonymous`) is the single gate for edit affordances — `EditableText`/`EnumSelect` check it themselves and render plain text when false; buttons that mutate (Pin new, Draw string, sidebar `+`, PIN/ARCHIVE/STRIKE, note composer, Add Relation, portrait upload, bulk archive) are hidden behind it. Gate any new edit surface the same way.
 
 RLS (migration [0006_reject_anonymous_writes.sql](supabase/migrations/0006_reject_anonymous_writes.sql)) keeps reads open to `anon` but write policies require `(auth.jwt() ->> 'is_anonymous')::boolean is not true` — anonymous JWTs hold the `authenticated` *role*, so the claim is the only reliable gate. Storage (`entity-images`) writes are gated the same way. Advisors may still flag the policies as claim-based rather than row-based; per-campaign membership is issue #18.
 
 Dashboard config this depends on (Authentication → …):
-- Providers: **Anonymous ON** (viewer JWTs) and **Email ON** (magic link).
-- **Sign-ups disabled** — editors are invite-only, added manually via the dashboard.
+- Providers: **Anonymous ON** (viewer JWTs), **Email ON** (magic link), and **Discord ON** (client ID/secret from the Discord developer app; its OAuth2 Redirects must include `https://nsemknuzupcnvctevgfd.supabase.co/auth/v1/callback`).
+- **Sign-ups open** — anyone with the URL can become an editor via Discord or magic link.
 - URL Configuration: Site URL = production URL; `http://localhost:5173` in Redirect URLs for dev.
 
 ### Entity model

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -28,10 +28,13 @@ if (import.meta.env.DEV && import.meta.env.VITE_DEV_EDITOR_EMAIL) {
 type AuthState = {
   user: User | null;
   displayName: string | null;
-  /** True for non-anonymous (magic-link) sessions; RLS rejects anonymous writes. */
+  /** Discord avatar for OAuth editors; null for email/anonymous sessions. */
+  avatarUrl: string | null;
+  /** True for non-anonymous (magic-link or Discord) sessions; RLS rejects anonymous writes. */
   canEdit: boolean;
   setDisplayName: (name: string) => Promise<void>;
   signInWithEmail: (email: string) => Promise<void>;
+  signInWithDiscord: () => Promise<void>;
   signOut: () => Promise<void>;
 };
 
@@ -41,10 +44,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
   const [ready, setReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [authNotice, setAuthNotice] = useState<string | null>(null);
   const signingOutRef = useRef(false);
 
   useEffect(() => {
     let cancelled = false;
+
+    // A failed OAuth redirect (Discord denied, provider error, …) lands back
+    // here with #error=...&error_description=... and no session — without this
+    // the app would silently stay anonymous. Strip the params before route.ts
+    // can misread them; supabase-js only cleans up successful callbacks.
+    const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ""));
+    const oauthError = hashParams.get("error_description") || hashParams.get("error");
+    if (oauthError) {
+      setAuthNotice(oauthError.replace(/\+/g, " "));
+      history.replaceState(null, "", window.location.pathname + window.location.search);
+    }
 
     (async () => {
       const { data: existing } = await supabase.auth.getSession();
@@ -90,6 +105,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const displayName =
     (user?.user_metadata?.display_name as string | undefined)?.trim() ||
     (user?.email ? user.email.split("@")[0] : null);
+  const avatarUrl = (user?.user_metadata?.avatar_url as string | undefined) || null;
 
   const setDisplayName = async (name: string) => {
     const trimmed = name.trim();
@@ -106,6 +122,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       options: { emailRedirectTo: window.location.origin },
     });
     if (otpErr) throw otpErr;
+  };
+
+  const signInWithDiscord = async () => {
+    const { error: oauthErr } = await supabase.auth.signInWithOAuth({
+      provider: "discord",
+      options: { redirectTo: window.location.origin },
+    });
+    if (oauthErr) throw oauthErr;
   };
 
   const signOut = async () => {
@@ -131,10 +155,43 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   return (
     <AuthContext.Provider
-      value={{ user, displayName, canEdit, setDisplayName, signInWithEmail, signOut }}
+      value={{ user, displayName, avatarUrl, canEdit, setDisplayName, signInWithEmail, signInWithDiscord, signOut }}
     >
       {children}
+      {authNotice && (
+        <AuthNotice message={authNotice} onDismiss={() => setAuthNotice(null)} />
+      )}
     </AuthContext.Provider>
+  );
+}
+
+function AuthNotice({ message, onDismiss }: { message: string; onDismiss: () => void }) {
+  return (
+    <div style={{
+      position: "fixed", top: 16, left: "50%", transform: "translateX(-50%)",
+      zIndex: 110, maxWidth: 480,
+      display: "flex", alignItems: "baseline", gap: 12,
+      padding: "10px 16px",
+      background: "var(--vellum-light)", color: "var(--ink)",
+      boxShadow: "0 6px 24px rgba(40,20,5,.3)",
+      border: "1px solid var(--ink-faded)",
+      fontFamily: "var(--font-fell)", fontSize: 13,
+    }}>
+      <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".2em", fontSize: 10, color: "var(--bloodred)", whiteSpace: "nowrap" }}>
+        SIGN-IN FAILED
+      </span>
+      <span style={{ fontStyle: "italic" }}>{message}</span>
+      <button
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        style={{
+          background: "none", border: "none", cursor: "pointer",
+          color: "var(--ink-secondary)", fontSize: 14, lineHeight: 1, padding: 0,
+        }}
+      >
+        ✕
+      </button>
+    </div>
   );
 }
 
@@ -171,6 +228,18 @@ export function DisplayNameGate({ children }: { children: ReactNode }) {
   const [draft, setDraft] = useState("");
   const [saving, setSaving] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+
+  // Discord editors arrive with a provider name in metadata but no
+  // display_name — prefill it so accepting is one click, while still letting
+  // them type a persona name. Seeded by effect, not useState: the gate is
+  // already mounted when the session flips from anonymous to Discord, so an
+  // initializer would only ever see the anonymous (empty) metadata.
+  const meta = (user?.user_metadata ?? {}) as Record<string, any>;
+  const suggested = ((meta.custom_claims?.global_name || meta.full_name || meta.name || "") as string).trim();
+  useEffect(() => {
+    if (suggested) setDraft((d) => d || suggested);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.id]);
 
   if (!user) return null;
   // Anonymous visitors are read-only viewers — the name only signs party
@@ -248,10 +317,11 @@ export function DisplayNameGate({ children }: { children: ReactNode }) {
 }
 
 export function SignInDialog({ onClose }: { onClose: () => void }) {
-  const { signInWithEmail } = useAuth();
+  const { signInWithEmail, signInWithDiscord } = useAuth();
   const [email, setEmail] = useState("");
   const [sending, setSending] = useState(false);
   const [sent, setSent] = useState(false);
+  const [redirecting, setRedirecting] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
   const submit = async () => {
@@ -265,6 +335,20 @@ export function SignInDialog({ onClose }: { onClose: () => void }) {
       setErr(e instanceof Error ? e.message : String(e));
     } finally {
       setSending(false);
+    }
+  };
+
+  const discord = async () => {
+    if (redirecting) return;
+    setRedirecting(true);
+    setErr(null);
+    try {
+      // On success the page navigates away to Discord; the redirecting state
+      // only shows for the moment before that (or sticks on error below).
+      await signInWithDiscord();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+      setRedirecting(false);
     }
   };
 
@@ -297,7 +381,33 @@ export function SignInDialog({ onClose }: { onClose: () => void }) {
         ) : (
           <>
             <div style={{ fontStyle: "italic", fontSize: 15, marginBottom: 22, color: "var(--ink)" }}>
-              Members of the party sign in by email to edit the codex.
+              Members of the party sign in with Discord or by email to edit the codex.
+            </div>
+            <button
+              onClick={discord}
+              disabled={redirecting}
+              style={{
+                width: "100%", padding: "10px 16px", marginBottom: 18,
+                display: "flex", alignItems: "center", justifyContent: "center", gap: 10,
+                background: "var(--ink)", color: "var(--vellum-light)",
+                fontFamily: "var(--font-fell-sc)", letterSpacing: ".2em", fontSize: 12,
+                border: "none", cursor: redirecting ? "wait" : "pointer",
+                opacity: redirecting ? 0.7 : 1,
+              }}
+            >
+              <svg width="16" height="12" viewBox="0 0 127 96" fill="currentColor" aria-hidden="true">
+                <path d="M107.7 8.07A105.15 105.15 0 0 0 81.47 0a72.06 72.06 0 0 0-3.36 6.83 97.68 97.68 0 0 0-29.11 0A72.37 72.37 0 0 0 45.64 0a105.89 105.89 0 0 0-26.25 8.09C2.79 32.65-1.71 56.6.54 80.21a105.73 105.73 0 0 0 32.17 16.15 77.7 77.7 0 0 0 6.89-11.11 68.42 68.42 0 0 1-10.85-5.18c.91-.66 1.8-1.34 2.66-2a75.57 75.57 0 0 0 64.32 0c.87.71 1.76 1.39 2.66 2a68.68 68.68 0 0 1-10.87 5.19 77 77 0 0 0 6.89 11.1 105.25 105.25 0 0 0 32.19-16.14c2.64-27.38-4.51-51.11-18.9-72.15ZM42.45 65.69C36.18 65.69 31 60 31 53s5-12.74 11.43-12.74S54 46 53.89 53s-5.05 12.69-11.44 12.69Zm42.24 0C78.41 65.69 73.25 60 73.25 53s5-12.74 11.44-12.74S96.23 46 96.12 53s-5.04 12.69-11.43 12.69Z" />
+              </svg>
+              {redirecting ? "Opening the portal…" : "Sign in with Discord"}
+            </button>
+            <div style={{
+              display: "flex", alignItems: "center", gap: 10, marginBottom: 18,
+              fontFamily: "var(--font-fell-sc)", letterSpacing: ".2em", fontSize: 10,
+              color: "var(--ink-secondary)",
+            }}>
+              <span style={{ flex: 1, borderTop: "1px solid var(--ink-faded)" }} />
+              OR BY EMAIL
+              <span style={{ flex: 1, borderTop: "1px solid var(--ink-faded)" }} />
             </div>
             <input
               autoFocus

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -701,7 +701,7 @@ function SessionPin() {
 
 export function Topbar({ onShare }: { onShare: () => void }) {
   const campaign = useCampaign();
-  const { canEdit, displayName, signOut } = useAuth();
+  const { canEdit, displayName, avatarUrl, signOut } = useAuth();
   const [signingIn, setSigningIn] = useState(false);
   return (
     <header className="topbar">
@@ -721,6 +721,17 @@ export function Topbar({ onShare }: { onShare: () => void }) {
         <button className="btn" onClick={onShare}><Icon name="share" size={14} /> Share link</button>
         {canEdit ? (
           <>
+            {avatarUrl && (
+              <img
+                src={avatarUrl}
+                alt=""
+                referrerPolicy="no-referrer"
+                style={{
+                  width: 20, height: 20, borderRadius: "50%",
+                  border: "1px solid var(--ink-faded)", objectFit: "cover",
+                }}
+              />
+            )}
             {/* Functional micro-text, not flavor — the UI face reads better
                 than 12px italic serif. */}
             <span style={{


### PR DESCRIPTION
## Summary
- Adds **Sign in with Discord** to `SignInDialog` as a second editor path next to the email magic link, via `supabase.auth.signInWithOAuth({ provider: "discord", options: { redirectTo: window.location.origin } })`
- `DisplayNameGate` prefills the name input from Discord metadata (`custom_claims.global_name` → `full_name` → `name`) — one click to accept, or type a persona name; seeded by effect because the gate is already mounted when the session flips from anonymous to Discord
- Failed OAuth redirects land back with `#error_description=…` and no session; `AuthProvider` now strips those params from the hash (before `route.ts` can misparse them) and shows a dismissible parchment-styled **SIGN-IN FAILED** banner
- Discord editors' `user_metadata.avatar_url` shows as a small round avatar next to the display name in the Topbar (email editors unaffected)
- CLAUDE.md auth section updated: Discord provider config + sign-up policy now open

No RLS/migration changes: Discord sessions are non-anonymous, so the existing `is_anonymous` claim gate and `canEdit` logic apply unchanged.

## Dashboard prerequisites (already done / to verify)
- Discord provider enabled with client ID + secret ✅
- Discord app OAuth2 Redirects include `https://nsemknuzupcnvctevgfd.supabase.co/auth/v1/callback`
- Authentication → Sign In / Up → "Allow new users to sign up" = ON (open sign-ups)

## Test plan
- [x] `npm run build` passes
- [x] Dialog renders on both parchment and grimoire themes (verified in browser)
- [x] Discord button navigates to `discord.com/oauth2/authorize` with correct client_id, Supabase callback `redirect_uri`, `scope=email+identify`
- [x] Simulated failed callback shows the banner and cleans the URL hash
- [x] Email flow, READ-ONLY badge, and anonymous viewer state unchanged
- [ ] Full Discord roundtrip on prod (needs a real Discord login): name gate prefilled, avatar in Topbar, party note signed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)