### PR TITLE
Show-now takeover + view-as-player (#69 + #71)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -145,7 +145,7 @@ function AppLoaded() {
         // lost. Degrade to the toast — the feed row is the recovery path.
         const el = document.activeElement;
         const midEdit = el instanceof HTMLElement &&
-          (el.isContentEditable || el.tagName === "INPUT" || el.tagName === "TEXTAREA");
+          (el.isContentEditable || el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.tagName === "SELECT");
         if (ent && !midEdit) {
           // One slot, never stacked: a second show replaces the first.
           setOpenId(last.entityId!);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CampaignProvider } from "./campaignContext";
 import { AuthProvider, DisplayNameGate } from "./auth";
-import { useCampaign, useCampaignStatus, useFindEntity, useIsDm, useKinds } from "./hooks";
-import { entityLabel } from "./data";
+import { useCampaign, useCampaignStatus, useFindEntity, useIsDm, useKinds, useViewAsPlayer } from "./hooks";
+import { entityLabel, isShowEvent, stripShowMark } from "./data";
 import { campaignHash, parseHash, writeCampaignHash } from "./route";
 import { Icon } from "./icons";
 import { Sidebar, Topbar } from "./components";
@@ -81,6 +81,7 @@ function AppLoaded() {
   const [locate, setLocate] = useState<{ id: string; seq: number } | null>(null);
   const locateSeq = useRef(0);
   const isDm = useIsDm();
+  const { viewAsPlayer, setViewAsPlayer } = useViewAsPlayer();
   // Reveal reactions (issue #68): the transient push half of a release. Both
   // are UI intents derived from session_events arriving over realtime — the
   // feed row is the persistent half and always exists first (push + persist).
@@ -114,16 +115,51 @@ function AppLoaded() {
       (e) => e.type === "reveal" && e.sessionId === activeSessionId && e.entityId,
     );
     if (reveals.length === 0) return;
-    const last = reveals[reveals.length - 1];
-    setRevealFlash({ id: last.entityId!, seq: ++revealSeq.current });
-    if (!isDm) {
-      // The releasing DM's feedback is the queue row flipping to "released".
-      const ent = findEntity(last.entityId);
-      setRevealToast({
-        eventId: last.id,
-        entityId: last.entityId!,
-        label: ent ? entityLabel(ent) : last.text || "something",
-      });
+    // Partition quiet releases from "show now" takeovers (#69) and process
+    // quiet first, show last — deterministic regardless of how a realtime
+    // flush interleaves them, and a takeover always wins over a toast.
+    const quiet = reveals.filter((e) => !isShowEvent(e));
+    const shows = reveals.filter(isShowEvent);
+    if (quiet.length > 0) {
+      const last = quiet[quiet.length - 1];
+      setRevealFlash({ id: last.entityId!, seq: ++revealSeq.current });
+      if (!isDm) {
+        // The releasing DM's feedback is the queue row flipping to "released".
+        const ent = findEntity(last.entityId);
+        setRevealToast({
+          eventId: last.id,
+          entityId: last.entityId!,
+          label: ent ? entityLabel(ent) : stripShowMark(last.text) || "something",
+        });
+      }
+    }
+    if (shows.length > 0) {
+      const last = shows[shows.length - 1];
+      setRevealFlash({ id: last.entityId!, seq: ++revealSeq.current });
+      // The takeover is for player clients only — never ambush the DM who
+      // triggered it (their feedback is the feed row / queue stamp).
+      if (!isDm) {
+        const ent = findEntity(last.entityId);
+        // Don't yank the sheet out from under someone mid-edit: unmounting a
+        // focused editable never fires its blur-commit, so the draft would be
+        // lost. Degrade to the toast — the feed row is the recovery path.
+        const el = document.activeElement;
+        const midEdit = el instanceof HTMLElement &&
+          (el.isContentEditable || el.tagName === "INPUT" || el.tagName === "TEXTAREA");
+        if (ent && !midEdit) {
+          // One slot, never stacked: a second show replaces the first.
+          setOpenId(last.entityId!);
+          setRevealToast(null);
+        } else {
+          // Entity unresolvable (dropped UPDATE / deleted) or user mid-edit —
+          // a blind setOpenId would render nothing; the toast at least tells.
+          setRevealToast({
+            eventId: last.id,
+            entityId: last.entityId!,
+            label: ent ? entityLabel(ent) : stripShowMark(last.text) || "something",
+          });
+        }
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionEvents]);
@@ -281,6 +317,35 @@ function AppLoaded() {
             }}
           >
             VIEW
+          </button>
+        </div>
+      )}
+
+      {/* Mode visibility for "view as player" (#71): the mode must be
+          unmissable while active and exit in one click (NN/g modes guidance).
+          z 72: above the detail overlay (50) and toasts (70) so it stays
+          visible with a sheet open, below ⌘K (80) which opens top-center. */}
+      {viewAsPlayer && (
+        <div style={{
+          position: "fixed", top: 64, left: "50%", transform: "translateX(-50%)",
+          background: "var(--bloodred)", color: "var(--vellum-light)",
+          padding: "8px 12px 8px 16px",
+          fontFamily: "var(--font-fell-sc)", letterSpacing: ".14em", fontSize: 11,
+          boxShadow: "0 6px 20px rgba(40,20,5,.45)",
+          display: "flex", alignItems: "center", gap: 14,
+          zIndex: 72, borderRadius: 2, whiteSpace: "nowrap",
+        }}>
+          <span>◉ VIEWING AS PLAYER — hidden entries &amp; DM tools concealed</span>
+          <button
+            onClick={() => setViewAsPlayer(false)}
+            style={{
+              background: "var(--vellum-light)", color: "var(--bloodred)",
+              border: "none", borderRadius: 2,
+              fontFamily: "var(--font-fell-sc)", letterSpacing: ".16em", fontSize: 10,
+              fontWeight: 700, padding: "4px 10px", cursor: "pointer", flexShrink: 0,
+            }}
+          >
+            EXIT
           </button>
         </div>
       )}

