### PR TITLE
DM-only notes field + session-end recap (#70 + #72)

### DIFF
--- a/src/campaignContext.tsx
+++ b/src/campaignContext.tsx
@@ -45,6 +45,7 @@ const archiveFields = (r: any) => ({
   archived: !!r.archived,
   pinned: !!r.pinned,
   hidden: !!r.hidden,
+  dmNotes: r.dm_notes ?? undefined,
   updatedAt: r.updated_at ?? undefined,
 });
 
@@ -135,6 +136,7 @@ const mapSession = (r: any) => ({
   imageUrl: r.image_url ?? undefined,
   inGameDate: r.in_game_date ?? undefined,
   arc: r.arc_id ?? undefined,
+  dmNotes: r.dm_notes ?? undefined,
 });
 
 const mapArc = (r: any) => ({

--- a/src/data.ts
+++ b/src/data.ts
@@ -28,6 +28,9 @@ export interface Session {
   imageUrl?: string;
   inGameDate?: string;
   arc?: string;
+  // DM prep notes (issue #70) — same projection-stripped rule as
+  // ArchivableFields.dmNotes; sessions just don't share that mixin.
+  dmNotes?: string;
 }
 
 // Story arcs group sessions and quests ("Barovia Saga"). Like sessions they
@@ -61,6 +64,10 @@ export interface ArchivableFields {
   // readable by everyone), hidden rows are projected out of the campaign
   // object entirely for non-DM users — see projectCampaignForViewers.
   hidden?: boolean;
+  // DM-only notes (issue #70): free prose, stripped from the projection for
+  // non-DM users like hidden entities — never rendered, indexed, or searched
+  // outside the DM's view. Client-gated in V1; RLS is issue #73.
+  dmNotes?: string;
   updatedAt?: string;
 }
 
@@ -303,11 +310,24 @@ export function isHidden(e: any): boolean {
 // nulls, and rewriting them here would risk write-back corruption.
 export function projectCampaignForViewers(c: Campaign): Campaign {
   const hiddenIds = new Set<string>();
-  const keep = <T extends { id: string; hidden?: boolean }>(list: T[]): T[] =>
-    list.filter((e) => {
-      if (e.hidden) hiddenIds.add(e.id);
-      return !e.hidden;
-    });
+  // dm_notes (issue #70) is stripped here too — same central-funnel rule as
+  // hidden entities, so no player surface can render it even by accident.
+  // Only entities that actually carry dmNotes get a new object; the rest keep
+  // their reference so downstream memos don't churn.
+  let sawDmNotes = false;
+  const stripDmNotes = <T extends { dmNotes?: string }>(e: T): T => {
+    if (e.dmNotes === undefined) return e;
+    sawDmNotes = true;
+    const { dmNotes: _dm, ...rest } = e;
+    return rest as T;
+  };
+  const keep = <T extends { id: string; hidden?: boolean; dmNotes?: string }>(list: T[]): T[] =>
+    list
+      .filter((e) => {
+        if (e.hidden) hiddenIds.add(e.id);
+        return !e.hidden;
+      })
+      .map(stripDmNotes);
   const people = keep(c.people);
   const locations = keep(c.locations);
   const quests = keep(c.quests);
@@ -315,12 +335,14 @@ export function projectCampaignForViewers(c: Campaign): Campaign {
   const factions = keep(c.factions);
   const items = keep(c.items);
   const lore = keep(c.lore);
-  // Identity fast path: when nothing is hidden AND nothing is staged, return
-  // the original object so downstream memos keep their referential equality.
-  // (The seven filter passes above still run — what's saved is the memo
-  // invalidation, not the scan.) Staging must be part of the condition: a
-  // staged-but-visible entity would otherwise leak the DM's prep to viewers.
-  if (hiddenIds.size === 0 && c.sessionStaging.length === 0) return c;
+  const sessions = c.sessions.map(stripDmNotes);
+  // Identity fast path: when nothing is hidden, nothing is staged AND no
+  // dm_notes exist, return the original object so downstream memos keep their
+  // referential equality. (The filter/strip passes above still run — what's
+  // saved is the memo invalidation, not the scan.) Staging must be part of
+  // the condition: a staged-but-visible entity would otherwise leak the DM's
+  // prep to viewers; dm_notes likewise would ride through untouched.
+  if (hiddenIds.size === 0 && c.sessionStaging.length === 0 && !sawDmNotes) return c;
   const dropHiddenValues = (rec: Record<string, string[]>): Record<string, string[]> =>
     Object.fromEntries(
       Object.entries(rec).map(([k, ids]) => [k, ids.filter((id) => !hiddenIds.has(id))]),
@@ -329,7 +351,7 @@ export function projectCampaignForViewers(c: Campaign): Campaign {
     Object.fromEntries(Object.entries(rec).filter(([id]) => !hiddenIds.has(id)));
   return {
     ...c,
-    people, locations, quests, goals, factions, items, lore,
+    people, locations, quests, goals, factions, items, lore, sessions,
     connections: c.connections.filter(([a, b]) => !hiddenIds.has(a) && !hiddenIds.has(b)),
     board: dropHiddenKeys(c.board),
     eventParticipants: dropHiddenValues(c.eventParticipants),
@@ -343,6 +365,37 @@ export function projectCampaignForViewers(c: Campaign): Campaign {
     // but a re-hidden entity must not leak back through old feed rows.
     sessionEvents: c.sessionEvents.filter((e) => !e.entityId || !hiddenIds.has(e.entityId)),
   };
+}
+
+// Session-end recap (issue #72): a plain deterministic transform of a
+// session's feed into a markdown digest the DM appends to the Chronicle.
+// No AI — the feed already is the record of the night. It runs on the DM's
+// unprojected campaign but the digest lands in the public `summary`, so it
+// must mirror the projection's reveal filter: reveals of currently-hidden
+// entities (released, then re-hidden) are skipped entirely — even the label
+// snapshotted in `text` would leak. Reveals whose entity was deleted fall
+// back to that snapshot, same as the live feed's rows.
+export function sessionFeedToMarkdown(
+  events: SessionEvent[],
+  resolveEntity: (id?: string | null) => Entity | null,
+): string {
+  const fmtTime = (iso: string) =>
+    new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  const lines: string[] = [];
+  for (const ev of events) {
+    const t = fmtTime(ev.createdAt);
+    if (ev.type === "start" || ev.type === "end") {
+      lines.push(`- *${t}* — ✦ the session ${ev.type === "start" ? "begins" : "ends"} ✦`);
+    } else if (ev.type === "reveal") {
+      const ent = resolveEntity(ev.entityId);
+      if (isHidden(ent)) continue;
+      const label = ent ? entityLabel(ent) : ev.text || "something struck from the codex";
+      lines.push(`- *${t}* — 🕯 **${label}** revealed${ev.author ? ` by ${ev.author}` : ""}`);
+    } else {
+      lines.push(`- *${t}* — ${ev.author || "Anonymous"}: ${ev.text ?? ""}`);
+    }
+  }
+  return `### As it happened\n\n${lines.join("\n")}`;
 }
 
 // Null tier reads as major: existing rows predate the column and every curated

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from "react";
-import { type KindKey, PERSON_STATUS_OPTIONS, PERSON_TIER_OPTIONS, entityLabel, isArchivableKind, isArchived, isHidden, isPinned, personTier, sessionLabel } from "./data";
+import { type KindKey, PERSON_STATUS_OPTIONS, PERSON_TIER_OPTIONS, entityLabel, isArchivableKind, isArchived, isHidden, isPinned, personTier, sessionFeedToMarkdown, sessionLabel } from "./data";
 import { Icon, kindIcon } from "./icons";
 import { StatusChip, EditableText, EditableMarkdown, EnumSelect, EntitySelect, EntityCombobox } from "./components";
 import { useCampaign, useFindEntity, useIsDm } from "./hooks";
@@ -20,6 +20,7 @@ import {
   deleteBoardPosition,
 } from "./mutations";
 import { findFreeSpot } from "./boardLayout";
+import { FeedRow } from "./livePanel";
 import { uploadEntityImage, type UploadableKind } from "./upload";
 import { deriveRelations } from "./relations";
 
@@ -363,6 +364,9 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
   // Double-click guard for the RELEASE button: the reveal event insert isn't
   // idempotent and realtime won't flip the staging row fast enough.
   const [releasing, setReleasing] = useState(false);
+  // Same guard for DRAFT RECAP (issue #72): the append is a read-modify-write
+  // on summary, and realtime lag would let a double-click land the digest twice.
+  const [draftingRecap, setDraftingRecap] = useState(false);
   const draftRef = useRef<HTMLDivElement>(null);
 
   // Manual strings + FK relations (resides at / member of / quest giver /
@@ -457,6 +461,24 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
     updateEntity(kind, entityId, fields).catch((e) =>
       console.error(`updateEntity(${kind}) failed`, e),
     );
+
+  // The session's own feed (issue #72): session_events are loaded campaign-
+  // wide and kept sorted, so past feeds are already in memory. Rendered
+  // read-only once the session isn't the live one — during live, the panel
+  // is the surface. Hidden-entity reveals are projected out for players.
+  const sessionFeed = kind === "sessions"
+    ? campaign.sessionEvents.filter((e) => e.sessionId === entityId)
+    : [];
+  const showFeed = sessionFeed.length > 0 && campaign.activeSessionId !== entityId;
+
+  const draftRecap = () => {
+    const digest = sessionFeedToMarkdown(sessionFeed, findEntity);
+    const existing = ((entity as any).summary ?? "").trim();
+    setDraftingRecap(true);
+    updateEntity("sessions", entityId, { summary: existing ? `${existing}\n\n${digest}` : digest })
+      .catch((e) => console.error("draft recap failed", e))
+      .finally(() => setDraftingRecap(false));
+  };
 
   const arcOptions = useMemo(
     () => campaign.arcs
@@ -814,6 +836,27 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                 </div>
               )}
 
+              {showFeed && (
+                <div className="detail-feed">
+                  <h3 style={{ marginTop: 28 }}>As It Happened</h3>
+                  <div className="detail-feed-rows">
+                    {sessionFeed.map((ev) => (
+                      <FeedRow key={ev.id} ev={ev} onOpenEntity={onOpen} />
+                    ))}
+                  </div>
+                  {isDm && (
+                    <button
+                      className="draft-recap-btn"
+                      disabled={draftingRecap}
+                      onClick={draftRecap}
+                      title="Append a markdown digest of this feed to the Chronicle — existing prose is kept"
+                    >
+                      {draftingRecap ? "…" : "✒ DRAFT RECAP FROM FEED"}
+                    </button>
+                  )}
+                </div>
+              )}
+
               {kind === "arcs" && (
                 <div className="long-note">
                   <EditableMarkdown
@@ -882,6 +925,22 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                     onSave={(v) => patch({ hooks: v })}
                     placeholder="(no warning given)"
                     style={{ display: "inline" }}
+                  />
+                </div>
+              )}
+
+              {/* DM-only notes (issue #70): one coarse field per entity, the
+                  80% substitute for per-section permissions. Client-gated on
+                  isDm like hide/stage/release; the projection strips dmNotes
+                  for everyone else, so this block can't exist for players. */}
+              {isDm && kind !== "arcs" && kind !== "events" && (
+                <div className="dm-note">
+                  <div className="dm-note-head">✦ DM'S EYES ONLY ✦</div>
+                  <EditableMarkdown
+                    value={(entity as any).dmNotes ?? ""}
+                    onSave={(v) => patch({ dmNotes: v })}
+                    placeholder="Prep notes the party never sees…"
+                    style={{ fontFamily: "var(--font-fell)" }}
                   />
                 </div>
               )}

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { type KindKey, PERSON_STATUS_OPTIONS, PERSON_TIER_OPTIONS, entityLabel, isArchivableKind, isArchived, isHidden, isPinned, personTier, sessionFeedToMarkdown, sessionLabel } from "./data";
 import { Icon, kindIcon } from "./icons";
 import { StatusChip, EditableText, EditableMarkdown, EnumSelect, EntitySelect, EntityCombobox } from "./components";
@@ -365,8 +365,15 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
   // idempotent and realtime won't flip the staging row fast enough.
   const [releasing, setReleasing] = useState(false);
   // Same guard for DRAFT RECAP (issue #72): the append is a read-modify-write
-  // on summary, and realtime lag would let a double-click land the digest twice.
+  // on summary. Like RELEASE, the guard clears on failure only — clearing on
+  // success would re-enable the button in the realtime echo gap while
+  // entity.summary is still stale. Unlike RELEASE the button doesn't unmount
+  // on success, so the echo itself (summary changing) is what re-enables it.
   const [draftingRecap, setDraftingRecap] = useState(false);
+  const entitySummary = entity ? (entity as any).summary : undefined;
+  useEffect(() => {
+    setDraftingRecap(false);
+  }, [entitySummary]);
   const draftRef = useRef<HTMLDivElement>(null);
 
   // Manual strings + FK relations (resides at / member of / quest giver /
@@ -476,8 +483,12 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
     const existing = ((entity as any).summary ?? "").trim();
     setDraftingRecap(true);
     updateEntity("sessions", entityId, { summary: existing ? `${existing}\n\n${digest}` : digest })
-      .catch((e) => console.error("draft recap failed", e))
-      .finally(() => setDraftingRecap(false));
+      // Clear ONLY on failure (for retry) — the summary-echo effect above
+      // handles success, once the appended digest is actually visible.
+      .catch((e) => {
+        console.error("draft recap failed", e);
+        setDraftingRecap(false);
+      });
   };
 
   const arcOptions = useMemo(

--- a/src/livePanel.tsx
+++ b/src/livePanel.tsx
@@ -15,7 +15,9 @@ import { endLiveSession, insertSessionEvent, releaseEntity } from "./mutations";
 const fmtTime = (iso: string) =>
   new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 
-function FeedRow({ ev, onOpenEntity }: { ev: SessionEvent; onOpenEntity: (id: string) => void }) {
+// Exported for the session detail sheet's read-only "As it happened" block
+// (issue #72) — past feeds render with the exact same row language.
+export function FeedRow({ ev, onOpenEntity }: { ev: SessionEvent; onOpenEntity: (id: string) => void }) {
   const findEntity = useFindEntity();
   if (ev.type === "start" || ev.type === "end") {
     return (

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -16,27 +16,37 @@ const fieldAlias: Record<KindKey, Record<string, string>> = {
     faction: "faction_id",
     lastSeen: "last_seen_session_id",
     imageUrl: "image_url",
+    dmNotes: "dm_notes",
   },
   quests: {
     giver: "giver_id",
     session: "session_id",
     arc: "arc_id",
+    dmNotes: "dm_notes",
   },
   locations: {
     imageUrl: "image_url",
+    dmNotes: "dm_notes",
   },
-  goals: {},
+  goals: {
+    dmNotes: "dm_notes",
+  },
   factions: {
     imageUrl: "image_url",
+    dmNotes: "dm_notes",
   },
   items: {
     imageUrl: "image_url",
+    dmNotes: "dm_notes",
   },
-  lore: {},
+  lore: {
+    dmNotes: "dm_notes",
+  },
   sessions: {
     imageUrl: "image_url",
     inGameDate: "in_game_date",
     arc: "arc_id",
+    dmNotes: "dm_notes",
   },
   arcs: {
     startSession: "start_session_id",

--- a/src/styles.css
+++ b/src/styles.css
@@ -1657,6 +1657,46 @@ button.session-pin { line-height: 1; }
   font-style: normal;
 }
 
+/* DM-only notes (issue #70): the veiled block on the detail sheet. Dashed
+   secondary-ink frame — deliberately quieter than .note-scrap (party) and
+   set apart from .long-note (public prose). Rendered only for the DM. */
+.dm-note {
+  margin-top: 28px;
+  padding: 12px 14px 14px;
+  border: 1px dashed var(--ink-secondary);
+  background: color-mix(in srgb, var(--vellum-deep) 24%, transparent);
+}
+.dm-note-head {
+  font-family: var(--font-fell-sc);
+  letter-spacing: .18em;
+  font-size: 10px;
+  color: var(--ink-secondary);
+  margin-bottom: 8px;
+}
+
+/* Session recap (issue #72): a past session's feed replayed read-only on its
+   detail sheet. Rows reuse the live panel's .live-note/.live-reveal/.live-marker
+   language; only the stack layout is ours (the panel's .live-feed provides it
+   there). */
+.detail-feed-rows {
+  margin-top: 16px;
+  display: flex; flex-direction: column; gap: 10px;
+}
+.draft-recap-btn {
+  margin-top: 12px;
+  background: transparent;
+  border: 1px solid var(--vellum-deep);
+  border-radius: 2px;
+  font-family: var(--font-fell-sc);
+  letter-spacing: .14em;
+  font-size: 10px;
+  color: var(--ink-secondary);
+  padding: 5px 12px;
+  cursor: pointer;
+}
+.draft-recap-btn:hover:not(:disabled) { border-color: var(--bloodred); color: var(--bloodred); }
+.draft-recap-btn:disabled { opacity: .5; cursor: default; }
+
 /* Relations rail */
 .detail-rail {
   padding: 24px 22px 30px;

--- a/supabase/migrations/0017_dm_notes.sql
+++ b/supabase/migrations/0017_dm_notes.sql
@@ -1,0 +1,21 @@
+-- M5 Live Session Mode, PR 5 (issue #70).
+-- DM-only notes: one nullable free-text `dm_notes` column on the 7 archivable
+-- kinds AND sessions (per-session DM prep notes are natural; sessions still
+-- get no archived/updated_at/hidden — permanent history, excluded per 0005).
+-- One coarse field, no per-section permissions — the Roll20 "GM notes on
+-- every object" shape.
+-- V1 is client-gated only, like the hidden flag (0015): the client strips
+-- dmNotes from the campaign projection for non-DM users; column-level RLS is
+-- deferred to issue #73 (needs a separate table or a view — column grants
+-- don't compose with `select *`). The 0003/0006 write policies are whole-row
+-- gates and already cover the new column, and every table here is already in
+-- the realtime publication — no index, policy, or publication work needed.
+
+alter table public.people    add column if not exists dm_notes text;
+alter table public.locations add column if not exists dm_notes text;
+alter table public.quests    add column if not exists dm_notes text;
+alter table public.goals     add column if not exists dm_notes text;
+alter table public.factions  add column if not exists dm_notes text;
+alter table public.items     add column if not exists dm_notes text;
+alter table public.lore      add column if not exists dm_notes text;
+alter table public.sessions  add column if not exists dm_notes text;


### PR DESCRIPTION
M5 Live Session Mode, PR 5 of the grouping (V1.5 "DM depth"): closes #70, closes #72. Builds on PR groups 1–3 (#76, #77, #78); group 4 is not a dependency.

## Migration (not applied — dashboard step)

[`0017_dm_notes.sql`](../blob/claude/live-session-mode-pr-group-5-792eaf/supabase/migrations/0017_dm_notes.sql): `dm_notes text` (nullable) on the 7 archivable kinds **and `sessions`** (DM prep notes per session). No new RLS/index/realtime plumbing needed — the 0003/0006 whole-row write policies cover new columns and every table is already in the publication. Sessions keep their no-`archived`/`updated_at`/`hidden` exclusion (0005): this is just a nullable column.

## #70 — DM-only notes on every entity

- One coarse field, no per-section permissions (the milestone's Kanka/World Anvil lesson).
- Standard pipeline: `dmNotes` on `ArchivableFields` + `Session`, mappers, `fieldAlias` → `dm_notes` for all 8 kinds; writes go through the existing `patch()`/`updateEntity`.
- Detail sheet: dashed `✦ DM'S EYES ONLY ✦` block (new `.dm-note` treatment, theme-aware variables) via `EditableMarkdown`, rendered only when `isDm`, above Party Notes. Arcs/events don't get the column and don't render it.
- **Defense in depth**: `projectCampaignForViewers` strips `dmNotes` from all entities (incl. sessions) for non-DM users — the same central funnel that hides hidden entities — so detail/search/⌘K can't leak it by construction. `buildIndex` never indexes it (not even for the DM). The identity fast-path now also requires "no dmNotes present"; untouched entities keep referential equality so memos don't churn. Network-level privacy stays V1 (client-gated, like `hidden`) — RLS is #73.

## #72 — session-end recap

- Any non-live session with feed rows renders them read-only on its detail sheet: "As It Happened" under the Chronicle, reusing the live panel's `FeedRow` (note scraps, gold reveal rows, session markers). Events are already loaded campaign-wide, so past feeds cost nothing extra. Hidden-entity reveals are already projected out for players.
- `✒ DRAFT RECAP FROM FEED` (DM-only): appends a plain markdown digest (`sessionFeedToMarkdown`, deterministic, no AI) to `sessions.summary` **without overwriting existing prose**, with an in-flight double-click guard.
- Leak guard: the digest runs on the DM's unprojected view but lands in the public Chronicle, so it mirrors the projection's reveal filter — reveals of currently-hidden (released-then-re-hidden) entities are skipped entirely; deleted-entity reveals fall back to the label snapshotted in `text`.

## Verification

- `npm run build` (tsc + vite) passes.
- Node unit checks against the bundled module: `projectCampaignForViewers` strips `dmNotes` from people **and sessions**, keeps untouched-entity references, keeps the identity fast-path; `sessionFeedToMarkdown` skips re-hidden reveals, falls back on dangling refs, attributes anonymous notes.
- Live dev-server checks (Fist of Ilmater, real data, via a dev-only injection harness that was removed before commit):
  - **Player view** (anonymous): "As It Happened" feed renders read-only on a past session's sheet; no DM-notes block, no recap button anywhere; ⌘K finds nothing for dmNotes-only text.
  - **DM view**: both blocks render in the sheet's visual language; clicking draft-recap produced a PATCH whose `summary` payload = existing Chronicle prose + blank line + correct digest (write itself rejected by RLS for the anonymous test session — no prod data touched); button re-enables after failure.
  - **dm_notes mutation path**: `updateEntity('items', …, { dmNotes })` sends `{"dm_notes": …}` campaign-scoped; fails today only with `Could not find the 'dm_notes' column` — confirming the payload is correct and will succeed once 0017 is applied.
- **Full end-to-end dm_notes write verification is pending the 0017 dashboard apply** (and a signed-in DM session, which this environment can't mint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)