### PR TITLE
Default theme: Modern Atlas

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 <div id="root"></div>
 <script>
   const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
-    "theme": "grimoire",
+    "theme": "modern",
     "showPresence": true,
     "density": "cozy"
   }/*EDITMODE-END*/;


### PR DESCRIPTION
## Summary

Flips the `TWEAK_DEFAULTS` theme in `index.html` from `grimoire` to `modern`, so fresh visitors land in the Modern Atlas look shipped in #101. Persisted host-page tweaks are unaffected; the other themes stay selectable in the Tweaks panel.

## Test plan

- [x] `npm run build` passes
- [x] Fresh load verified in dev: `data-theme="modern"` on boot with no interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)