--- a/src/campaignContext.tsx
+++ b/src/campaignContext.tsx
@@ -27,7 +27,18 @@ interface CampaignContextValue {
   // True when the signed-in editor is this campaign's DM (campaigns.dm_user_id).
   // Derived fresh every render, so it tracks campaign switches and realtime
   // changes of the campaigns row automatically. V1: client-side gate only.
+  // While viewAsPlayer is on this reads FALSE even for the real DM — it is the
+  // effective gate, and flipping it here flips the projection and every DM
+  // affordance at once (that's the whole "view as player" mechanism, #71).
   isDm: boolean;
+  // The un-flipped DM check. Only for surfaces that must survive view-as-player:
+  // the toggle/banner itself, and write paths whose *mutation choice* depends on
+  // real DM-ness (SessionPin's feed brackets) — a view toggle must never change
+  // what gets persisted.
+  isRealDm: boolean;
+  // "View as player" (#71): pure client state, reset on campaign switch.
+  viewAsPlayer: boolean;
+  setViewAsPlayer: (on: boolean) => void;
 }
 
 export const CampaignContext = createContext<CampaignContextValue>({
@@ -38,6 +49,9 @@ export const CampaignContext = createContext<CampaignContextValue>({
   activeCampaignId: null,
   switchCampaign: () => {},
   isDm: false,
+  isRealDm: false,
+  viewAsPlayer: false,
+  setViewAsPlayer: () => {},
 });
 
 // Map a DB row (snake_case, `desc`) to the app's object shape (camelCase).
@@ -327,6 +341,7 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
   const [error, setError] = useState<string | null>(null);
   const [campaigns, setCampaigns] = useState<CampaignSummary[]>([]);
   const [campaignId, setCampaignId] = useState<string | null>(null);
+  const [viewAsPlayer, setViewAsPlayer] = useState(false);
 
   // Load the picker list once, then resolve the active id:
   // hash → host-page tweak → first campaign by creation date.
@@ -404,6 +419,7 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
     setCampaign(null);
     setLoading(true);
     setError(null);
+    setViewAsPlayer(false); // a view mode never outlives its campaign
 
     (async () => {
       try {
@@ -619,7 +635,11 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
     };
   }, [campaignId]);
 
-  const isDm = !!campaign && canEdit && !!campaign.dmUserId && user?.id === campaign.dmUserId;
+  const isRealDm = !!campaign && canEdit && !!campaign.dmUserId && user?.id === campaign.dmUserId;
+  // The effective gate: "view as player" (#71) flips this one derivation and
+  // the projection below plus every isDm-gated affordance follow — that single
+  // choke point IS the feature. Real DM-ness is untouched, so exit is instant.
+  const isDm = isRealDm && !viewAsPlayer;
 
   // The single hidden-entity funnel: non-DM users get a projected campaign
   // with hidden rows (and every reference to them) stripped, so no downstream
@@ -630,7 +650,7 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
   );
 
   return (
-    <CampaignContext.Provider value={{ campaign: visibleCampaign, loading, error, campaigns, activeCampaignId: campaignId, switchCampaign, isDm }}>
+    <CampaignContext.Provider value={{ campaign: visibleCampaign, loading, error, campaigns, activeCampaignId: campaignId, switchCampaign, isDm, isRealDm, viewAsPlayer, setViewAsPlayer }}>
       {children}
     </CampaignContext.Provider>
   );

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -5,7 +5,7 @@ import remarkGfm from "remark-gfm";
 import { sessionLabel, type KindKey, type PresenceUser } from "./data";
 import { Icon, MapScribble, kindIcon } from "./icons";
 import { rankIndex, KIND_LABEL, type Indexed } from "./entitySearch";
-import { useCampaign, useCampaignSwitcher, useIsDm, useKinds } from "./hooks";
+import { useCampaign, useCampaignSwitcher, useKinds, useViewAsPlayer } from "./hooks";
 import { createEntity, endLiveSession, setActiveSession, startLiveSession, switchLiveSession } from "./mutations";
 import { SignInDialog, useAuth } from "./auth";
 
@@ -600,7 +600,10 @@ function CampaignPicker() {
 function SessionPin() {
   const campaign = useCampaign();
   const { canEdit, displayName } = useAuth();
-  const isDm = useIsDm();
+  // Real DM-ness, NOT the view-as-player-flipped gate: this decides which
+  // MUTATION runs (bracketed vs bare pin move). A view toggle changing what
+  // gets persisted would silently drop feed markers from the append-only log.
+  const { isRealDm } = useViewAsPlayer();
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
 
@@ -643,7 +646,7 @@ function SessionPin() {
   const pick = (id: string | null) => {
     const prev = campaign.activeSessionId ?? null;
     const author = displayName || undefined;
-    const op = !isDm || id === prev
+    const op = !isRealDm || id === prev
       ? setActiveSession(id)
       : id && prev
         ? switchLiveSession(prev, id, author)
@@ -702,6 +705,7 @@ function SessionPin() {
 export function Topbar({ onShare }: { onShare: () => void }) {
   const campaign = useCampaign();
   const { canEdit, displayName, signOut } = useAuth();
+  const { isRealDm, viewAsPlayer, setViewAsPlayer } = useViewAsPlayer();
   const [signingIn, setSigningIn] = useState(false);
   return (
     <header className="topbar">
@@ -718,6 +722,18 @@ export function Topbar({ onShare }: { onShare: () => void }) {
       </div>
       <div className="topbar-right">
         <Presence users={campaign.presence} />
+        {/* "View as player" (#71) — DM-only, gated on isRealDm so it doesn't
+            vanish mid-mode; while active the banner's EXIT is the off-switch,
+            so the button hides rather than double up as a second exit. */}
+        {isRealDm && !viewAsPlayer && (
+          <button
+            className="btn"
+            onClick={() => setViewAsPlayer(true)}
+            title="See the codex exactly as a player does — hidden entries and DM tools concealed"
+          >
+            <Icon name="eye" size={14} /> View as player
+          </button>
+        )}
         <button className="btn" onClick={onShare}><Icon name="share" size={14} /> Share link</button>
         {canEdit ? (
           <>

--- a/src/data.ts
+++ b/src/data.ts
@@ -188,6 +188,22 @@ export interface SessionEvent {
   createdAt: string;
 }
 
+// "Show now" (#69) rides a 'reveal' row with this sentinel prefixed to `text`:
+// the 0016 CHECK constraint pins type to note/reveal/start/end, so a dedicated
+// 'show' type needs a migration (planned for 0017). Zero-width space + bolt —
+// nothing a user would type into a label, so plain reveals can't collide.
+// Data-as-flag caveat: EVERY renderer of a reveal event's `text` must go
+// through stripShowMark, or the invisible sentinel leaks into the UI/exports.
+export const SHOW_MARK = "\u200b⚡";
+
+export function isShowEvent(e: SessionEvent): boolean {
+  return e.type === "reveal" && !!e.text?.startsWith(SHOW_MARK);
+}
+
+export function stripShowMark(text: string | undefined): string | undefined {
+  return text?.startsWith(SHOW_MARK) ? text.slice(SHOW_MARK.length) : text;
+}
+
 export type Entity =
   & (Person | Location | Quest | Goal | Faction | Item | Lore | Session | Arc | CampaignEvent)
   & { _kind?: KindKey; _kindLabel?: string };

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -621,7 +621,7 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                         released_at stamp, no seen-mark. */}
                     {staged && !stagingRow!.releasedAt && isHidden(entity) && (
                       <button
-                        disabled={releasing}
+                        disabled={releasing || showing}
                         onClick={() => {
                           setReleasing(true);
                           releaseEntity(kind, entityId, campaign.activeSessionId!, {

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { type KindKey, PERSON_STATUS_OPTIONS, PERSON_TIER_OPTIONS, entityLabel, isArchivableKind, isArchived, isHidden, isPinned, personTier, sessionLabel } from "./data";
 import { Icon, kindIcon } from "./icons";
 import { StatusChip, EditableText, EditableMarkdown, EnumSelect, EntitySelect, EntityCombobox } from "./components";
@@ -16,6 +16,7 @@ import {
   stageEntity,
   unstageEntity,
   releaseEntity,
+  showEntity,
   upsertBoardPosition,
   deleteBoardPosition,
 } from "./mutations";
@@ -363,7 +364,29 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
   // Double-click guard for the RELEASE button: the reveal event insert isn't
   // idempotent and realtime won't flip the staging row fast enough.
   const [releasing, setReleasing] = useState(false);
+  // Same guard for SHOW NOW, but cleared on settle (success and failure):
+  // this button never unmounts, and a deliberate re-show is legitimate.
+  const [showing, setShowing] = useState(false);
   const draftRef = useRef<HTMLDivElement>(null);
+
+  // Esc closes the sheet ("single Esc/click dismiss", #69 — and general UX).
+  // defaultPrevented skips Esc already claimed by an inner editor (EditableText
+  // cancel, combobox/palette close — all preventDefault, and React's root-
+  // attached handlers run before this window listener). The editable-target
+  // check is the second belt for editors that don't.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape" || e.defaultPrevented) return;
+      const el = e.target;
+      if (
+        el instanceof HTMLElement &&
+        (el.isContentEditable || el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.tagName === "SELECT")
+      ) return;
+      onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
 
   // Manual strings + FK relations (resides at / member of / quest giver /
   // happened at), unioned by the same selector the board reads — so the sheet
@@ -372,6 +395,33 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
   const relations = useMemo(
     () => deriveRelations(campaign),
     [campaign.connections, campaign.people, campaign.quests, campaign.events],
+  );
+
+  // These four sat below the `if (!entity) return null` early return, which
+  // violates the Rules of Hooks the moment `entity` resolves across renders —
+  // the sheet can legitimately mount before its row lands over realtime
+  // ("New person" opens the id right after createEntity; the takeover and
+  // deep links guard with findEntity, this flow can't). Hooks live above the
+  // return; they only read campaign, so a null entity is fine here.
+  const arcOptions = useMemo(
+    () => campaign.arcs
+      .slice()
+      .sort((a, b) => a.orderNum - b.orderNum)
+      .map((a) => ({ id: a.id, label: a.title, kind: "arcs" as const })),
+    [campaign.arcs],
+  );
+  const sessionOptions = useMemo(
+    () => campaign.sessions
+      .map((s) => ({ id: s.id, label: `${sessionLabel(s.num)} — ${s.title}`, kind: "sessions" as const })),
+    [campaign.sessions],
+  );
+  const locationOptions = useMemo(
+    () => campaign.locations.map((l) => ({ id: l.id, label: l.name, kind: "locations" as const, archived: l.archived, hidden: l.hidden })),
+    [campaign.locations],
+  );
+  const factionOptions = useMemo(
+    () => campaign.factions.map((f) => ({ id: f.id, label: f.name, kind: "factions" as const, archived: f.archived, hidden: f.hidden })),
+    [campaign.factions],
   );
 
   if (!entity) return null;
@@ -457,27 +507,6 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
     updateEntity(kind, entityId, fields).catch((e) =>
       console.error(`updateEntity(${kind}) failed`, e),
     );
-
-  const arcOptions = useMemo(
-    () => campaign.arcs
-      .slice()
-      .sort((a, b) => a.orderNum - b.orderNum)
-      .map((a) => ({ id: a.id, label: a.title, kind: "arcs" as const })),
-    [campaign.arcs],
-  );
-  const sessionOptions = useMemo(
-    () => campaign.sessions
-      .map((s) => ({ id: s.id, label: `${sessionLabel(s.num)} — ${s.title}`, kind: "sessions" as const })),
-    [campaign.sessions],
-  );
-  const locationOptions = useMemo(
-    () => campaign.locations.map((l) => ({ id: l.id, label: l.name, kind: "locations" as const, archived: l.archived, hidden: l.hidden })),
-    [campaign.locations],
-  );
-  const factionOptions = useMemo(
-    () => campaign.factions.map((f) => ({ id: f.id, label: f.name, kind: "factions" as const, archived: f.archived, hidden: f.hidden })),
-    [campaign.factions],
-  );
 
   const onDelete = () => {
     if (!entity) return;
@@ -612,6 +641,28 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
                         {releasing ? "🕯 …" : "🕯 RELEASE"}
                       </button>
                     )}
+                    {/* "Show now" (#69): the loud reveal — release semantics
+                        (unhide + stamp if queued) plus a takeover that opens
+                        this sheet on every player's screen. Legal on anything
+                        while live, hidden or not, staged or not. */}
+                    <button
+                      disabled={showing || releasing}
+                      onClick={() => {
+                        setShowing(true);
+                        showEntity(kind, entityId, campaign.activeSessionId!, {
+                          author: displayName || undefined,
+                          label: entityLabel(entity),
+                          unhide: isHidden(entity),
+                        })
+                          .catch((e) => console.error("showEntity failed", e))
+                          .finally(() => setShowing(false));
+                      }}
+                      title={`Show “${entityLabel(entity)}” now — opens it on every player's screen and lands in the ${code} feed`}
+                      className="detail-action-btn"
+                      style={{ background: "var(--bloodred)", borderColor: "var(--bloodred)", color: "var(--vellum-light)" }}
+                    >
+                      {showing ? "⚡ …" : "⚡ SHOW NOW"}
+                    </button>
                   </>
                 );
               })()}

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -16,9 +16,18 @@ export function useCampaignStatus() {
 }
 
 // The DM gate for edit affordances that go beyond canEdit (hide/reveal,
-// staging, release). False for viewers, non-DM editors, and DM-less campaigns.
+// staging, release). False for viewers, non-DM editors, DM-less campaigns —
+// and for the real DM while "view as player" is on (that flip is the feature).
 export function useIsDm(): boolean {
   return useContext(CampaignContext).isDm;
+}
+
+// "View as player" (#71). isRealDm ignores the toggle — it gates the toggle
+// affordance and banner themselves (which must survive the flip) and write
+// paths whose mutation choice depends on real DM-ness (SessionPin brackets).
+export function useViewAsPlayer() {
+  const { isRealDm, viewAsPlayer, setViewAsPlayer } = useContext(CampaignContext);
+  return { isRealDm, viewAsPlayer, setViewAsPlayer };
 }
 
 export function useCampaignSwitcher() {

--- a/src/livePanel.tsx
+++ b/src/livePanel.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState } from "react";
-import { entityLabel, isHidden, type KindKey, type SessionEvent } from "./data";
+import { entityLabel, isHidden, isShowEvent, stripShowMark, type KindKey, type SessionEvent } from "./data";
 import { Icon, kindIcon } from "./icons";
 import { useCampaign, useFindEntity, useIsDm } from "./hooks";
 import { useAuth } from "./auth";
-import { endLiveSession, insertSessionEvent, releaseEntity } from "./mutations";
+import { endLiveSession, insertSessionEvent, releaseEntity, showEntity } from "./mutations";
 
 // The at-the-table surface (issue #67): a docked right panel that opens when a
 // session is live (campaigns.active_session_id) and closes when it isn't. It
@@ -26,16 +26,18 @@ function FeedRow({ ev, onOpenEntity }: { ev: SessionEvent; onOpenEntity: (id: st
   }
   if (ev.type === "reveal") {
     // The ceremonial row. entityId may dangle (feed rows outlive entity
-    // deletion by design) — fall back to the label snapshotted in `text`.
+    // deletion by design) — fall back to the label snapshotted in `text`
+    // (always through stripShowMark: show rows carry the sentinel prefix).
     const ent = findEntity(ev.entityId);
-    const label = ent ? entityLabel(ent) : ev.text || "something struck from the codex";
+    const label = ent ? entityLabel(ent) : stripShowMark(ev.text) || "something struck from the codex";
+    const shown = isShowEvent(ev);
     return (
       <div
         className={`live-reveal${ent ? " linked" : ""}`}
         onClick={ent ? () => onOpenEntity(ent.id) : undefined}
         title={ent ? "Open in the codex" : undefined}
       >
-        <div>🕯 The DM revealed <em>{label}</em></div>
+        <div>{shown ? <>⚡ The DM showed <em>{label}</em></> : <>🕯 The DM revealed <em>{label}</em></>}</div>
         <div className="live-meta"><span>{ev.author ? `by ${ev.author}` : ""}</span><span>{fmtTime(ev.createdAt)}</span></div>
       </div>
     );
@@ -59,6 +61,10 @@ function DmSection({ sessionId, onOpenEntity }: { sessionId: string; onOpenEntit
   // means released_at won't disable the button in time — guard double-clicks
   // locally. Cleared on failure so the button comes back.
   const [releasing, setReleasing] = useState<ReadonlySet<string>>(new Set());
+  // In-flight shows, same double-click guard — but cleared on settle (success
+  // AND failure), unlike `releasing`: the SHOW button never unmounts (released
+  // rows keep it) and a deliberate re-show is legitimate.
+  const [showing, setShowing] = useState<ReadonlySet<string>>(new Set());
 
   const rows = campaign.sessionStaging
     .filter((r) => r.sessionId === sessionId)
@@ -85,6 +91,19 @@ function DmSection({ sessionId, onOpenEntity }: { sessionId: string; onOpenEntit
         return next;
       });
     });
+  };
+
+  // "Show now" (#69): the loud reveal — release semantics plus a takeover on
+  // every player client. Legal on both queued and already-released rows.
+  const onShow = (kind: KindKey, entityId: string, label: string, unhide: boolean) => {
+    setShowing((prev) => new Set(prev).add(entityId));
+    showEntity(kind, entityId, sessionId, { author, label, unhide })
+      .catch((e) => console.error("showEntity failed", e))
+      .finally(() => setShowing((prev) => {
+        const next = new Set(prev);
+        next.delete(entityId);
+        return next;
+      }));
   };
 
   return (
@@ -120,13 +139,21 @@ function DmSection({ sessionId, onOpenEntity }: { sessionId: string; onOpenEntit
             ) : (
               <button
                 className="release-btn"
-                disabled={releasing.has(row.entityId)}
+                disabled={releasing.has(row.entityId) || showing.has(row.entityId)}
                 onClick={() => onRelease(kind, row.entityId, label)}
                 title={`Reveal “${label}” to the party — unhides it, stamps the queue, and lands in the feed`}
               >
                 {releasing.has(row.entityId) ? "…" : "RELEASE"}
               </button>
             )}
+            <button
+              className="release-btn show-btn"
+              disabled={showing.has(row.entityId) || releasing.has(row.entityId)}
+              onClick={() => onShow(kind, row.entityId, label, isHidden(ent))}
+              title={`Show “${label}” now — ${row.releasedAt ? "" : "releases it and "}opens it on every player's screen`}
+            >
+              {showing.has(row.entityId) ? "…" : "⚡ SHOW"}
+            </button>
           </div>
         );
       })}

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -1,7 +1,7 @@
 import { supabase } from "./utils/supabase";
 import { getActiveCampaignId } from "./activeCampaign";
 import { getActiveSessionId } from "./activeSession";
-import { type KindKey, type PartyNote, type BoardPosition, type SessionEventType } from "./data";
+import { SHOW_MARK, type KindKey, type PartyNote, type BoardPosition, type SessionEventType } from "./data";
 
 // Realtime subscriptions in campaignContext.tsx reflect writes back into UI
 // state, so callers do not need to patch local state (fire-and-forget is fine).
@@ -309,6 +309,44 @@ export async function releaseEntity(
   ]);
   // A released person has, by definition, shown up on screen. Idempotent and
   // non-fatal — the release itself already succeeded.
+  if (kind === "people") markSeen(entityId).catch(console.error);
+}
+
+// The loud sibling of releaseEntity ("show now", #69): same permanent unlock,
+// but the transient push is a takeover — player clients open the entity's
+// sheet the moment the SHOW_MARK-prefixed reveal event lands. Same commit-
+// order doctrine as releaseEntity when unhiding. Differences from release:
+// - `unhide` is caller-decided (isHidden(entity)): re-showing an already
+//   visible entity must not touch the row — updateEntity would bump
+//   updated_at and jump it to the top of every sorted list.
+// - The staging stamp is scoped to `released_at is null`: showing an
+//   already-released row keeps its original release time, and showing a
+//   never-staged entity is a clean no-op on the queue.
+export async function showEntity(
+  kind: KindKey,
+  entityId: string,
+  sessionId: string,
+  opts: { author?: string; label?: string; unhide?: boolean } = {},
+) {
+  if (opts.unhide) await updateEntity(kind, entityId, { hidden: false });
+  const stamp = supabase
+    .from("session_staging")
+    .update({ released_at: new Date().toISOString() })
+    .eq("campaign_id", getActiveCampaignId())
+    .eq("session_id", sessionId)
+    .eq("entity_id", entityId)
+    .is("released_at", null)
+    .then(({ error }) => { if (error) throw error; });
+  await Promise.all([
+    stamp,
+    insertSessionEvent({
+      type: "reveal",
+      sessionId,
+      author: opts.author,
+      entityId,
+      text: SHOW_MARK + (opts.label ?? ""),
+    }),
+  ]);
   if (kind === "people") markSeen(entityId).catch(console.error);
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -2670,6 +2670,17 @@ button.session-pin { line-height: 1; }
 }
 .release-btn:hover:not(:disabled) { background: var(--bloodred-deep); }
 .release-btn:disabled { opacity: .5; cursor: default; }
+/* "Show now" (#69): the rare, loud sibling of RELEASE — outlined so the two
+   verbs read as different intensities, not duplicates. */
+.release-btn.show-btn {
+  background: transparent;
+  color: var(--bloodred);
+  border: 1px solid var(--bloodred);
+}
+.release-btn.show-btn:hover:not(:disabled) {
+  background: var(--bloodred);
+  color: var(--vellum-light);
+}
 .live-released {
   font-family: var(--font-ui);
   font-size: 10px;


### PR DESCRIPTION
M5 — Live Session Mode, PR group 4 (V1.5 reveal polish). Client-only, **no migrations**. Closes #69, closes #71.

## Show now (#69) — the takeover reveal

- New mutation `showEntity()` in mutations.ts: same commit-order doctrine as `releaseEntity` (unhide must commit before the event lands), but the reveal event's `text` is prefixed with `SHOW_MARK`.
  - `unhide` is caller-decided so re-showing a visible entity doesn't bump `updated_at` (which would jump it to the top of sorted lists).
  - The staging stamp is scoped `released_at is null`: original release times survive re-shows, and never-staged entities are a clean queue no-op.
- **Transport decision**: a `session_events` row, not broadcast — the row doubles as the mandatory feed record (push + persist in one write), and the existing seen-set diff in App.tsx already guarantees reloads/late joiners get the row but never the popup.
- **Marker decision (deviation from the issue's "dedicated type" option)**: `session_events.type` has a CHECK constraint (`note/reveal/start/end`, 0016) and this PR is migration-free, so the issue's other sanctioned option — "reveal with a show marker" — is used: `SHOW_MARK = "​⚡"` (non-typeable sentinel). `isShowEvent()`/`stripShowMark()` live next to the `SessionEvent` type; every `ev.text` renderer strips the mark. **Follow-up** (next free migration slot is 0018 — 0017 shipped dm_notes in #81): legalize a real `'show'` type and retire the marker; until then the feed→recap feature (#72) must strip it.
- Client: the reveal effect partitions fresh events into quiet/show (deterministic under realtime batching). Shows call `setOpenId` on player clients — one slot, a second show replaces the first, never stacked. Mid-edit clients degrade to the reveal toast (unmounting a focused editable would eat the draft). The DM is never ambushed by their own show.
- DM affordances: **⚡ SHOW** on desk rows (queued *and* released — re-show is legal), **⚡ SHOW NOW** on the detail sheet, both with settle-cleared in-flight guards. Show rows render with distinct flair ("⚡ The DM showed …").
- DetailSheet gains **Esc-to-close** (issue's "single Esc/click dismiss"), guarded by `defaultPrevented` + editable-target checks so inner editors keep their Esc-cancel.
- Takeover opens the plain detail sheet (the issue's first-listed option); the portrait-forward variant is deliberately out of scope.

## View as player (#71)

- `viewAsPlayer` client state in `CampaignProvider`, ANDed into the derived `isDm` — the single choke point feeding both the viewer projection and every DM affordance gate, so one flip renders pixel-equivalent to a **signed-in player (non-DM editor)**: hidden entities, staging queue, hide/stage/release/show buttons, DM desk all gone. (Scope: view as *player*, not view as *guest* — `canEdit` affordances intentionally remain; that's what the group's players see.)
- **Exception**: `SessionPin`'s bracket decision uses the new `isRealDm` — it picks which *mutation* runs, and a view toggle must never change what gets persisted (feed markers would silently vanish from the append-only log).
- Unmissable bloodred banner (z 72: above sheet + toasts, below ⌘K) with one-click **EXIT**; topbar toggle hides while active; state resets on campaign switch.
- Bonus: in view-as-player the DM receives toasts/takeovers exactly like a player.

## Drive-by fix: Rules-of-Hooks crash in DetailSheet

Four option `useMemo`s sat below the `if (!entity) return null` early return — a pre-existing white-screen when a sheet mounts before its row lands over realtime (the "New person" flow reproduces it; hit it live during verification). Hoisted above the return.

## Verification

- `npm run build` (tsc + vite) clean.
- Two-browser check (signed-in DM + anonymous player on the Test Campaign, live session):
  - SHOW on a hidden staged entity → player's sheet opened within ~1s; feed row "⚡ The DM showed …" on both clients; Esc, ✕, and backdrop each dismiss in one action.
  - Reload after dismissal → no popup, feed row persists (seen-set seed).
  - Second show (different entity, from the sheet's SHOW NOW) → replaced the player's open sheet, hash followed.
  - Released desk rows keep ⚡ SHOW (re-show verified, original release time preserved).
  - View as player → hidden entity vanished from list/roster/feed (its show row projected away), DM desk + all DM buttons gone (a11y tree shows zero DM affordances), banner shown; EXIT restored everything in one click.
  - Note: verification leaves one hidden "Unnamed wayfarer" person + a few show feed rows in the Test Campaign (append-only feed; service-role cleanup was declined by the permission gate).

Milestone principles check: blocking-modal slot never stacked, one-action dismiss, always backed by a feed row, late joiners never ambushed; mode unmissable while active with one-click exit; push+persist and append-only doctrine preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Post-review updates on this branch:**
- Review follow-ups (75-scored, fixed anyway): detail-sheet RELEASE now cross-guards against an in-flight SHOW (matching livePanel), and the takeover's mid-edit guard includes `SELECT` like the Esc guard.
- Merged `origin/main` (#80 Discord OAuth, #81 dm_notes + recap): `sessionFeedToMarkdown` now strips `SHOW_MARK` and words show rows as "shown to the table"; re-verified in-browser that view-as-player also conceals #81's DM'S EYES ONLY block (the #71 DM-notes criterion, now testable end-to-end).
