### PR TITLE
Live panel: 'now showing' spotlight card for the latest ⚡ show

### DIFF
--- a/src/livePanel.tsx
+++ b/src/livePanel.tsx
@@ -165,6 +165,7 @@ function DmSection({ sessionId, onOpenEntity }: { sessionId: string; onOpenEntit
 
 export function LivePanel({ onOpenEntity }: { onOpenEntity: (id: string) => void }) {
   const campaign = useCampaign();
+  const findEntity = useFindEntity();
   const presenceUsers = usePresence();
   const isDm = useIsDm();
   const { canEdit, displayName } = useAuth();
@@ -178,6 +179,15 @@ export function LivePanel({ onOpenEntity }: { onOpenEntity: (id: string) => void
 
   const sessionId = campaign.activeSessionId ?? null;
   const events = campaign.sessionEvents.filter((e) => e.sessionId === sessionId);
+
+  // "Now showing" (this session's latest ⚡ show whose entity still resolves):
+  // pinned above the feed rather than reordering it — the feed stays a
+  // chronological chat, but the thing currently on display keeps a persistent
+  // slot with its portrait. Quiet 🕯 releases don't qualify; the takeover is
+  // the "everyone look at this" act. A re-hidden or deleted entity drops out
+  // of findEntity, so the card retires itself with the projection.
+  const lastShow = events.filter(isShowEvent).at(-1);
+  const shownEnt = lastShow ? findEntity(lastShow.entityId) : null;
 
   // Going live (or switching sessions) re-opens a collapsed panel — the state
   // change is the moment the panel earns attention again.
@@ -240,6 +250,30 @@ export function LivePanel({ onOpenEntity }: { onOpenEntity: (id: string) => void
           <Icon name="chevron" size={12} />
         </button>
       </header>
+
+      {lastShow && shownEnt && (
+        <div
+          className="live-spotlight"
+          onClick={() => onOpenEntity(shownEnt.id)}
+          title="Open in the codex"
+        >
+          {shownEnt.imageUrl ? (
+            <img className="live-spotlight-img" src={shownEnt.imageUrl} alt={entityLabel(shownEnt)} />
+          ) : (
+            <div className="live-spotlight-icon">
+              <Icon name={kindIcon[shownEnt._kind as KindKey]} size={22} />
+            </div>
+          )}
+          <div className="live-spotlight-body">
+            <div className="live-spotlight-kicker">⚡ NOW SHOWING</div>
+            <div className="live-spotlight-label">{entityLabel(shownEnt)}</div>
+            <div className="live-meta">
+              <span>{lastShow.author ? `by ${lastShow.author}` : ""}</span>
+              <span>{fmtTime(lastShow.createdAt)}</span>
+            </div>
+          </div>
+        </div>
+      )}
 
       <div
         className="live-feed"

--- a/src/styles.css
+++ b/src/styles.css
@@ -2691,6 +2691,50 @@ button.session-pin { line-height: 1; }
   color: var(--ink-secondary);
   margin: 4px 0;
 }
+/* Spotlight card: the session's latest ⚡ show, pinned between the header and
+   the feed — portrait plus label, one click back into the codex. */
+.live-spotlight {
+  display: flex; align-items: center; gap: 10px;
+  flex-shrink: 0;
+  margin: 10px 12px 0;
+  padding: 8px;
+  background: color-mix(in srgb, var(--mustard) 20%, var(--vellum-light));
+  border: 1px solid var(--mustard);
+  cursor: pointer;
+}
+.live-spotlight:hover {
+  background: color-mix(in srgb, var(--mustard) 28%, var(--vellum-light));
+}
+.live-spotlight-img,
+.live-spotlight-icon {
+  width: 56px; height: 56px;
+  flex-shrink: 0;
+  border: 1px solid var(--ink);
+}
+.live-spotlight-img {
+  object-fit: cover;
+  filter: sepia(.2) contrast(.95);
+}
+.live-spotlight-icon {
+  display: flex; align-items: center; justify-content: center;
+  background: var(--vellum-dark);
+  color: var(--ink-secondary);
+}
+.live-spotlight-body { flex: 1; min-width: 0; }
+.live-spotlight-kicker {
+  font-family: var(--font-fell-sc);
+  letter-spacing: .18em;
+  font-size: 10px;
+  color: var(--ink-secondary);
+}
+.live-spotlight-label {
+  font-family: var(--font-fell-sc);
+  font-size: 15px;
+  line-height: 1.2;
+  color: var(--ink);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.live-spotlight .live-meta { margin-top: 3px; }
 
 /* DM's desk: tonight's staged queue + end-session control. */
 .live-dm {


### PR DESCRIPTION
Closes Part A of #96.

## What

Pins the session's most recent `⚡` takeover show above the live feed as a **"⚡ NOW SHOWING"** card — the shown entity's portrait (kind-icon fallback when there's no image), name, author, and time. Clicking it opens the entity in the codex.

## Why

The feed is a flat chronological chat, so the character currently on display was just another gold row — and repeated shows of the same entity stack into identical rows. The card gives "what's on display right now" a persistent, portrait-bearing slot without disturbing the feed's chronology (it's also the note chat, and sticky-scroll already keeps the newest row in view).

## Behaviour

- Only `⚡` takeover shows claim the card — quiet 🕯 releases don't (the takeover is the "everyone look at this" act).
- Reflects the session's **latest** show; updates on each new one.
- A deleted or re-hidden entity drops out of the viewer projection, so the card retires itself automatically.

## Scope

Part B of #96 (desk search-to-show for recurring cast) and the duplicate-show collapse (#97) are separate follow-ups, not in this PR.

## Verification

Built (`npm run build` clean) and exercised in the browser against a live session: the card renders with the shown character's portrait, updates across multiple shows, and clicking it opens the detail sheet. No console errors.

## Files

- `src/livePanel.tsx` — `.live-spotlight` card computation + render
- `src/styles.css` — card styling (matches the gold reveal-row language and the detail sheet's sepia portrait treatment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)