### PR TITLE
Live session v2: RLS-enforced hiding via campaign_members (#73)

### DIFF
--- a/src/campaignContext.tsx
+++ b/src/campaignContext.tsx
@@ -24,9 +24,12 @@ interface CampaignContextValue {
   campaigns: CampaignSummary[];
   activeCampaignId: string | null;
   switchCampaign: (id: string) => void;
-  // True when the signed-in editor is this campaign's DM (campaigns.dm_user_id).
-  // Derived fresh every render, so it tracks campaign switches and realtime
-  // changes of the campaigns row automatically. V1: client-side gate only.
+  // True when the signed-in editor holds the dm role in campaign_members
+  // (issue #73 — supersedes campaigns.dm_user_id). Fetched per campaign; a
+  // membership change mid-session needs a reload (campaign_members isn't in
+  // the realtime publication — deliberate, membership is dashboard-managed).
+  // Since 0018 this is a UI affordance gate, not the security boundary: RLS
+  // decides what actually reaches the client.
   // While viewAsPlayer is on this reads FALSE even for the real DM — it is the
   // effective gate, and flipping it here flips the projection and every DM
   // affordance at once (that's the whole "view as player" mechanism, #71).
@@ -59,7 +62,6 @@ const archiveFields = (r: any) => ({
   archived: !!r.archived,
   pinned: !!r.pinned,
   hidden: !!r.hidden,
-  dmNotes: r.dm_notes ?? undefined,
   updatedAt: r.updated_at ?? undefined,
 });
 
@@ -150,7 +152,6 @@ const mapSession = (r: any) => ({
   imageUrl: r.image_url ?? undefined,
   inGameDate: r.in_game_date ?? undefined,
   arc: r.arc_id ?? undefined,
-  dmNotes: r.dm_notes ?? undefined,
 });
 
 const mapArc = (r: any) => ({
@@ -188,6 +189,10 @@ const buildSessionParticipants = (rows: any[]): Record<string, string[]> => {
   });
   return bySession;
 };
+
+// dm_notes side table (0018, issue #73) → entity id → text map.
+const buildDmNotes = (rows: any[]): Record<string, string> =>
+  Object.fromEntries(rows.map((r: any) => [r.entity_id, r.text ?? ""]));
 
 const mapSessionStaging = (r: any): SessionStagingRow => ({
   sessionId: r.session_id,
@@ -248,6 +253,7 @@ async function fetchCampaign(id: string): Promise<Campaign> {
     sessionParticipantsRes,
     sessionStagingRes,
     sessionEventsRes,
+    dmNotesRes,
     peopleRes,
     locationsRes,
     questsRes,
@@ -268,6 +274,8 @@ async function fetchCampaign(id: string): Promise<Campaign> {
     supabase.from("session_participants").select("*").eq("campaign_id", id),
     supabase.from("session_staging").select("*").eq("campaign_id", id),
     supabase.from("session_events").select("*").eq("campaign_id", id).order("created_at").order("id"),
+    // DM-only read policy (0018): returns rows on the DM's client, [] on all others.
+    supabase.from("dm_notes").select("*").eq("campaign_id", id),
     supabase.from("people").select("*").eq("campaign_id", id),
     supabase.from("locations").select("*").eq("campaign_id", id),
     supabase.from("quests").select("*").eq("campaign_id", id),
@@ -283,9 +291,9 @@ async function fetchCampaign(id: string): Promise<Campaign> {
 
   const first = [
     campaignRes, sessionsRes, arcsRes, eventsRes, participantsRes,
-    sessionParticipantsRes, sessionStagingRes, sessionEventsRes, peopleRes,
-    locationsRes, questsRes, goalsRes, factionsRes, itemsRes, loreRes,
-    connectionsRes, boardRes, presenceRes, notesRes,
+    sessionParticipantsRes, sessionStagingRes, sessionEventsRes, dmNotesRes,
+    peopleRes, locationsRes, questsRes, goalsRes, factionsRes, itemsRes,
+    loreRes, connectionsRes, boardRes, presenceRes, notesRes,
   ].find((r) => r.error);
   if (first?.error) throw new Error(first.error.message);
 
@@ -307,7 +315,7 @@ async function fetchCampaign(id: string): Promise<Campaign> {
     sessionStaging: (sessionStagingRes.data ?? []).map(mapSessionStaging),
     sessionEvents: (sessionEventsRes.data ?? []).map(mapSessionEvent),
     activeSessionId: campaignRes.data.active_session_id ?? undefined,
-    dmUserId: campaignRes.data.dm_user_id ?? undefined,
+    dmNotes: buildDmNotes(dmNotesRes.data ?? []),
     people: (peopleRes.data ?? []).map(mapPerson),
     locations: (locationsRes.data ?? []).map(mapLocation),
     quests: (questsRes.data ?? []).map(mapQuest),
@@ -331,7 +339,16 @@ function applyArrayChange<T extends { id: string | number }>(
   oldRow: T | null,
 ): T[] {
   if (event === "INSERT" && newRow) return [...list, newRow];
-  if (event === "UPDATE" && newRow) return list.map((item) => (item.id === newRow.id ? newRow : item));
+  if (event === "UPDATE" && newRow) {
+    // Upsert, not replace: under RLS (0018) an UPDATE can be the first event
+    // a client is ALLOWED to see for a row — a release flips hidden to false
+    // and realtime re-checks visibility per subscriber against the new row.
+    // Players never held the hidden row, so an unmatched id must append or
+    // the reveal silently vanishes until reload.
+    return list.some((item) => item.id === newRow.id)
+      ? list.map((item) => (item.id === newRow.id ? newRow : item))
+      : [...list, newRow];
+  }
   if (event === "DELETE" && oldRow) return list.filter((item) => item.id !== oldRow.id);
   return list;
 }
@@ -344,6 +361,27 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
   const [campaigns, setCampaigns] = useState<CampaignSummary[]>([]);
   const [campaignId, setCampaignId] = useState<string | null>(null);
   const [viewAsPlayer, setViewAsPlayer] = useState(false);
+  const [isDmMember, setIsDmMember] = useState(false);
+
+  // DM membership lookup (issue #73): one campaign_members row decides
+  // isRealDm. Not realtime-synced — roles are dashboard-managed, a mid-
+  // session change takes a reload. Until it resolves the DM briefly renders
+  // the player projection (no flash of hidden content the other way around).
+  useEffect(() => {
+    setIsDmMember(false);
+    if (!campaignId || !user || user.is_anonymous) return;
+    let cancelled = false;
+    supabase
+      .from("campaign_members")
+      .select("role")
+      .eq("campaign_id", campaignId)
+      .eq("user_id", user.id)
+      .eq("role", "dm")
+      .then(({ data }) => {
+        if (!cancelled) setIsDmMember((data ?? []).length > 0);
+      });
+    return () => { cancelled = true; };
+  }, [campaignId, user?.id, user?.is_anonymous]);
 
   // Load the picker list once, then resolve the active id:
   // hash → host-page tweak → first campaign by creation date.
@@ -434,6 +472,24 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
         const filter = `campaign_id=eq.${campaignId}`;
         channel = supabase.channel(`campaign:${campaignId}`);
 
+        // Shared by each table's own handler AND the reveal path below. A
+        // release makes connections/board rows that reference the revealed
+        // entity newly visible to players (0018 gates them on entity_hidden)
+        // WITHOUT any event on those tables — the rows didn't change, the
+        // entity did — so the reveal event has to trigger the refetch.
+        const refetchConnections = () => {
+          supabase.from("connections").select("*").eq("campaign_id", campaignId).then(({ data }) => {
+            if (cancelled) return;
+            setCampaign((c) => c && c.id === campaignId ? { ...c, connections: (data ?? []).map(mapConnection) } : c);
+          });
+        };
+        const refetchBoard = () => {
+          supabase.from("board_positions").select("*").eq("campaign_id", campaignId).then(({ data }) => {
+            if (cancelled) return;
+            setCampaign((c) => c && c.id === campaignId ? { ...c, board: Object.fromEntries((data ?? []).map(mapBoardPosition)) } : c);
+          });
+        };
+
         // The shared pin lives on the campaigns row itself, so it's filtered by
         // `id`, not `campaign_id`. Keep both the React state and the module-level
         // store (read by mutations) in sync when another client moves the pin.
@@ -447,7 +503,7 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
             if (cancelled) return;
             const next = payload.new?.active_session_id ?? undefined;
             setActiveSessionId(next ?? null);
-            setCampaign((c) => c && c.id === campaignId ? { ...c, activeSessionId: next, dmUserId: payload.new?.dm_user_id ?? undefined, title: payload.new?.title ?? c.title, subtitle: payload.new?.subtitle ?? c.subtitle } : c);
+            setCampaign((c) => c && c.id === campaignId ? { ...c, activeSessionId: next, title: payload.new?.title ?? c.title, subtitle: payload.new?.subtitle ?? c.subtitle } : c);
           },
         );
         channel.on(
@@ -577,6 +633,30 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
             // filter and drops them — a reload is the backstop for the rare
             // "session deleted mid-feed" case, not this handler.
             setCampaign((c) => c && c.id === campaignId ? { ...c, sessionEvents: sortSessionEvents(applyArrayChange(c.sessionEvents, payload.eventType, payload.new?.id != null ? mapSessionEvent(payload.new) : null, payload.old?.id != null ? mapSessionEvent(payload.old) : null)) } : c);
+            // Release side effect (issue #73): the revealed entity's own
+            // UPDATE arrives via its table handler, but its connections and
+            // board pin become visible without any event of their own.
+            // Unconditional (DM clients refetch redundantly but harmlessly —
+            // reveals are rare) because isDm isn't in this effect's scope.
+            if (payload.eventType === "INSERT" && payload.new?.type === "reveal") {
+              refetchConnections();
+              refetchBoard();
+            }
+          },
+        );
+        channel.on(
+          "postgres_changes" as any,
+          { event: "*", schema: "public", table: "dm_notes", filter },
+          () => {
+            // Composite PK that INCLUDES campaign_id, so unlike
+            // session_staging a DELETE's PK-only old-row still matches the
+            // server-side filter. Refetch like the other composite-PK tables;
+            // RLS returns [] on non-DM clients (the only events that even
+            // reach them are unfiltered DELETEs — metadata-only).
+            supabase.from("dm_notes").select("*").eq("campaign_id", campaignId).then(({ data }) => {
+              if (cancelled) return;
+              setCampaign((c) => c && c.id === campaignId ? { ...c, dmNotes: buildDmNotes(data ?? []) } : c);
+            });
           },
         );
         channel.on(
@@ -589,23 +669,13 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
         channel.on(
           "postgres_changes" as any,
           { event: "*", schema: "public", table: "connections", filter },
-          () => {
-            // Connections have no stable `id` on the client (stored as tuples). Refetch.
-            supabase.from("connections").select("*").eq("campaign_id", campaignId).then(({ data }) => {
-              if (cancelled) return;
-              setCampaign((c) => c && c.id === campaignId ? { ...c, connections: (data ?? []).map(mapConnection) } : c);
-            });
-          },
+          // Connections have no stable `id` on the client (stored as tuples). Refetch.
+          refetchConnections,
         );
         channel.on(
           "postgres_changes" as any,
           { event: "*", schema: "public", table: "board_positions", filter },
-          () => {
-            supabase.from("board_positions").select("*").eq("campaign_id", campaignId).then(({ data }) => {
-              if (cancelled) return;
-              setCampaign((c) => c && c.id === campaignId ? { ...c, board: Object.fromEntries((data ?? []).map(mapBoardPosition)) } : c);
-            });
-          },
+          refetchBoard,
         );
         channel.on(
           "postgres_changes" as any,
@@ -637,7 +707,7 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
     };
   }, [campaignId]);
 
-  const isRealDm = !!campaign && canEdit && !!campaign.dmUserId && user?.id === campaign.dmUserId;
+  const isRealDm = !!campaign && canEdit && isDmMember;
   // The effective gate: "view as player" (#71) flips this one derivation and
   // the projection below plus every isDm-gated affordance follow — that single
   // choke point IS the feature. Real DM-ness is untouched, so exit is instant.

--- a/src/data.ts
+++ b/src/data.ts
@@ -28,9 +28,6 @@ export interface Session {
   imageUrl?: string;
   inGameDate?: string;
   arc?: string;
-  // DM prep notes (issue #70) — same projection-stripped rule as
-  // ArchivableFields.dmNotes; sessions just don't share that mixin.
-  dmNotes?: string;
 }
 
 // Story arcs group sessions and quests ("Barovia Saga"). Like sessions they
@@ -64,10 +61,6 @@ export interface ArchivableFields {
   // readable by everyone), hidden rows are projected out of the campaign
   // object entirely for non-DM users — see projectCampaignForViewers.
   hidden?: boolean;
-  // DM-only notes (issue #70): free prose, stripped from the projection for
-  // non-DM users like hidden entities — never rendered, indexed, or searched
-  // outside the DM's view. Client-gated in V1; RLS is issue #73.
-  dmNotes?: string;
   updatedAt?: string;
 }
 
@@ -232,9 +225,10 @@ export interface Campaign {
   sessionEvents: SessionEvent[];
   // The shared "we're live in session N" pin (campaigns.active_session_id).
   activeSessionId?: string;
-  // The campaign's DM (campaigns.dm_user_id, an auth user id). One DM per
-  // campaign; V1 gating is client-side only.
-  dmUserId?: string;
+  // DM-only prep notes (issues #70/#73), entity id → text. Lives in the
+  // dm_notes side table with a DM-only read policy, so this map is populated
+  // only on the DM's client — RLS returns zero rows to everyone else.
+  dmNotes: Record<string, string>;
   people: Person[];
   locations: Location[];
   quests: Quest[];
@@ -326,24 +320,11 @@ export function isHidden(e: any): boolean {
 // nulls, and rewriting them here would risk write-back corruption.
 export function projectCampaignForViewers(c: Campaign): Campaign {
   const hiddenIds = new Set<string>();
-  // dm_notes (issue #70) is stripped here too — same central-funnel rule as
-  // hidden entities, so no player surface can render it even by accident.
-  // Only entities that actually carry dmNotes get a new object; the rest keep
-  // their reference so downstream memos don't churn.
-  let sawDmNotes = false;
-  const stripDmNotes = <T extends { dmNotes?: string }>(e: T): T => {
-    if (e.dmNotes === undefined) return e;
-    sawDmNotes = true;
-    const { dmNotes: _dm, ...rest } = e;
-    return rest as T;
-  };
-  const keep = <T extends { id: string; hidden?: boolean; dmNotes?: string }>(list: T[]): T[] =>
-    list
-      .filter((e) => {
-        if (e.hidden) hiddenIds.add(e.id);
-        return !e.hidden;
-      })
-      .map(stripDmNotes);
+  const keep = <T extends { id: string; hidden?: boolean }>(list: T[]): T[] =>
+    list.filter((e) => {
+      if (e.hidden) hiddenIds.add(e.id);
+      return !e.hidden;
+    });
   const people = keep(c.people);
   const locations = keep(c.locations);
   const quests = keep(c.quests);
@@ -351,14 +332,21 @@ export function projectCampaignForViewers(c: Campaign): Campaign {
   const factions = keep(c.factions);
   const items = keep(c.items);
   const lore = keep(c.lore);
-  const sessions = c.sessions.map(stripDmNotes);
+  // Since 0018 (issue #73) RLS already keeps hidden rows, staging and
+  // dm_notes off non-DM clients — for players this projection is normally the
+  // identity. It still must exist and still must strip everything: it is the
+  // "view as player" mechanism (#71), where the DM's own client (whose JWT
+  // receives everything) flips isDm off without changing what's loaded.
+  //
   // Identity fast path: when nothing is hidden, nothing is staged AND no
   // dm_notes exist, return the original object so downstream memos keep their
-  // referential equality. (The filter/strip passes above still run — what's
-  // saved is the memo invalidation, not the scan.) Staging must be part of
-  // the condition: a staged-but-visible entity would otherwise leak the DM's
+  // referential equality. (The filter passes above still run — what's saved
+  // is the memo invalidation, not the scan.) Staging must be part of the
+  // condition: a staged-but-visible entity would otherwise leak the DM's
   // prep to viewers; dm_notes likewise would ride through untouched.
-  if (hiddenIds.size === 0 && c.sessionStaging.length === 0 && !sawDmNotes) return c;
+  let hasDmNotes = false;
+  for (const _ in c.dmNotes) { hasDmNotes = true; break; }
+  if (hiddenIds.size === 0 && c.sessionStaging.length === 0 && !hasDmNotes) return c;
   const dropHiddenValues = (rec: Record<string, string[]>): Record<string, string[]> =>
     Object.fromEntries(
       Object.entries(rec).map(([k, ids]) => [k, ids.filter((id) => !hiddenIds.has(id))]),
@@ -367,7 +355,9 @@ export function projectCampaignForViewers(c: Campaign): Campaign {
     Object.fromEntries(Object.entries(rec).filter(([id]) => !hiddenIds.has(id)));
   return {
     ...c,
-    people, locations, quests, goals, factions, items, lore, sessions,
+    people, locations, quests, goals, factions, items, lore,
+    // DM's eyes only — emptied for the player view (issue #70/#73).
+    dmNotes: {},
     connections: c.connections.filter(([a, b]) => !hiddenIds.has(a) && !hiddenIds.has(b)),
     board: dropHiddenKeys(c.board),
     eventParticipants: dropHiddenValues(c.eventParticipants),

--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "./auth";
 import {
   insertPartyNote,
   updateEntity,
+  updateDmNotes,
   deleteEntity,
   insertConnection,
   addEventParticipant,
@@ -992,15 +993,16 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
               )}
 
               {/* DM-only notes (issue #70): one coarse field per entity, the
-                  80% substitute for per-section permissions. Client-gated on
-                  isDm like hide/stage/release; the projection strips dmNotes
-                  for everyone else, so this block can't exist for players. */}
+                  80% substitute for per-section permissions. Stored in the
+                  dm_notes side table whose RLS is DM-only (issue #73), so
+                  campaign.dmNotes is empty on every non-DM client; the isDm
+                  gate here is the view-as-player affordance, not security. */}
               {isDm && kind !== "arcs" && kind !== "events" && (
                 <div className="dm-note">
                   <div className="dm-note-head">✦ DM'S EYES ONLY ✦</div>
                   <EditableMarkdown
-                    value={(entity as any).dmNotes ?? ""}
-                    onSave={(v) => patch({ dmNotes: v })}
+                    value={campaign.dmNotes[entityId] ?? ""}
+                    onSave={(v) => updateDmNotes(entityId, v).catch((e) => console.error("updateDmNotes failed", e))}
                     placeholder="Prep notes the party never sees…"
                     style={{ fontFamily: "var(--font-fell)" }}
                   />

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -479,9 +479,13 @@ export async function deleteEntity(kind: KindKey, id: string) {
     deleteBoardPosition(id).catch(() => {}),
     deleteConnectionsFor(id),
     deletePartyNotesFor(id),
+    // Since 0018 the staging and dm_notes sweeps are DM-only at the DB
+    // layer: when a non-DM editor strikes a visible entity the DM had staged
+    // or annotated, these two match 0 rows and the orphaned row lingers.
+    // Accepted: it's invisible to players (RLS), the live panel drops
+    // staging rows whose entity is gone, and entity ids never recur (uuid) —
+    // metadata-only residue, not a leak.
     deleteSessionStagingFor(id),
-    // RLS makes this a DM-only delete; for non-DM editors the sweep is a
-    // silent 0-row no-op (a non-DM can't have a dm_note to sweep anyway).
     deleteDmNotesFor(id),
   ]);
   const { error } = await supabase

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -16,37 +16,27 @@ const fieldAlias: Record<KindKey, Record<string, string>> = {
     faction: "faction_id",
     lastSeen: "last_seen_session_id",
     imageUrl: "image_url",
-    dmNotes: "dm_notes",
   },
   quests: {
     giver: "giver_id",
     session: "session_id",
     arc: "arc_id",
-    dmNotes: "dm_notes",
   },
   locations: {
     imageUrl: "image_url",
-    dmNotes: "dm_notes",
   },
-  goals: {
-    dmNotes: "dm_notes",
-  },
+  goals: {},
   factions: {
     imageUrl: "image_url",
-    dmNotes: "dm_notes",
   },
   items: {
     imageUrl: "image_url",
-    dmNotes: "dm_notes",
   },
-  lore: {
-    dmNotes: "dm_notes",
-  },
+  lore: {},
   sessions: {
     imageUrl: "image_url",
     inGameDate: "in_game_date",
     arc: "arc_id",
-    dmNotes: "dm_notes",
   },
   arcs: {
     startSession: "start_session_id",
@@ -383,6 +373,42 @@ export async function switchLiveSession(fromId: string, toId: string, author?: s
   await insertSessionEvent({ type: "start", sessionId: toId, author });
 }
 
+// ===== DM notes =============================================================
+
+// DM-only notes live in the dm_notes side table (0018, issue #73) — a column
+// on the entity rows can't be hidden from `select *`, a table with a DM-only
+// read policy can. Empty text deletes the row so the table stays a sparse map.
+export async function updateDmNotes(entityId: string, text: string) {
+  const campaignId = getActiveCampaignId();
+  if (text.trim() === "") {
+    const { error } = await supabase
+      .from("dm_notes")
+      .delete()
+      .eq("campaign_id", campaignId)
+      .eq("entity_id", entityId);
+    if (error) throw error;
+    return;
+  }
+  const { error } = await supabase
+    .from("dm_notes")
+    .upsert(
+      { campaign_id: campaignId, entity_id: entityId, text },
+      { onConflict: "campaign_id,entity_id" },
+    );
+  if (error) throw error;
+}
+
+// dm_notes.entity_id spans eight tables (7 kinds + sessions) so it has no FK
+// (like connections) — swept on entity delete.
+async function deleteDmNotesFor(entityId: string) {
+  const { error } = await supabase
+    .from("dm_notes")
+    .delete()
+    .eq("campaign_id", getActiveCampaignId())
+    .eq("entity_id", entityId);
+  if (error) throw error;
+}
+
 // session_staging.entity_id spans seven tables so it has no FK (like
 // connections) — swept here. session_events rows are deliberately NOT swept:
 // the feed is append-only history and reveals should outlive their entity
@@ -454,6 +480,9 @@ export async function deleteEntity(kind: KindKey, id: string) {
     deleteConnectionsFor(id),
     deletePartyNotesFor(id),
     deleteSessionStagingFor(id),
+    // RLS makes this a DM-only delete; for non-DM editors the sweep is a
+    // silent 0-row no-op (a non-DM can't have a dm_note to sweep anyway).
+    deleteDmNotesFor(id),
   ]);
   const { error } = await supabase
     .from(kind)

--- a/supabase/migrations/0018_campaign_members_rls.sql
+++ b/supabase/migrations/0018_campaign_members_rls.sql
@@ -1,0 +1,417 @@
+-- ===========================================================================
+-- M5 Live Session Mode, V2 (issue #73): RLS-enforced hiding via
+-- campaign_members. V1 secrecy (0015-0017) was client-gated: hidden rows,
+-- the staging queue, and dm_notes all travel to every client and the client
+-- projection strips them. This migration makes secrecy real at the DB layer:
+-- a player client's network traffic never contains hidden rows or DM notes.
+--
+-- Design, verified empirically against a local Supabase stack (spike output
+-- in the PR): Realtime postgres_changes authorizes every event against each
+-- subscriber's SELECT policies at event time, checked against the NEW row —
+-- so flipping hidden=false delivers the full-row UPDATE to player clients
+-- that couldn't see the row before. That is what keeps one-click release
+-- (0016/PR #78) round-tripping through realtime under RLS.
+--
+-- Pieces:
+--   1. campaign_members(campaign_id, user_id, role dm|player) — supersedes
+--      campaigns.dm_user_id (kept populated so pre-deploy clients keep
+--      working; the new client reads membership instead). Seeded from
+--      dm_user_id. Writes are dashboard/service-role only, like dm_user_id.
+--   2. is_campaign_dm() / entity_hidden() helper functions. Both SECURITY
+--      DEFINER: entity_hidden MUST be — with invoker rights the new SELECT
+--      policies would make hidden rows invisible to its own subqueries,
+--      returning NULL, and `not entity_hidden(x)` would read as visible.
+--   3. dm_notes side table with DM-only read/write. Column-level privacy
+--      can't be done with column grants (they don't compose with the app's
+--      `select *`), so the 8 dm_notes columns (0017) are copied here and
+--      NULLed. Migration 0019 drops them after the client deploy is
+--      verified — NULL-then-drop keeps this step reversible.
+--   4. Hidden-gated SELECT policies on the 7 entity tables:
+--      hidden = false OR requester is the campaign's DM. Anonymous viewers
+--      keep seeing everything non-hidden (first read-gating in the app).
+--   5. Replacement write policies. CRITICAL: permissive policies OR
+--      together per command, and a FOR ALL policy's USING clause counts
+--      toward SELECT — the 0006 `for all using (nonanon)` write policies
+--      would let any signed-in editor read hidden rows straight past the
+--      new select policies. So every gated table's write policy is
+--      replaced: entity tables get hidden-aware FOR ALL policies (editors
+--      can't see, touch, delete, or unhide hidden rows; only the DM can),
+--      connections/board_positions get per-command write policies (which
+--      never count toward SELECT).
+--   6. connections + board_positions SELECT gated on the hidden-ness of
+--      the entities they reference (labels like "secretly serves" are
+--      spoiler content). session_staging becomes DM-only outright. The
+--      session_events INSERT policy restricts reveal/start/end to the DM;
+--      editors keep posting notes.
+--
+-- Understood exceptions (leak inventory — all metadata-only, no content):
+--   * DELETE events are never RLS-filtered by Realtime and carry only the
+--     PK: an unstage leaks (session_id, entity_id), a dm_notes delete leaks
+--     (campaign_id, entity_id). Opaque ids; the rows themselves stay
+--     unreadable.
+--   * event_participants / session_participants stay open-read: they can
+--     reference a hidden person, leaking an opaque person id only.
+--   * party_notes stay open-read: a party note on a hidden entity is only
+--     writable through the DM's own UI — DM error, not an attack path.
+--   * session_events stay open-read: a reveal row for a later re-hidden
+--     entity keeps its text (entity label). Re-hide is off-doctrine
+--     (reveal-forward, 0016) but the detail-sheet hide toggle exists; the
+--     client projection still strips these for display. Related realtime
+--     caveat: a re-hide UPDATE is invisible to player subscribers (RLS
+--     filters it), so their in-memory copy lingers until reload.
+--   * Per-campaign WRITE scoping (any editor can write any campaign) is
+--     unchanged — split into its own follow-up per issue #73.
+--
+-- Advisor notes: helpers pin search_path; the is_anonymous claim checks are
+-- wrapped in scalar subqueries for initplan caching. rls_policy heuristics
+-- may still flag the claim-based halves, as with 0006 — by design.
+--
+-- Rollout: apply this, then deploy the client built against it,
+-- back-to-back (not on a session night). Gap behavior on the old client:
+-- players simply stop receiving hidden rows (the projection no-ops); the
+-- DM's dm-notes editor reads/writes the NULLed columns until the deploy.
+-- Then verify, then apply 0019 (drops the dm_notes columns).
+-- ===========================================================================
+
+-- ==========================================================================
+-- 1. campaign_members
+-- ==========================================================================
+
+create table if not exists public.campaign_members (
+  campaign_id text not null references public.campaigns(id) on delete cascade,
+  user_id     uuid not null references auth.users(id) on delete cascade,
+  role        text not null check (role in ('dm', 'player')),
+  primary key (campaign_id, user_id)
+);
+
+-- Older projects have default privileges that cover new tables; newer
+-- Supabase stacks don't auto-grant to anon/authenticated. Explicit is safe
+-- on both (verified necessary on the spike stack).
+grant select on public.campaign_members to anon, authenticated;
+
+alter table public.campaign_members enable row level security;
+
+drop policy if exists "campaign_members are readable by anyone" on public.campaign_members;
+create policy "campaign_members are readable by anyone"
+  on public.campaign_members for select
+  to anon, authenticated
+  using (true);
+-- No write policies: membership is managed via dashboard/SQL (service
+-- role), exactly like campaigns.dm_user_id was. RLS-enabled + no policy =
+-- deny-all for client roles.
+
+-- Seed the DM rows from campaigns.dm_user_id (text, so guard the cast).
+insert into public.campaign_members (campaign_id, user_id, role)
+select id, dm_user_id::uuid, 'dm'
+from public.campaigns
+where dm_user_id ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+on conflict (campaign_id, user_id) do update set role = 'dm';
+
+do $$
+declare
+  src bigint;
+  dst bigint;
+begin
+  select count(*) into src from public.campaigns
+    where dm_user_id ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$';
+  select count(*) into dst from public.campaign_members where role = 'dm';
+  if dst < src then
+    raise exception 'campaign_members seed incomplete: % dm rows for % campaigns with a dm_user_id', dst, src;
+  end if;
+end;
+$$;
+
+-- ==========================================================================
+-- 2. Helpers
+-- ==========================================================================
+
+create or replace function public.is_campaign_dm(cid text)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1
+    from public.campaign_members m
+    where m.campaign_id = cid
+      and m.user_id = auth.uid()
+      and m.role = 'dm'
+  );
+$$;
+
+-- Cross-kind hidden lookup for reference tables (connections/board). The
+-- id may belong to sessions/arcs/events, which have no hidden column and
+-- miss all seven lookups — coalesce(..., false) keeps those visible (NULL
+-- in a USING clause would deny, vanishing every session-linked connection).
+create or replace function public.entity_hidden(eid text)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select coalesce(
+    (select hidden from public.people    where id = eid),
+    (select hidden from public.locations where id = eid),
+    (select hidden from public.quests    where id = eid),
+    (select hidden from public.goals     where id = eid),
+    (select hidden from public.factions  where id = eid),
+    (select hidden from public.items     where id = eid),
+    (select hidden from public.lore      where id = eid),
+    false
+  );
+$$;
+
+grant execute on function public.is_campaign_dm(text) to anon, authenticated;
+grant execute on function public.entity_hidden(text) to anon, authenticated;
+
+-- ==========================================================================
+-- 3. dm_notes side table (+ copy, + NULL the source columns)
+-- ==========================================================================
+
+create table if not exists public.dm_notes (
+  campaign_id text not null references public.campaigns(id) on delete cascade,
+  entity_id   text not null,  -- cross-kind ref (7 kinds + sessions), no FK
+  text        text,
+  updated_at  timestamptz not null default now(),
+  primary key (campaign_id, entity_id)
+);
+
+grant select, insert, update, delete on public.dm_notes to authenticated;
+
+drop trigger if exists tg_dm_notes_touch on public.dm_notes;
+create trigger tg_dm_notes_touch
+  before update on public.dm_notes
+  for each row execute function public.touch_updated_at();
+
+alter table public.dm_notes enable row level security;
+
+drop policy if exists "dm reads dm_notes" on public.dm_notes;
+create policy "dm reads dm_notes"
+  on public.dm_notes for select
+  to authenticated
+  using (public.is_campaign_dm(campaign_id));
+
+drop policy if exists "dm writes dm_notes" on public.dm_notes;
+create policy "dm writes dm_notes"
+  on public.dm_notes for all
+  to authenticated
+  using      ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and public.is_campaign_dm(campaign_id))
+  with check ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and public.is_campaign_dm(campaign_id));
+
+-- Copy, assert, then close the read leak by NULLing (0019 drops the
+-- columns once the deployed client is verified).
+insert into public.dm_notes (campaign_id, entity_id, text)
+select campaign_id, id, dm_notes from public.people    where dm_notes is not null union all
+select campaign_id, id, dm_notes from public.locations where dm_notes is not null union all
+select campaign_id, id, dm_notes from public.quests    where dm_notes is not null union all
+select campaign_id, id, dm_notes from public.goals     where dm_notes is not null union all
+select campaign_id, id, dm_notes from public.factions  where dm_notes is not null union all
+select campaign_id, id, dm_notes from public.items     where dm_notes is not null union all
+select campaign_id, id, dm_notes from public.lore      where dm_notes is not null union all
+select campaign_id, id, dm_notes from public.sessions  where dm_notes is not null
+on conflict (campaign_id, entity_id) do nothing;
+
+do $$
+declare
+  src bigint;
+  dst bigint;
+begin
+  select (select count(*) from public.people    where dm_notes is not null)
+       + (select count(*) from public.locations where dm_notes is not null)
+       + (select count(*) from public.quests    where dm_notes is not null)
+       + (select count(*) from public.goals     where dm_notes is not null)
+       + (select count(*) from public.factions  where dm_notes is not null)
+       + (select count(*) from public.items     where dm_notes is not null)
+       + (select count(*) from public.lore      where dm_notes is not null)
+       + (select count(*) from public.sessions  where dm_notes is not null)
+    into src;
+  select count(*) into dst from public.dm_notes;
+  if dst < src then
+    raise exception 'dm_notes copy incomplete: % side-table rows for % source notes', dst, src;
+  end if;
+end;
+$$;
+
+update public.people    set dm_notes = null where dm_notes is not null;
+update public.locations set dm_notes = null where dm_notes is not null;
+update public.quests    set dm_notes = null where dm_notes is not null;
+update public.goals     set dm_notes = null where dm_notes is not null;
+update public.factions  set dm_notes = null where dm_notes is not null;
+update public.items     set dm_notes = null where dm_notes is not null;
+update public.lore      set dm_notes = null where dm_notes is not null;
+update public.sessions  set dm_notes = null where dm_notes is not null;
+
+-- Realtime publication (guarded, 0016 pattern).
+do $$
+begin
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime' and schemaname = 'public' and tablename = 'dm_notes'
+  ) then
+    alter publication supabase_realtime add table public.dm_notes;
+  end if;
+end;
+$$;
+
+-- ==========================================================================
+-- 4 + 5. The 7 entity tables: hidden-gated SELECT, hidden-aware writes
+-- ==========================================================================
+-- Write-policy truth table (FOR ALL: SELECT/DELETE check USING, INSERT
+-- checks WITH CHECK, UPDATE checks USING on the old row and WITH CHECK on
+-- the new): a non-DM editor can't target a hidden row (USING fails: no
+-- blind update/delete), can't set hidden=true (WITH CHECK fails on the new
+-- row), can't insert hidden rows; the DM can do all of it. `hidden` is
+-- NOT NULL so the comparisons never NULL out.
+
+drop policy if exists "anon read people" on public.people;
+create policy "visible or dm read people" on public.people
+  for select to anon, authenticated
+  using (hidden = false or public.is_campaign_dm(campaign_id));
+drop policy if exists "member write people" on public.people;
+create policy "member write people" on public.people
+  for all to authenticated
+  using      ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and (hidden = false or public.is_campaign_dm(campaign_id)))
+  with check ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and (hidden = false or public.is_campaign_dm(campaign_id)));
+
+drop policy if exists "anon read locations" on public.locations;
+create policy "visible or dm read locations" on public.locations
+  for select to anon, authenticated
+  using (hidden = false or public.is_campaign_dm(campaign_id));
+drop policy if exists "member write locations" on public.locations;
+create policy "member write locations" on public.locations
+  for all to authenticated
+  using      ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and (hidden = false or public.is_campaign_dm(campaign_id)))
+  with check ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and (hidden = false or public.is_campaign_dm(campaign_id)));
+
+drop policy if exists "anon read quests" on public.quests;
+create policy "visible or dm read quests" on public.quests
+  for select to anon, authenticated
+  using (hidden = false or public.is_campaign_dm(campaign_id));
+drop policy if exists "member write quests" on public.quests;
+create policy "member write quests" on public.quests
+  for all to authenticated
+  using      ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and (hidden = false or public.is_campaign_dm(campaign_id)))
+  with check ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and (hidden = false or public.is_campaign_dm(campaign_id)));
+
+drop policy if exists "anon read goals" on public.goals;
+create policy "visible or dm read goals" on public.goals
+  for select to anon, authenticated
+  using (hidden = false or public.is_campaign_dm(campaign_id));
+drop policy if exists "member write goals" on public.goals;
+create policy "member write goals" on public.goals
+  for all to authenticated
+  using      ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and (hidden = false or public.is_campaign_dm(campaign_id)))
+  with check ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and (hidden = false or public.is_campaign_dm(campaign_id)));
+
+drop policy if exists "anon read factions" on public.factions;
+create policy "visible or dm read factions" on public.factions
+  for select to anon, authenticated
+  using (hidden = false or public.is_campaign_dm(campaign_id));
+drop policy if exists "member write factions" on public.factions;
+create policy "member write factions" on public.factions
+  for all to authenticated
+  using      ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and (hidden = false or public.is_campaign_dm(campaign_id)))
+  with check ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and (hidden = false or public.is_campaign_dm(campaign_id)));
+
+drop policy if exists "anon read items" on public.items;
+create policy "visible or dm read items" on public.items
+  for select to anon, authenticated
+  using (hidden = false or public.is_campaign_dm(campaign_id));
+drop policy if exists "member write items" on public.items;
+create policy "member write items" on public.items
+  for all to authenticated
+  using      ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and (hidden = false or public.is_campaign_dm(campaign_id)))
+  with check ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and (hidden = false or public.is_campaign_dm(campaign_id)));
+
+drop policy if exists "anon read lore" on public.lore;
+create policy "visible or dm read lore" on public.lore
+  for select to anon, authenticated
+  using (hidden = false or public.is_campaign_dm(campaign_id));
+drop policy if exists "member write lore" on public.lore;
+create policy "member write lore" on public.lore
+  for all to authenticated
+  using      ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and (hidden = false or public.is_campaign_dm(campaign_id)))
+  with check ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and (hidden = false or public.is_campaign_dm(campaign_id)));
+
+-- ==========================================================================
+-- 6. Reference tables
+-- ==========================================================================
+
+-- connections: an edge to a hidden entity leaks its existence and the label
+-- ("secretly serves"). Gate on both endpoints. Writes become per-command
+-- policies so their clauses stop counting toward SELECT visibility.
+drop policy if exists "anon read connections" on public.connections;
+create policy "visible or dm read connections" on public.connections
+  for select to anon, authenticated
+  using (
+    public.is_campaign_dm(campaign_id)
+    or (not public.entity_hidden(from_id) and not public.entity_hidden(to_id))
+  );
+drop policy if exists "member write connections" on public.connections;
+drop policy if exists "member insert connections" on public.connections;
+create policy "member insert connections" on public.connections
+  for insert to authenticated
+  with check ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true);
+drop policy if exists "member update connections" on public.connections;
+create policy "member update connections" on public.connections
+  for update to authenticated
+  using      ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true)
+  with check ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true);
+drop policy if exists "member delete connections" on public.connections;
+create policy "member delete connections" on public.connections
+  for delete to authenticated
+  using ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true);
+
+-- board_positions: a hidden entity's pin leaks its existence.
+drop policy if exists "anon read board_positions" on public.board_positions;
+create policy "visible or dm read board_positions" on public.board_positions
+  for select to anon, authenticated
+  using (
+    public.is_campaign_dm(campaign_id)
+    or not public.entity_hidden(entity_id)
+  );
+drop policy if exists "member write board_positions" on public.board_positions;
+drop policy if exists "member insert board_positions" on public.board_positions;
+create policy "member insert board_positions" on public.board_positions
+  for insert to authenticated
+  with check ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true);
+drop policy if exists "member update board_positions" on public.board_positions;
+create policy "member update board_positions" on public.board_positions
+  for update to authenticated
+  using      ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true)
+  with check ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true);
+drop policy if exists "member delete board_positions" on public.board_positions;
+create policy "member delete board_positions" on public.board_positions
+  for delete to authenticated
+  using ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true);
+
+-- ==========================================================================
+-- 7. session_staging: the DM's prep queue is DM-only, read and write
+--    (replaces 0016's editor-wide FOR ALL, which also leaked SELECT).
+-- ==========================================================================
+
+drop policy if exists "session_staging is readable by anyone" on public.session_staging;
+drop policy if exists "non-anonymous users can manage session staging" on public.session_staging;
+drop policy if exists "dm manages session_staging" on public.session_staging;
+create policy "dm manages session_staging"
+  on public.session_staging for all
+  to authenticated
+  using      ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and public.is_campaign_dm(campaign_id))
+  with check ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and public.is_campaign_dm(campaign_id));
+
+-- ==========================================================================
+-- 8. session_events: feed stays readable by anyone; notes stay open to
+--    editors; reveal/start/end become DM-only.
+-- ==========================================================================
+
+drop policy if exists "non-anonymous users can append session events" on public.session_events;
+create policy "non-anonymous users can append session events"
+  on public.session_events for insert
+  to authenticated
+  with check (
+    (select (auth.jwt() ->> 'is_anonymous')::boolean) is not true
+    and (type = 'note' or public.is_campaign_dm(campaign_id))
+  );

