### PR TITLE
Derive reveal chips on the detail sheet from the session_events log

### DIFF
--- a/src/detail.tsx
+++ b/src/detail.tsx
@@ -514,6 +514,31 @@ export function DetailSheet({ entityId, onClose, onOpen }: DetailSheetProps) {
       });
     }
   }
+  // Reveal chips, derived from the session_events log rather than stored as
+  // connections rows — releaseEntity/showEntity already record the fact, so a
+  // second table would just drift (re-hide, unstage, event delete). A session's
+  // sheet lists what surfaced during it; an entity's sheet points back at the
+  // sessions that revealed it. Curated chips win: any existing chip for the
+  // same pair (manual string, introduced in / last seen in) suppresses the
+  // derived one, mirroring how FK edges yield to manual strings. Hidden-entity
+  // reveals are already projected out for players, so nothing leaks here.
+  {
+    const revealSeen = new Set<string>();
+    campaign.sessionEvents.forEach((ev) => {
+      if (ev.type !== "reveal" || !ev.entityId || !ev.sessionId) return;
+      if (kind === "sessions" ? ev.sessionId !== entityId : ev.entityId !== entityId) return;
+      const otherId = kind === "sessions" ? ev.entityId : ev.sessionId;
+      if (revealSeen.has(otherId)) return; // re-reveals collapse to the first
+      revealSeen.add(otherId);
+      const other = findEntity(otherId);
+      if (!other) return;
+      const k = kind === "sessions" ? (other._kind as string) : "sessions";
+      related[k] = related[k] || [];
+      if (!related[k].find((r) => r.entity.id === other.id)) {
+        related[k].push({ entity: other, rel: kind === "sessions" ? "revealed this session" : "revealed in" });
+      }
+    });
+  }
 
   const patch = (fields: Record<string, unknown>) =>
     updateEntity(kind, entityId, fields).catch((e) =>


### PR DESCRIPTION
## What

Show which entities were **revealed** in a session, and which sessions revealed an entity, as relation chips on the detail sheet — the "derive route" from the design discussion, chosen over auto-generating `connections` rows.

- **Session sheet** → lists every entity that surfaced during it (`revealed this session`), grouped under the usual kind sections.
- **Entity sheet** → points back at the sessions that revealed it (`revealed in`).

## Why derive instead of store

`releaseEntity`/`showEntity` already write a `session_events` reveal row carrying `session_id` + `entity_id`. A parallel `connections` edge would be a second source of truth with no cleanup story — re-hiding, unstaging, or deleting an event wouldn't retract the edge, and (since `connections` refetches the whole table on any change) every release mid-live-session would fan out full refetches. Deriving is free, retroactive for all past sessions, and can't drift.

## Behavior details

- **Curated chips win**: an existing manual string or `introduced in` / `last seen in` chip for the same pair suppresses the derived one — mirroring how FK edges yield to manual strings elsewhere on the rail.
- **Re-reveals collapse** to the first occurrence.
- **Hidden-entity reveals** are already projected out for players (`projectForViewer`), so nothing leaks.

## Verification

Verified live against the `test-campaingn` data in the running dev app:

- **Session 2's sheet** shows `Noob 56 — MET` (its existing manual connection suppressed the derived chip, as designed) and `Test NPC — REVEALED THIS SESSION`.
- **Test NPC's sheet** shows `The Dance Of The Humblebee — LAST SEEN IN` (existing chip wins for that session) and `Test Session One — REVEALED IN`.
- `npm run build` passes; zero console errors in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)