### PR TITLE
Replace last fixture decorations on the Notice Board

### DIFF
--- a/src/board.tsx
+++ b/src/board.tsx
@@ -586,7 +586,7 @@ export function NoticeBoard({
           }}>
             <span className="pin-head" style={{ left: "10%" }} />
             <span className="pin-head" style={{ left: "90%" }} />
-            ✦ THE NOTICE BOARD OF THE CROOKED TANKARD ✦
+            ✦ {campaign.title.toUpperCase()} ✦
           </div>
 
           <svg className="yarn-layer" viewBox={`0 0 ${bounds.w} ${bounds.h}`} preserveAspectRatio="none">
@@ -672,7 +672,7 @@ export function NoticeBoard({
             );
           })}
 
-          <div className="wax-seal" style={{ top: 120, left: 60 }}>EC</div>
+          <div className="wax-seal" style={{ top: 120, left: 60 }}>✦</div>
           <div className="wax-seal" style={{ top: 1820, left: 2200, background: "radial-gradient(circle at 35% 30%, #c5a04a 0%, #8a6820 60%, #5a430f 100%)" }}>✦</div>
         </div>
 


### PR DESCRIPTION
## Summary
- The board banner was still hardcoded to `✦ THE NOTICE BOARD OF THE CROOKED TANKARD ✦`; it now renders the active campaign's title (`campaign.title.toUpperCase()`), so it follows the campaign picker.
- The top-left wax seal dropped its fixture `EC` monogram for the neutral `✦` glyph already used by the bottom-right seal.

This picks up the only surviving remnant of #40, which had gone stale behind main (the rest of its cleanup landed via #31). Closes the loop on the stale-PR sweep (#29, #40, #47 closed as superseded).

## Test plan
- `npm run build` passes.
- Verified in the dev preview: banner reads "✦ THE FENDWICK INVESTIGATION ✦" for the active campaign; seal shows ✦; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)