### PR TITLE
Modern Atlas dress for the live panel's Now Showing spotlight

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -3493,6 +3493,36 @@ button.session-pin { line-height: 1; }
 }
 [data-theme="modern"] .live-reveal.linked:hover { background: rgba(208,165,72,.14); }
 [data-theme="modern"] .live-reveal em { font-family: var(--font-ui); font-weight: 600; color: var(--ink); letter-spacing: 0; }
+/* Spotlight (latest ⚡ show): same gold-ceremony dress as reveal rows —
+   translucent wash + rim instead of the parchment's solid gold frame. */
+[data-theme="modern"] .live-spotlight {
+  background: rgba(208,165,72,.08);
+  border: 1px solid rgba(208,165,72,.35);
+  border-radius: 10px;
+}
+[data-theme="modern"] .live-spotlight:hover { background: rgba(208,165,72,.14); }
+[data-theme="modern"] .live-spotlight-img,
+[data-theme="modern"] .live-spotlight-icon {
+  border: 1px solid var(--card-edge);
+  border-radius: 6px;
+}
+[data-theme="modern"] .live-spotlight-img { filter: none; }
+[data-theme="modern"] .live-spotlight-icon {
+  background: linear-gradient(160deg, #252a38, #191c26);
+  color: #454c60;
+}
+[data-theme="modern"] .live-spotlight-kicker {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: .08em;
+  color: var(--mustard);
+}
+[data-theme="modern"] .live-spotlight-label {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 17px;
+  letter-spacing: 0;
+}
 [data-theme="modern"] .live-marker { font-size: 10.5px; letter-spacing: .04em; color: var(--ink-secondary); }
 [data-theme="modern"] .live-empty { font-style: normal; font-size: 12px; color: var(--ink-ghost); }
 [data-theme="modern"] .live-dm { background: #161923; }


### PR DESCRIPTION
## Summary

The "Now Showing" spotlight card (#100) merged in parallel with the Modern Atlas theme (#101), so the new theme's override layer never covered it — on the dark panel it still rendered with its parchment dress (solid `--mustard` frame, square corners, sepia'd portrait, `color-mix` mustard wash).

This restyles it under `[data-theme="modern"]` to the same gold-ceremony language the reveal rows use: `rgba(208,165,72,.08)` wash with a `.35`-alpha rim, 10px radius, rounded gradient icon tile (no sepia on portraits), gold Inter kicker, Cormorant Garamond display label. Parchment themes are untouched.

## Test plan

- [x] `npm run build` passes
- [x] Visual verification via a static replica of the live-panel markup in the Modern theme (spotlight + reveal row + note row side by side) — spotlight now reads as the reveal rows' hero sibling

🤖 Generated with [Claude Code](https://claude.com/claude-code)