### PR TITLE
Campaign charter (v1): read-only campaign screen + DM-editable identity (#85)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { Sidebar, Topbar } from "./components";
 import { NoticeBoard, KindList } from "./board";
 import { ArcsPage } from "./arcs";
 import { EventsPage } from "./events";
+import { CampaignCharterPage } from "./campaign";
 import { DetailSheet } from "./detail";
 import { LivePanel } from "./livePanel";
 import { CommandPalette, useCommandPaletteHotkey } from "./commandPalette";
@@ -239,7 +240,7 @@ function AppLoaded() {
   return (
     <>
       <div className="app">
-        <Topbar onShare={onShare} />
+        <Topbar onShare={onShare} onOpenCharter={() => setView("campaign")} />
         <Sidebar active={view} onSelect={setView} onOpenEntity={setOpenId} onOpenCleanup={() => setCleanupOpen(true)} counts={counts} />
         <main className="main">
           {view === "board" && (
@@ -252,7 +253,10 @@ function AppLoaded() {
           )}
           {view === "arcs" && <ArcsPage onOpenEntity={setOpenId} />}
           {view === "events" && <EventsPage onOpenEntity={setOpenId} />}
-          {!["board", "arcs", "events"].includes(view) && <KindList kind={view} onOpenEntity={setOpenId} />}
+          {view === "campaign" && <CampaignCharterPage onOpenEntity={setOpenId} />}
+          {/* Catch-all treats the view as a KindKey — every non-kind view
+              must be excluded here or it double-renders a bogus KindList. */}
+          {!["board", "arcs", "events", "campaign"].includes(view) && <KindList kind={view} onOpenEntity={setOpenId} />}
         </main>
         <LivePanel onOpenEntity={setOpenId} />
       </div>

--- a/src/arcs.tsx
+++ b/src/arcs.tsx
@@ -3,8 +3,9 @@ import { useCampaign } from "./hooks";
 import { useAuth } from "./auth";
 import { createEntity } from "./mutations";
 
-// Plain-text excerpt of a markdown summary for the arc list.
-function excerpt(text: string | undefined, max = 140): string {
+// Plain-text excerpt of a markdown summary for the arc list (also used by
+// the charter's sessions ledger).
+export function excerpt(text: string | undefined, max = 140): string {
   if (!text) return "";
   const plain = text.replace(/[#*_>`~\[\]]/g, "").replace(/\s+/g, " ").trim();
   return plain.length > max ? `${plain.slice(0, max)}…` : plain;

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useRef, useState, type ReactNode } from "react";
 import type { Session, User } from "@supabase/supabase-js";
 import { supabase } from "./utils/supabase";
+import { upsertMyProfile } from "./mutations";
 
 // Dev-only editor quick-login for local/automated testing. Anonymous sessions
 // fail both the canEdit gate and the RLS write policy, so real end-to-end
@@ -106,6 +107,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     (user?.user_metadata?.display_name as string | undefined)?.trim() ||
     (user?.email ? user.email.split("@")[0] : null);
   const avatarUrl = (user?.user_metadata?.avatar_url as string | undefined) || null;
+
+  // Mirror editor identity into public.profiles (0020) so the charter roster
+  // can name campaign_members rows — auth metadata is only readable for the
+  // signed-in user. Re-runs when the DisplayNameGate saves (updateUser →
+  // auth state change → displayName re-derives); token refreshes don't
+  // change these deps. Fire-and-forget: a pre-migration 404 is harmless.
+  const userId = user?.id;
+  const isAnon = user?.is_anonymous;
+  useEffect(() => {
+    if (!userId || isAnon) return;
+    upsertMyProfile(userId, displayName, avatarUrl).catch(console.error);
+  }, [userId, isAnon, displayName, avatarUrl]);
 
   const setDisplayName = async (name: string) => {
     const trimmed = name.trim();

--- a/src/campaign.tsx
+++ b/src/campaign.tsx
@@ -1,0 +1,509 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { supabase } from "./utils/supabase";
+import { sessionLabel } from "./data";
+import { useCampaign, useIsDm, useKinds } from "./hooks";
+import { EditableText } from "./components";
+import { updateCampaign } from "./mutations";
+import { uploadEntityImage } from "./upload";
+import { excerpt } from "./arcs";
+
+// ============================================================================
+// The Campaign Charter (issue #85) — a parchment frontispiece for the whole
+// campaign: identity plate (DM-editable), living stats, the party, and a
+// sessions ledger. Everything except the roster reads already-loaded
+// campaign state, so the viewer projection applies automatically.
+// ============================================================================
+
+const LEDGER_PREVIEW = 10;
+
+// Tiny deterministic string hash — varies the procedural crest ornament per
+// campaign title. Not crypto, just stable visual variety.
+function hashString(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0;
+  return Math.abs(h);
+}
+
+// Initials for the procedural seal: first letters of the first two
+// meaningful title words ("The Fist of Ilmater" → "FI").
+function sealInitials(title: string): string {
+  const minor = new Set(["the", "of", "a", "an", "and", "de", "van", "het"]);
+  const words = title.split(/\s+/).filter((w) => w && !minor.has(w.toLowerCase()));
+  const picked = (words.length ? words : title.split(/\s+/)).slice(0, 2);
+  return picked.map((w) => w[0]?.toUpperCase() ?? "").join("") || "✦";
+}
+
+// Procedural wax-seal crest — the default when no image is uploaded. Wax
+// colors are hardcoded like the .wax-seal class (it's wax, not text on card
+// stock); the ornament ring's dash pattern and rotation vary by title hash.
+function CrestSeal({ title, size }: { title: string; size: number }) {
+  const h = hashString(title);
+  const dash = 3 + (h % 4);
+  const gap = 2 + ((h >> 3) % 4);
+  const rotate = h % 360;
+  const initials = sealInitials(title);
+  return (
+    <svg width={size} height={size} viewBox="0 0 100 100" role="img" aria-label={`Wax seal of ${title}`}>
+      <defs>
+        <radialGradient id="charter-wax" cx="35%" cy="30%" r="80%">
+          <stop offset="0%" stopColor="#b53a2a" />
+          <stop offset="60%" stopColor="#7a1f14" />
+          <stop offset="100%" stopColor="#4a120a" />
+        </radialGradient>
+      </defs>
+      <circle cx="50" cy="50" r="48" fill="url(#charter-wax)" stroke="rgba(0,0,0,.35)" strokeWidth="1" />
+      <circle
+        cx="50" cy="50" r="41"
+        fill="none" stroke="rgba(255,220,180,.3)" strokeWidth="1.5"
+        strokeDasharray={`${dash} ${gap}`}
+        transform={`rotate(${rotate} 50 50)`}
+      />
+      <circle cx="50" cy="50" r="35" fill="none" stroke="rgba(255,220,180,.15)" strokeWidth="1" />
+      <text
+        x="50" y="50"
+        textAnchor="middle" dominantBaseline="central"
+        fill="#f4d9a0"
+        style={{ fontFamily: "var(--font-fell-sc)", fontSize: initials.length > 1 ? 30 : 38, letterSpacing: ".04em" }}
+      >
+        {initials}
+      </text>
+    </svg>
+  );
+}
+
+// Crest slot: uploaded image when set, procedural seal otherwise. The DM
+// gets replace/remove affordances; everyone else sees the plain crest.
+// Deliberately not EntityPortrait — that component is entity-shaped
+// (KindKey fallbacks, sheet classes).
+function CharterCrest() {
+  const campaign = useCampaign();
+  const isDm = useIsDm();
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const onFile = async (file: File) => {
+    setUploading(true);
+    try {
+      const url = await uploadEntityImage(file, "campaign", campaign.id);
+      await updateCampaign({ imageUrl: url });
+    } catch (e) {
+      window.alert(e instanceof Error ? e.message : String(e));
+    } finally {
+      setUploading(false);
+      if (fileRef.current) fileRef.current.value = "";
+    }
+  };
+
+  const clear = () => {
+    if (!window.confirm("Remove the campaign crest?")) return;
+    updateCampaign({ imageUrl: null }).catch(console.error);
+  };
+
+  const size = 116;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 6, flexShrink: 0 }}>
+      {campaign.imageUrl ? (
+        <img
+          src={campaign.imageUrl}
+          alt={`Crest of ${campaign.title}`}
+          style={{
+            width: size, height: size, objectFit: "cover", borderRadius: "50%",
+            border: "1px solid var(--vellum-deep)", boxShadow: "0 2px 8px rgba(40,20,5,.25)",
+          }}
+        />
+      ) : (
+        <CrestSeal title={campaign.title} size={size} />
+      )}
+      {isDm && (
+        <>
+          <input
+            ref={fileRef}
+            type="file"
+            accept="image/*"
+            style={{ display: "none" }}
+            onChange={(e) => { const f = e.target.files?.[0]; if (f) onFile(f); }}
+          />
+          <div style={{ display: "flex", gap: 10 }}>
+            <button className="cleanup-link-btn" onClick={() => fileRef.current?.click()} disabled={uploading}>
+              {uploading ? "sealing…" : campaign.imageUrl ? "replace crest" : "upload crest"}
+            </button>
+            {campaign.imageUrl && (
+              <button className="cleanup-link-btn" onClick={clear}>remove</button>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// "191 sessions · chronicled across three years" — best-effort: session
+// dates are free text, so unparseable dates degrade to the count alone.
+function chronicleEpigraph(sessions: { date?: string }[]): string | null {
+  if (sessions.length === 0) return null;
+  const count = `${sessions.length} ${sessions.length === 1 ? "session" : "sessions"}`;
+  const times = sessions
+    .map((s) => (s.date ? Date.parse(s.date) : NaN))
+    .filter((t) => !Number.isNaN(t));
+  if (times.length < 2) return `${count} chronicled`;
+  const spanDays = (Math.max(...times) - Math.min(...times)) / 86_400_000;
+  const words = ["", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven", "twelve"];
+  const inWords = (n: number) => words[n] ?? String(n);
+  const years = Math.round(spanDays / 365.25);
+  const months = Math.round(spanDays / 30.44);
+  const span =
+    years >= 2 ? `across ${inWords(years)} years`
+    : months >= 12 ? "across a year and more"
+    : months >= 2 ? `across ${inWords(months)} months`
+    : months === 1 ? "within a single month"
+    : null;
+  return span ? `${count} · chronicled ${span}` : `${count} chronicled`;
+}
+
+function SectionHeading({ children }: { children: string }) {
+  return (
+    <div style={{
+      fontFamily: "var(--font-fell-sc)", letterSpacing: ".25em", fontSize: 12,
+      color: "var(--ink-secondary)", marginTop: 38, marginBottom: 14,
+    }}>
+      ✦ {children} ✦
+    </div>
+  );
+}
+
+interface RosterEntry {
+  userId: string;
+  role: "dm" | "player";
+  name: string | null;
+  avatarUrl: string | null;
+}
+
+export function CampaignCharterPage({ onOpenEntity }: { onOpenEntity: (id: string) => void }) {
+  const campaign = useCampaign();
+  const isDm = useIsDm();
+  const kinds = useKinds();
+  const [roster, setRoster] = useState<RosterEntry[] | null>(null);
+  const [ledgerExpanded, setLedgerExpanded] = useState(false);
+
+  // Party roster: campaign_members joined with profiles in JS (no FK
+  // between them, so no PostgREST embed). Members are dashboard-managed and
+  // not realtime-published; profiles staleness is accepted for v1 — the
+  // fetch reruns per charter mount / campaign switch.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const { data: members, error } = await supabase
+        .from("campaign_members")
+        .select("user_id,role")
+        .eq("campaign_id", campaign.id);
+      if (cancelled) return;
+      if (error) { console.error(error); setRoster([]); return; }
+      const ids = (members ?? []).map((m: any) => m.user_id as string);
+      const profiles = new Map<string, { display_name: string | null; avatar_url: string | null }>();
+      if (ids.length > 0) {
+        const { data: profs, error: pErr } = await supabase
+          .from("profiles")
+          .select("user_id,display_name,avatar_url")
+          .in("user_id", ids);
+        if (cancelled) return;
+        if (pErr) console.error(pErr);
+        (profs ?? []).forEach((p: any) => profiles.set(p.user_id, p));
+      }
+      const entries: RosterEntry[] = (members ?? []).map((m: any) => ({
+        userId: m.user_id,
+        role: m.role,
+        name: profiles.get(m.user_id)?.display_name ?? null,
+        avatarUrl: profiles.get(m.user_id)?.avatar_url ?? null,
+      }));
+      // DM first, then named members alphabetically, unnamed last.
+      entries.sort((a, b) =>
+        a.role !== b.role ? (a.role === "dm" ? -1 : 1) : (a.name ?? "￿").localeCompare(b.name ?? "￿"));
+      setRoster(entries);
+    })();
+    return () => { cancelled = true; };
+  }, [campaign.id]);
+
+  const liveSession = campaign.sessions.find((s) => s.id === campaign.activeSessionId);
+  const epigraph = chronicleEpigraph(campaign.sessions);
+  const lastPlayed = useMemo(() => {
+    const dated = campaign.sessions.filter((s) => s.date).sort((a, b) => b.num - a.num);
+    return dated[0] ?? null;
+  }, [campaign.sessions]);
+  // Presence is "who has the codex open now" — its ids don't join to
+  // campaign_members (text vs auth uuid), so this is deliberately a
+  // separate strip, not a roster decoration.
+  const atTheTable = campaign.presence.filter((p) => p.active);
+  const orderedSessions = useMemo(
+    () => [...campaign.sessions].sort((a, b) => b.num - a.num),
+    [campaign.sessions],
+  );
+  const ledger = ledgerExpanded ? orderedSessions : orderedSessions.slice(0, LEDGER_PREVIEW);
+
+  const titleStyle: React.CSSProperties = {
+    fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 40,
+    color: "var(--ink)", letterSpacing: ".01em", lineHeight: 1.15,
+  };
+  const subtitleStyle: React.CSSProperties = {
+    fontFamily: "var(--font-fell)", fontStyle: "italic", fontSize: 17, color: "var(--ink-body)",
+  };
+
+  return (
+    <div style={{ flex: 1, overflow: "auto", padding: "28px 40px 60px", background: "var(--vellum)", position: "relative" }} className="tex-vellum">
+      <div style={{ position: "relative", zIndex: 1, maxWidth: 860 }}>
+        <div style={{
+          fontFamily: "var(--font-fell-sc)", letterSpacing: ".3em", fontSize: 12,
+          color: "var(--ink-secondary)", textAlign: "center", marginBottom: 18,
+        }}>
+          ✦ THE CAMPAIGN CHARTER ✦
+        </div>
+
+        {/* Identity plate. The isDm wrapper (not just EditableText's canEdit
+            gate) is load-bearing: a non-DM editor's write would match 0 rows
+            under 0020's DM-only policy, silently. View-as-player folds into
+            isDm, hiding the affordances. */}
+        <div style={{ display: "flex", gap: 26, alignItems: "center" }}>
+          <CharterCrest />
+          <div style={{ minWidth: 0, flex: 1 }}>
+            {isDm ? (
+              <EditableText
+                value={campaign.title}
+                onSave={(v) => {
+                  const t = v.trim();
+                  if (!t) return false; // campaigns.title is NOT NULL
+                  updateCampaign({ title: t }).catch(console.error);
+                }}
+                style={titleStyle}
+              />
+            ) : (
+              <h1 style={{ ...titleStyle, margin: 0 }}>{campaign.title}</h1>
+            )}
+            {isDm ? (
+              <EditableText
+                value={campaign.subtitle}
+                onSave={(v) => updateCampaign({ subtitle: v }).catch(console.error)}
+                placeholder="Add a subtitle…"
+                style={subtitleStyle}
+              />
+            ) : (
+              campaign.subtitle && <div style={subtitleStyle}>{campaign.subtitle}</div>
+            )}
+            {epigraph && (
+              <div style={{
+                fontFamily: "var(--font-fell)", fontStyle: "italic", fontSize: 14,
+                color: "var(--ink-secondary)", marginTop: 8,
+              }}>
+                {epigraph}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="scratch-divider" style={{ marginTop: 22 }}><em>✦ ✦ ✦</em></div>
+
+        {/* Living stats — derived from loaded state, no extra queries. */}
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 18, alignItems: "stretch" }}>
+          <StatTile label="SESSIONS PLAYED" value={String(campaign.sessions.length)} />
+          {lastPlayed?.date && <StatTile label="LAST PLAYED" value={lastPlayed.date} />}
+          {liveSession && (
+            <div style={{
+              display: "flex", alignItems: "center", gap: 8,
+              padding: "8px 14px", border: "1px solid var(--bloodred)", borderRadius: 4,
+              background: "var(--paper-cream)",
+            }}>
+              <span style={{
+                width: 8, height: 8, borderRadius: "50%", background: "var(--bloodred)",
+                boxShadow: "0 0 0 2px rgba(138,42,31,.25)", flexShrink: 0,
+              }} />
+              <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".15em", fontSize: 11, color: "var(--bloodred)" }}>
+                LIVE · SESSION {liveSession.num}
+              </span>
+            </div>
+          )}
+        </div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 12 }}>
+          {kinds.map((k) => {
+            const list = k.list() as { archived?: boolean }[];
+            const active = list.filter((e) => !e.archived).length;
+            return <StatTile key={k.key} label={k.plural.toUpperCase()} value={String(active)} dotColor={k.color} />;
+          })}
+        </div>
+
+        {/* The Party — read-only in this phase; management is issue #86. */}
+        <SectionHeading>THE PARTY</SectionHeading>
+        {roster === null ? (
+          <div style={{ fontFamily: "var(--font-fell)", fontStyle: "italic", fontSize: 14, color: "var(--ink-secondary)" }}>
+            Consulting the rolls…
+          </div>
+        ) : roster.length === 0 ? (
+          <div style={{ fontFamily: "var(--font-fell)", fontStyle: "italic", fontSize: 14, color: "var(--ink-secondary)" }}>
+            No members are recorded on this charter yet.
+          </div>
+        ) : (
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 14 }}>
+            {roster.map((m) => (
+              <div
+                key={m.userId}
+                style={{
+                  position: "relative",
+                  display: "flex", alignItems: "center", gap: 10,
+                  padding: "8px 14px",
+                  background: "var(--paper-cream)",
+                  border: "1px solid var(--vellum-deep)",
+                  borderRadius: 22,
+                  boxShadow: "0 1px 2px rgba(40,20,5,.12)",
+                }}
+              >
+                {m.avatarUrl ? (
+                  <img
+                    src={m.avatarUrl}
+                    alt=""
+                    style={{ width: 28, height: 28, borderRadius: "50%", objectFit: "cover", border: "1px solid var(--vellum-deep)" }}
+                  />
+                ) : (
+                  <span style={{
+                    width: 28, height: 28, borderRadius: "50%", background: "var(--vellum-deep)",
+                    display: "grid", placeItems: "center",
+                    fontFamily: "var(--font-fell-sc)", fontSize: 12, color: "var(--ink-secondary)",
+                  }}>
+                    {(m.name?.[0] ?? "?").toUpperCase()}
+                  </span>
+                )}
+                {m.name ? (
+                  <span style={{ fontFamily: "var(--font-fell)", fontSize: 14, color: "var(--ink)" }}>{m.name}</span>
+                ) : (
+                  <span style={{ fontFamily: "var(--font-fell)", fontStyle: "italic", fontSize: 14, color: "var(--ink-faded)" }}>
+                    an unnamed adventurer
+                  </span>
+                )}
+                {m.role === "dm" && (
+                  <span
+                    className="wax-seal"
+                    title="Dungeon Master"
+                    style={{ top: -9, right: -9, width: 26, height: 26, fontSize: 9 }}
+                  >
+                    DM
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+        {atTheTable.length > 0 && (
+          <div style={{ marginTop: 16 }}>
+            <div style={{
+              fontFamily: "var(--font-fell-sc)", letterSpacing: ".18em", fontSize: 11,
+              color: "var(--ink-secondary)", marginBottom: 8,
+            }}>
+              AT THE TABLE · {atTheTable.length}
+            </div>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+              {atTheTable.map((p) => (
+                <span
+                  key={p.id}
+                  title={p.name}
+                  style={{
+                    display: "inline-flex", alignItems: "center", gap: 7,
+                    padding: "3px 10px",
+                    background: "var(--paper-cream)", border: "1px solid var(--vellum-deep)",
+                    borderRadius: 12, fontFamily: "var(--font-fell)", fontSize: 12, color: "var(--ink)",
+                  }}
+                >
+                  <span style={{
+                    width: 7, height: 7, borderRadius: "50%",
+                    background: p.color || "var(--forest)",
+                    // Neutral glow — p.color's format isn't guaranteed hex6,
+                    // so no alpha-suffix tricks on it.
+                    boxShadow: "0 0 5px 1px rgba(138,42,31,.3)",
+                    flexShrink: 0,
+                  }} />
+                  {p.name || p.initials}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Sessions ledger — links into the existing detail flow. Go-live
+            lives on the SessionPin; the charter only reads. */}
+        <SectionHeading>SESSIONS LEDGER</SectionHeading>
+        {orderedSessions.length === 0 ? (
+          <div style={{ fontFamily: "var(--font-fell)", fontStyle: "italic", fontSize: 14, color: "var(--ink-secondary)" }}>
+            The first session is yet to be written.
+          </div>
+        ) : (
+          <>
+            {ledger.map((s) => {
+              const snippet = excerpt(s.summary);
+              const isLive = s.id === campaign.activeSessionId;
+              return (
+                <button
+                  key={s.id}
+                  onClick={() => onOpenEntity(s.id)}
+                  style={{
+                    display: "block", width: "100%", textAlign: "left",
+                    background: "none", border: "none", cursor: "pointer",
+                    padding: "10px 4px",
+                    borderBottom: "1px dashed var(--vellum-deep)",
+                  }}
+                >
+                  <div style={{ display: "flex", alignItems: "baseline", gap: 10, flexWrap: "wrap" }}>
+                    <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".1em", fontSize: 12, color: isLive ? "var(--bloodred)" : "var(--ink-secondary)" }}>
+                      {sessionLabel(s.num).toUpperCase()}
+                    </span>
+                    <span style={{ fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 16, color: "var(--ink)" }}>
+                      {s.title}
+                    </span>
+                    {s.date && (
+                      <span style={{ fontFamily: "var(--font-fell)", fontStyle: "italic", fontSize: 13, color: "var(--ink-secondary)" }}>
+                        {s.date}
+                      </span>
+                    )}
+                    {isLive && (
+                      <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".15em", fontSize: 10, color: "var(--bloodred)" }}>
+                        ● LIVE NOW
+                      </span>
+                    )}
+                  </div>
+                  {snippet && (
+                    <div style={{ fontFamily: "var(--font-fell)", fontSize: 14, color: "var(--ink-body)", marginTop: 3 }}>
+                      {snippet}
+                    </div>
+                  )}
+                </button>
+              );
+            })}
+            {orderedSessions.length > LEDGER_PREVIEW && (
+              <button
+                className="cleanup-link-btn"
+                onClick={() => setLedgerExpanded((e) => !e)}
+                style={{ marginTop: 12 }}
+              >
+                {ledgerExpanded
+                  ? "show fewer"
+                  : `show the full chronicle (${orderedSessions.length - LEDGER_PREVIEW} more)`}
+              </button>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatTile({ label, value, dotColor }: { label: string; value: string; dotColor?: string }) {
+  return (
+    <div style={{
+      display: "flex", alignItems: "center", gap: 8,
+      padding: "8px 14px",
+      background: "var(--paper-cream)", border: "1px solid var(--vellum-deep)", borderRadius: 4,
+    }}>
+      {dotColor && <span style={{ width: 8, height: 8, borderRadius: "50%", background: dotColor, flexShrink: 0 }} />}
+      <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".15em", fontSize: 11, color: "var(--ink-secondary)" }}>
+        {label}
+      </span>
+      <span style={{ fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 16, color: "var(--ink)" }}>
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/src/campaignContext.tsx
+++ b/src/campaignContext.tsx
@@ -307,6 +307,7 @@ async function fetchCampaign(id: string): Promise<Campaign> {
     id: campaignRes.data.id,
     title: campaignRes.data.title,
     subtitle: campaignRes.data.subtitle ?? "",
+    imageUrl: campaignRes.data.image_url ?? undefined,
     sessions: (sessionsRes.data ?? []).map(mapSession),
     arcs: (arcsRes.data ?? []).map(mapArc),
     events: (eventsRes.data ?? []).map(mapEvent),
@@ -503,7 +504,23 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
             if (cancelled) return;
             const next = payload.new?.active_session_id ?? undefined;
             setActiveSessionId(next ?? null);
-            setCampaign((c) => c && c.id === campaignId ? { ...c, activeSessionId: next, title: payload.new?.title ?? c.title, subtitle: payload.new?.subtitle ?? c.subtitle } : c);
+            // subtitle/imageUrl map null → ""/undefined (not `?? c.x`): the
+            // DM clearing them from the charter must propagate, and `??`
+            // would swallow the null. title is NOT NULL so falling back to
+            // the current value is safe there.
+            setCampaign((c) => c && c.id === campaignId ? {
+              ...c,
+              activeSessionId: next,
+              title: payload.new?.title ?? c.title,
+              subtitle: payload.new?.subtitle ?? "",
+              imageUrl: payload.new?.image_url ?? undefined,
+            } : c);
+            // Keep the picker's dropdown list fresh for the active campaign.
+            // Other campaigns' rows aren't in this realtime filter — their
+            // renames still take a reload (pre-existing, acceptable).
+            setCampaigns((list) => list.map((s) => s.id === campaignId
+              ? { ...s, title: payload.new?.title ?? s.title, subtitle: payload.new?.subtitle ?? null }
+              : s));
           },
         );
         channel.on(

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -525,7 +525,7 @@ export function Sidebar({ active, onSelect, onOpenEntity, onOpenCleanup, counts 
 
 // Campaign switcher in the Topbar. Visible to read-only viewers too —
 // switching campaigns is navigation, not an edit.
-function CampaignPicker() {
+function CampaignPicker({ onOpenCharter }: { onOpenCharter: () => void }) {
   const campaign = useCampaign();
   const { campaigns, activeCampaignId, switchCampaign } = useCampaignSwitcher();
   const [open, setOpen] = useState(false);
@@ -553,17 +553,19 @@ function CampaignPicker() {
     <div className="campaign-picker" ref={rootRef}>
       <button
         className="campaign-chip"
-        onClick={() => canSwitch && setOpen((o) => !o)}
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        title={canSwitch ? "Switch campaign" : undefined}
-        style={{ cursor: canSwitch ? "pointer" : "default" }}
+        onClick={() => (canSwitch ? setOpen((o) => !o) : onOpenCharter())}
+        aria-haspopup={canSwitch ? "listbox" : undefined}
+        aria-expanded={canSwitch ? open : undefined}
+        title={canSwitch ? "Switch campaign" : "View campaign charter"}
+        style={{ cursor: "pointer" }}
       >
         <span className="dot" />
         <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".1em", fontSize: 11 }}>CAMPAIGN</span>
         <span>·</span>
         <span style={{ fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 15 }}>{campaign.title}</span>
-        <span style={{ color: "var(--ink-secondary)", fontStyle: "italic", fontSize: 12 }}>· {campaign.subtitle}</span>
+        {campaign.subtitle && (
+          <span style={{ color: "var(--ink-secondary)", fontStyle: "italic", fontSize: 12 }}>· {campaign.subtitle}</span>
+        )}
         {canSwitch && (
           <Icon name="chevron" size={11} style={{ transform: open ? "rotate(-90deg)" : "rotate(90deg)", color: "var(--ink-faded)", flexShrink: 0 }} />
         )}
@@ -587,6 +589,16 @@ function CampaignPicker() {
               </span>
             </button>
           ))}
+          <button
+            className="campaign-picker-item"
+            onClick={() => { onOpenCharter(); setOpen(false); }}
+            style={{ borderTop: "1px dashed var(--vellum-deep)" }}
+          >
+            <span className="dot" style={{ visibility: "hidden" }} />
+            <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".14em", fontSize: 11, color: "var(--ink-secondary)" }}>
+              VIEW CHARTER
+            </span>
+          </button>
         </div>
       )}
     </div>
@@ -594,15 +606,18 @@ function CampaignPicker() {
 }
 
 // The shared "we're live in session N" pin, beside the campaign picker.
-// Editors get a dropdown to go live / switch / stand down; viewers see a static
-// label so everyone at the table knows which session is current. The value is
+// The DM gets a dropdown to go live / switch / stand down; everyone else —
+// viewers AND non-DM editors — sees a static label so the whole table knows
+// which session is current. DM-only since #85: migration 0020 gates the
+// campaigns UPDATE (which carries active_session_id) on is_campaign_dm, so a
+// non-DM editor's pin move would silently match 0 rows. The value is
 // campaign-wide and synced to every client via realtime.
 function SessionPin() {
   const campaign = useCampaign();
   const { canEdit, displayName } = useAuth();
-  // Real DM-ness, NOT the view-as-player-flipped gate: this decides which
-  // MUTATION runs (bracketed vs bare pin move). A view toggle changing what
-  // gets persisted would silently drop feed markers from the append-only log.
+  // Real DM-ness, NOT the view-as-player-flipped gate: the pin must keep
+  // working while the DM previews the player view (it's a write control,
+  // like the toggle itself), and the mutations write the DM's feed brackets.
   const { isRealDm } = useViewAsPlayer();
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -626,8 +641,9 @@ function SessionPin() {
   const live = campaign.sessions.find((s) => s.id === campaign.activeSessionId);
   const label = live ? `SESSION ${live.num}` : "NOT LIVE";
 
-  // Viewers: static, non-interactive label (only shown when a session is live).
-  if (!canEdit) {
+  // Viewers and non-DM editors: static, non-interactive label (only shown
+  // when a session is live) — their pin writes would be RLS no-ops (0020).
+  if (!canEdit || !isRealDm) {
     if (!live) return null;
     return (
       <div className="session-pin">
@@ -639,14 +655,15 @@ function SessionPin() {
     );
   }
 
-  // When the DM moves the pin, the feed gets its start/end brackets too; other
-  // editors keep the plain pin move (the markers are the DM's ceremony).
-  // Switching A→B goes through switchLiveSession so the pin never passes
-  // through null — that would flicker "not live" across every client.
+  // Only the DM reaches this point (see the gate above), so every pin move
+  // gets its feed start/end brackets; re-picking the current session stays a
+  // bare no-op write. Switching A→B goes through switchLiveSession so the
+  // pin never passes through null — that would flicker "not live" across
+  // every client.
   const pick = (id: string | null) => {
     const prev = campaign.activeSessionId ?? null;
     const author = displayName || undefined;
-    const op = !isRealDm || id === prev
+    const op = id === prev
       ? setActiveSession(id)
       : id && prev
         ? switchLiveSession(prev, id, author)
@@ -702,7 +719,7 @@ function SessionPin() {
   );
 }
 
-export function Topbar({ onShare }: { onShare: () => void }) {
+export function Topbar({ onShare, onOpenCharter }: { onShare: () => void; onOpenCharter: () => void }) {
   const campaign = useCampaign();
   const { canEdit, displayName, avatarUrl, signOut } = useAuth();
   const { isRealDm, viewAsPlayer, setViewAsPlayer } = useViewAsPlayer();
@@ -717,7 +734,7 @@ export function Topbar({ onShare }: { onShare: () => void }) {
         </div>
       </div>
       <div className="topbar-center">
-        <CampaignPicker />
+        <CampaignPicker onOpenCharter={onOpenCharter} />
         <SessionPin />
       </div>
       <div className="topbar-right">

--- a/src/data.ts
+++ b/src/data.ts
@@ -212,6 +212,8 @@ export interface Campaign {
   id: string;
   title: string;
   subtitle: string;
+  // Optional crest/cover image for the charter (campaigns.image_url, 0020).
+  imageUrl?: string;
   sessions: Session[];
   arcs: Arc[];
   events: CampaignEvent[];

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -198,6 +198,36 @@ export async function setActiveSession(sessionId: string | null) {
   if (error) throw error;
 }
 
+// Campaign identity for the charter (issue #85). DM-only at the DB layer
+// (0020's UPDATE policy): a non-DM write matches 0 rows with NO error, so
+// callers must gate the affordance on isDm rather than rely on error
+// handling. Realtime echoes title/subtitle/image_url back into state.
+export async function updateCampaign(patch: { title?: string; subtitle?: string; imageUrl?: string | null }) {
+  const row: Record<string, unknown> = {};
+  if (patch.title !== undefined) row.title = patch.title; // NOT NULL — callers reject empty
+  if (patch.subtitle !== undefined) row.subtitle = patch.subtitle || null;
+  if (patch.imageUrl !== undefined) row.image_url = patch.imageUrl || null;
+  const { error } = await supabase
+    .from("campaigns")
+    .update(row)
+    .eq("id", getActiveCampaignId());
+  if (error) throw error;
+}
+
+// User-scoped, not campaign-scoped (no getActiveCampaignId): mirrors the
+// signed-in editor's auth metadata into public.profiles (0020) so the
+// charter roster can put names/avatars on campaign_members rows. RLS
+// restricts the upsert to the caller's own row.
+export async function upsertMyProfile(userId: string, displayName: string | null, avatarUrl: string | null) {
+  const { error } = await supabase
+    .from("profiles")
+    .upsert(
+      { user_id: userId, display_name: displayName, avatar_url: avatarUrl },
+      { onConflict: "user_id" },
+    );
+  if (error) throw error;
+}
+
 export async function markSeen(personId: string) {
   const sessionId = getActiveSessionId();
   if (!sessionId) {

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -5,9 +5,12 @@ const MAX_BYTES = 5 * 1024 * 1024;
 
 export type UploadableKind = "people" | "locations" | "factions" | "items" | "sessions";
 
+// "campaign" is a path prefix for the campaign crest (issue #85), not a
+// KindKey — keep it out of UploadableKind, which detail.tsx feeds into
+// KindKey-typed helpers.
 export async function uploadEntityImage(
   file: File,
-  kind: UploadableKind,
+  kind: UploadableKind | "campaign",
   entityId: string,
 ): Promise<string> {
   if (!file.type.startsWith("image/")) {

--- a/supabase/migrations/0020_campaign_charter.sql
+++ b/supabase/migrations/0020_campaign_charter.sql
@@ -1,0 +1,107 @@
+-- ===========================================================================
+-- M6 Campaign Management, phase 1 (issue #85): the Campaign Charter.
+-- A campaign-level screen visible to every role, with the DM able to edit
+-- the campaign identity (title / subtitle / crest image) inline. This
+-- migration provides the three DB pieces the screen needs:
+--
+--   1. campaigns.image_url — the optional crest/cover, stored in the
+--      existing entity-images bucket under a campaign/ prefix (the 0006
+--      storage policies gate on bucket + non-anonymous claim only, so no
+--      storage policy change is needed).
+--   2. A DM-only UPDATE policy on campaigns, replacing 0006's
+--      `member write campaigns` FOR ALL policy. Two deliberate
+--      consequences, both decided during planning:
+--        * campaigns.active_session_id becomes DM-writable only — the
+--          live-session pin is now the DM's control. The client gates the
+--          SessionPin dropdown on real-DM-ness to match; non-DM editors
+--          get the viewer's static label. (Old clients in the apply→deploy
+--          gap fire-and-forget a 0-row update: silent no-op, console error
+--          only. Apply + deploy back-to-back, not on a session night.)
+--        * The dropped FOR ALL policy also carried INSERT/DELETE on
+--          campaigns; no client UI creates or deletes campaigns today, so
+--          those verbs become deny-all for client roles until issue #87
+--          (campaign CRUD) adds its own policies.
+--   3. profiles(user_id, display_name, avatar_url) — auth user metadata is
+--      only readable for the signed-in user, so the charter's party roster
+--      (campaign_members × names) needs a public mirror. Each editor's
+--      client upserts its own row on session load (AuthProvider). Not in
+--      the realtime publication: the roster is fetched on charter mount
+--      and staleness is accepted for v1.
+--
+-- Privacy posture: the open profiles SELECT means any visitor can
+-- enumerate editor display names / avatars via the API — deliberate, the
+-- same posture as campaign_members (private group app). Scoping reads to
+-- co-members would need another SECURITY DEFINER helper; deferred.
+--
+-- Advisor notes: the is_anonymous claim checks are wrapped in scalar
+-- subqueries for initplan caching; rls_policy heuristics may still flag
+-- the claim-based halves, as with 0006/0018 — by design.
+--
+-- Rollout: apply this, then deploy the client built against it,
+-- back-to-back. The new client hard-depends on campaigns.image_url and
+-- profiles (its fire-and-forget writes fail silently against a
+-- pre-migration schema).
+-- ===========================================================================
+
+-- ==========================================================================
+-- 1. Campaign identity: crest/cover image
+-- ==========================================================================
+
+alter table public.campaigns add column if not exists image_url text;
+
+-- ==========================================================================
+-- 2. DM-only campaigns UPDATE (replaces the 0006 FOR ALL write policy)
+-- ==========================================================================
+-- Gate column is `id` — the pin/identity live on the campaigns row itself.
+-- is_campaign_dm is the SECURITY DEFINER helper from 0018.
+
+drop policy if exists "member write campaigns" on public.campaigns;
+
+drop policy if exists "dm updates campaign" on public.campaigns;
+create policy "dm updates campaign" on public.campaigns
+  for update to authenticated
+  using      ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and public.is_campaign_dm(id))
+  with check ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and public.is_campaign_dm(id));
+
+-- ==========================================================================
+-- 3. profiles: public mirror of editor identity for the party roster
+-- ==========================================================================
+
+create table if not exists public.profiles (
+  user_id      uuid primary key references auth.users(id) on delete cascade,
+  display_name text,
+  avatar_url   text,
+  updated_at   timestamptz not null default now()
+);
+
+-- Explicit grants: newer Supabase stacks don't auto-grant to
+-- anon/authenticated (0018 precedent). No DELETE — rows live as long as
+-- the auth user; the FK cascade handles cleanup.
+grant select on public.profiles to anon, authenticated;
+grant insert, update on public.profiles to authenticated;
+
+drop trigger if exists tg_profiles_touch on public.profiles;
+create trigger tg_profiles_touch
+  before update on public.profiles
+  for each row execute function public.touch_updated_at();
+
+alter table public.profiles enable row level security;
+
+drop policy if exists "profiles are readable by anyone" on public.profiles;
+create policy "profiles are readable by anyone"
+  on public.profiles for select
+  to anon, authenticated
+  using (true);
+
+drop policy if exists "user inserts own profile" on public.profiles;
+create policy "user inserts own profile"
+  on public.profiles for insert
+  to authenticated
+  with check ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and auth.uid() = user_id);
+
+drop policy if exists "user updates own profile" on public.profiles;
+create policy "user updates own profile"
+  on public.profiles for update
+  to authenticated
+  using      ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and auth.uid() = user_id)
+  with check ((select (auth.jwt() ->> 'is_anonymous')::boolean) is not true and auth.uid() = user_id);


### PR DESCRIPTION
Closes #85 — M6 Campaign Management, phase 1.

## The Campaign Charter

A parchment frontispiece for the whole campaign, opened from the CampaignPicker (chip click when there's a single campaign; a "VIEW CHARTER" footer item in the dropdown otherwise). New `view: "campaign"` branch in App.tsx; new `src/campaign.tsx`.

- **Identity plate** — title + subtitle DM-editable via `EditableText` (gated on `isDm`, so view-as-player hides them); optional crest image in the existing `entity-images` bucket under a `campaign/` prefix.
- **Procedural wax-seal crest** — when no image is uploaded, a deterministic SVG wax seal (initials + hash-varied ornament ring) renders from the campaign title.
- **Chronicle epigraph** — "191 sessions · chronicled across three years", best-effort from free-text session dates, degrades to count-only.
- **Living stats** — sessions played, last played, live-now chip, per-kind counts; all from already-loaded state (viewer projection applies).
- **The Party** — roster from `campaign_members` joined client-side with the new `profiles` table (names/avatars); wax-seal DM badge. Read-only — management is #86.
- **At the table** — active `presence_users` as a live strip (already realtime-synced).
- **Sessions ledger** — newest-first with recap snippets (session `summary`), latest 10 + expander, rows open the existing detail sheet.

## ⚠️ Product change: going live is now DM-only

Migration 0020 replaces 0006's open `member write campaigns` FOR ALL policy with a **DM-only UPDATE policy** (`is_campaign_dm`). Since `active_session_id` lives on the campaigns row, **non-DM editors can no longer move the live-session pin** — their SessionPin dropdown is replaced by the viewer's static label. Decided with Kris during planning. The dropped FOR ALL policy also carried INSERT/DELETE: campaigns become client deny-all for those verbs until #87 (campaign CRUD).

## Migration `0020_campaign_charter.sql`

1. `campaigns.image_url` (crest).
2. DM-only campaigns UPDATE policy (above).
3. `profiles(user_id, display_name, avatar_url)` — public mirror of editor identity (auth metadata is self-only); each editor's client upserts its own row on session load (AuthProvider effect). Open SELECT is deliberate (same posture as `campaign_members`); deviates knowingly from the issue's "no new tables" AC.

## Also fixed in passing

- Realtime campaigns handler swallowed a cleared subtitle (`?? c.subtitle` on a null) — now maps null → `""`; same treatment for `image_url`. The picker summaries list is now patched live for the active campaign.
- The campaign chip rendered a dangling "·" when the subtitle is empty.

## Rollout

Apply 0020 first, then deploy this client back-to-back (not on a session night). Gap behavior on the old client: non-DM editors' go-live silently no-ops. Note: fendwick & fist-of-ilmater have no `campaign_members` rows yet — nobody can edit their charters until DM rows are inserted (dashboard/SQL, same as today for hide/stage).

## Verification

- `npm run build` clean (tsc + vite).
- **Migration 0020 applied to prod** via the Management API and recorded in `schema_migrations`; verified: `member write campaigns` gone, `dm updates campaign` present, `campaigns.image_url` + `profiles` (3 policies) live.
- Browser e2e (dev server on 5173, dev-editor session):
  - Picker dropdown shows all 3 campaigns + "VIEW CHARTER" footer; charter opens from it.
  - **Non-DM editor on fendwick**: charter fully read-only (no EditableText, no upload-crest), "FI" procedural seal, stats match sidebar (16/8/6/0/3/2/3), empty roster/ledger states render. SessionPin hidden (new DM-only gate).
  - **DM on test-campaingn**: dashed-editable title/subtitle, "upload crest" affordance, "1 session chronicled" epigraph, LAST PLAYED tile, roster shows **Dev + DM wax-seal badge** (profiles upsert → JS join works — row confirmed via anon REST), ledger row with recap snippet.
  - **Rename round-trip**: title edited to "The Grand Test Campaign" → persisted (REST-confirmed) → picker chip updated **live in the same tab via realtime, no reload, no flash-back**; the procedural seal re-derived "TC"→"GT" live. Reverted to "Test Campaign" the same way.
  - **RLS rejection (AC)**: in-page `supabase.from("campaigns").update({title:"hax attempt"}).eq("id","fendwick")` as the authenticated non-DM editor → `data: []`, no error, title unchanged.
  - **View-as-player**: banner on, upload-crest + editable fields gone, PEOPLE stat dropped 2→1 (viewer projection strips the hidden wayfarer from counts too). GO LIVE pin correctly survives (isRealDm write control).
- Not exercised: actual crest file upload (affordance renders; code path mirrors the proven EntityPortrait flow) and a true anonymous tab (the read-only rendering path is identical to the verified non-DM view minus `canEdit`).

## Incident found & fixed during verification (prod, out of band)

`public.presence_users` had been dropped from prod **outside the migration chain** (no migration drops it) — every campaign load selects it, so **prod was hard-down** ("THE PAGES WILL NOT TURN") before this PR's work. With Kris's approval I recreated it via the Management API: 0001 schema + 0006-style policies + explicit grants + realtime publication, **without** the old fixture seed rows (real presence is #74). Prod loads again. How it got dropped is unconfirmed — worth keeping an eye on the Supabase branching integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