--- a/supabase/migrations/0019_drop_dm_notes_columns.sql
+++ b/supabase/migrations/0019_drop_dm_notes_columns.sql
@@ -1,0 +1,18 @@
+-- M5 Live Session Mode, V2 (issue #73), part 2 of 2.
+-- 0018 copied every dm_notes value into the DM-only public.dm_notes side
+-- table and NULLed the source columns (closing the read leak while keeping
+-- the schema reversible). Apply this ONLY after the client built against
+-- 0018 is deployed and verified — the old client still reads/writes these
+-- columns for the DM's notes editor.
+--
+-- Down-path before this is applied: repopulate the columns from
+-- public.dm_notes and drop the side table.
+
+alter table public.people    drop column if exists dm_notes;
+alter table public.locations drop column if exists dm_notes;
+alter table public.quests    drop column if exists dm_notes;
+alter table public.goals     drop column if exists dm_notes;
+alter table public.factions  drop column if exists dm_notes;
+alter table public.items     drop column if exists dm_notes;
+alter table public.lore      drop column if exists dm_notes;
+alter table public.sessions  drop column if exists dm_notes;


### PR DESCRIPTION
## Summary

Makes hidden-entity and DM-notes secrecy real at the database layer (issue #73). V1 (#63–#68) was client-gated and trust-based — hidden rows and `dm_notes` still travelled to every client. After **0018**, a player client's network traffic never contains hidden rows, staging rows, DM notes, or connections/board pins that reference hidden entities; anonymous viewers keep seeing everything non-hidden; release still round-trips live through realtime.

## Critical spike (done before committing to the design)

Verified empirically on a local `supabase start` stack that **Realtime postgres_changes applies RLS per-subscriber at event time against the NEW row**: flipping `hidden=false` delivers the full-row UPDATE to player and anonymous subscribers who could not see the row before; they receive nothing while it is hidden; the DM receives everything (so `auth.uid()`/`is_campaign_dm()` resolve inside the realtime check); re-hide delivers nothing to players (documented); policy swaps take effect on already-joined channels. 17/17 spike assertions pass — this is what makes one-click release work under RLS, so no fallback redesign was needed.

## Migrations (for Kris to apply via dashboard SQL editor)

**`0018_campaign_members_rls.sql`** — apply first, then deploy the client, back-to-back (not on a session night):
- `campaign_members` (dm|player, PK campaign+user), seeded from `campaigns.dm_user_id` (uuid-guarded, sanity-asserted). Writes are dashboard/service-role only. `dm_user_id` stays populated so the *old* client keeps working during the gap.
- Helpers `is_campaign_dm()` / `entity_hidden()` — SECURITY DEFINER, `search_path=''`. `entity_hidden` must coalesce to false (connection endpoints can be sessions/arcs/events, which have no hidden column).
- `dm_notes` side table (DM-only read/write, realtime-published); the 8 `dm_notes` columns are copied in (sanity-asserted) and **NULLed, not dropped**.
- 7 entity tables: select `hidden = false OR is_campaign_dm(campaign_id)`; write policies replaced with hidden-aware versions. **Key subtlety:** permissive `FOR ALL` policies OR into SELECT — leaving 0006's `using(nonanon)` write policies in place would have let any signed-in editor read every hidden row straight past the new select policies. The replacement also means non-DM editors can't blind-unhide, can't set `hidden=true`, can't edit/delete rows they can't see (verified truth-table + tests).
- `connections`/`board_positions`: select gated on `entity_hidden()` of referenced ids; writes split into per-command policies (which never count toward SELECT).
- `session_staging`: DM-only, read and write. `session_events`: reveal/start/end inserts DM-only, notes stay open to editors, reads stay open.

**`0019_drop_dm_notes_columns.sql`** — apply only after the deployed client is verified; drops the 8 NULLed columns. Down-path before 0019: repopulate the columns from `public.dm_notes`, drop the side table, and revert 0018's policies to the 0006/0016 versions.

## Client changes

- `applyArrayChange` UPDATE is now an **upsert** — under RLS, a release UPDATE is the first event a player client is allowed to see for that row; the old replace-only splice would silently drop the reveal.
- `campaign.dmNotes` is a `Record<entityId, string>` from the side table (RLS returns `[]` to non-DMs); `updateDmNotes` mutation (upsert / delete-on-empty); `deleteEntity` sweeps dm_notes; all 8 `dmNotes` fieldAliases removed.
- Reveal events trigger a connections + board refetch — those rows become visible to players without any event of their own.
- `isRealDm` now comes from a `campaign_members` lookup. `projectCampaignForViewers` stays: it is the view-as-player (#71) mechanism (the DM's JWT still receives everything).

## Understood exceptions (leak inventory, all metadata-only — in the 0018 header)

- Realtime DELETE events are never RLS-filtered and carry only the PK: an unstage leaks `(session_id, entity_id)`, a dm_notes delete leaks `(campaign_id, entity_id)` — opaque ids, no content.
- `event_participants`/`session_participants` stay open-read (opaque person ids); `party_notes` stays open-read (a party note on a hidden entity is only writable through the DM's own UI); `session_events` reveal rows keep their label snapshot if an entity is later re-hidden (re-hide is off-doctrine; the client projection still strips them for display). A re-hide UPDATE is also invisible to player subscribers — their in-memory copy lingers until reload.
- Per-campaign **write** scoping (any editor can write any campaign) is unchanged — split into a follow-up per the issue.

## Verification

- `npm run build` (tsc) passes.
- Local stack: full migration chain 0001→0019 applies cleanly; **31-assertion e2e suite ALL PASS** against the real schema — player/anon REST traffic contains zero hidden rows / dm_notes / staging / hidden-linked connections / hidden pins; DM sees everything; blind-unhide = 0 rows; hiding-by-editor rejected (42501); reveal-insert-by-editor rejected; note insert works; anon writes still rejected; release UPDATE arrives to the player via realtime.
- Browser end-to-end on the local stack: anonymous tab (41 people) + DM tab (42, magic-link sign-in, `campaign_members`-driven View-as-player toggle). One-click RELEASE from the DM's desk: the anon tab gained the entity live (41→42, no reload), toast + feed row shown, and the previously-gated connection appeared (reveal-refetch). DM-notes editor round-trips through the side table (touch trigger bumps `updated_at`).
- Advisors: to be run via dashboard after applying 0018 (project isn't reachable from the MCP server). Expected/understood: `rls_policy` heuristics on the claim-based halves (same as 0006, by design); helpers pin `search_path`; `is_anonymous` checks are initplan-wrapped.
- Prod verify after apply+deploy: anon tab network check, DM release round-trip (dev-editor recipe), then apply 0019.

🤖 Generated with [Claude Code](https://claude.com/claude-code)