### PR TITLE
Modern Atlas topbar & toolbar: breadcrumb, search chip, terse voice

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -282,7 +282,7 @@ function AppLoaded() {
   return (
     <>
       <div className="app">
-        <Topbar onShare={onShare} onOpenCharter={() => setView("campaign")} />
+        <Topbar view={view} onShare={onShare} onOpenCharter={() => setView("campaign")} onSearch={() => setPaletteOpen(true)} />
         <Sidebar active={view} onSelect={setView} onOpenEntity={setOpenId} onOpenCleanup={() => setCleanupOpen(true)} counts={counts} />
         <main className="main">
           {view === "board" && (

--- a/src/board.tsx
+++ b/src/board.tsx
@@ -11,7 +11,7 @@ import {
 import { CompassRose, Icon, kindIcon } from "./icons";
 import { useCampaign, useDismiss, useFindEntity, useKinds } from "./hooks";
 import { useAuth } from "./auth";
-import { CardBody, PinnedCard } from "./components";
+import { CardBody, PinnedCard, ThemedLabel } from "./components";
 import { entityLabel, sessionLabel } from "./data";
 import { computeTidyLayout, cardDims, findFreeSpot } from "./boardLayout";
 import { deriveRelations } from "./relations";
@@ -521,7 +521,7 @@ export function NoticeBoard({
           disabled={tidying}
           title="Auto-arrange the board: connected cards cluster, same-kind cards group, starred cards stay put"
         >
-          <Icon name="sparkle" size={14} /> {tidying ? "Tidying…" : "Tidy board"}
+          <Icon name="sparkle" size={14} /> <ThemedLabel parchment={tidying ? "Tidying…" : "Tidy board"} atlas={tidying ? "Tidying…" : "Tidy"} />
         </button>}
 
         {canEdit && <button
@@ -529,16 +529,16 @@ export function NoticeBoard({
           onClick={() => { setConnectMode((m) => !m); setConnectSource(null); }}
           title="Draw a connection between two cards"
         >
-          <Icon name="link" size={14} /> {connectMode ? "Cancel string" : "Draw string"}
+          <Icon name="link" size={14} /> <ThemedLabel parchment={connectMode ? "Cancel string" : "Draw string"} atlas={connectMode ? "Cancel" : "Connect"} />
         </button>}
 
         {canEdit && <div style={{ position: "relative" }} ref={addMenuRef}>
           <button
-            className="btn btn-primary"
+            className="btn btn-primary btn-newcard"
             onClick={() => setAddMenuOpen((o) => !o)}
             title="Pin a new card to the board"
           >
-            <Icon name="plus" size={14} /> Pin new
+            <Icon name="plus" size={14} /> <ThemedLabel parchment="Pin new" atlas="New card" />
           </button>
           {addMenuOpen && (
             <div className="view-menu" style={{ minWidth: 180 }}>

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -192,6 +192,18 @@ export function CardBody({ entity, kind }: { entity: any; kind: KindKey }) {
 
 // Decorative ✦ flourishes around small-caps kind tags. A real span (not CSS
 // content) so the Modern Atlas theme can hide them and swap in its own dot.
+// Modern Atlas speaks a terser UI voice than the parchment themes ("Tidy"
+// vs "Tidy board", "S191" vs "Session 191"). Both labels render; the theme
+// CSS shows exactly one — same override-layer pattern as the visual dress.
+export function ThemedLabel({ parchment, atlas }: { parchment: React.ReactNode; atlas: React.ReactNode }) {
+  return (
+    <>
+      <span className="label-parchment">{parchment}</span>
+      <span className="label-atlas">{atlas}</span>
+    </>
+  );
+}
+
 export function Fleurons({ children }: { children: React.ReactNode }) {
   return (
     <>
@@ -589,11 +601,11 @@ function CampaignPicker({ onOpenCharter }: { onOpenCharter: () => void }) {
         style={{ cursor: "pointer" }}
       >
         <span className="dot" />
-        <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".1em", fontSize: 11 }}>CAMPAIGN</span>
-        <span>·</span>
-        <span style={{ fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 15 }}>{campaign.title}</span>
+        <span className="campaign-chip-kicker">CAMPAIGN</span>
+        <span className="campaign-chip-sep">·</span>
+        <span className="campaign-chip-title">{campaign.title}</span>
         {campaign.subtitle && (
-          <span style={{ color: "var(--ink-secondary)", fontStyle: "italic", fontSize: 12 }}>· {campaign.subtitle}</span>
+          <span className="campaign-chip-sub">· {campaign.subtitle}</span>
         )}
         {canSwitch && (
           <Icon name="chevron" size={11} style={{ transform: open ? "rotate(-90deg)" : "rotate(90deg)", color: "var(--ink-faded)", flexShrink: 0 }} />
@@ -714,9 +726,9 @@ function SessionPin() {
     return (
       <div className="session-pin">
         <span className={"pin-dot live"} />
-        <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".1em", fontSize: 11 }}>LIVE</span>
-        <span>·</span>
-        <span style={{ fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 14 }}>Session {live.num}</span>
+        <span className="pin-kicker"><ThemedLabel parchment="LIVE" atlas="Live" /></span>
+        <span className="pin-sep">·</span>
+        <span className="pin-session"><ThemedLabel parchment={`Session ${live.num}`} atlas={sessionLabel(live.num)} /></span>
       </div>
     );
   }
@@ -752,8 +764,8 @@ function SessionPin() {
         title={live ? "Switch or stand down" : "Go live on a session"}
       >
         <span className={"pin-dot" + (live ? " live" : "")} />
-        <span style={{ fontFamily: "var(--font-fell-sc)", letterSpacing: ".1em", fontSize: 11 }}>{live ? "LIVE" : "GO LIVE"}</span>
-        {live && <><span>·</span><span style={{ fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 14 }}>{label}</span></>}
+        <span className="pin-kicker"><ThemedLabel parchment={live ? "LIVE" : "GO LIVE"} atlas={live ? "Live" : "Go live"} /></span>
+        {live && <><span className="pin-sep">·</span><span className="pin-session"><ThemedLabel parchment={label} atlas={sessionLabel(live.num)} /></span></>}
         <Icon name="chevron" size={11} style={{ transform: open ? "rotate(-90deg)" : "rotate(90deg)", color: "var(--ink-faded)", flexShrink: 0 }} />
       </button>
       {open && (
@@ -785,23 +797,48 @@ function SessionPin() {
   );
 }
 
-export function Topbar({ onShare, onOpenCharter }: { onShare: () => void; onOpenCharter: () => void }) {
+export function Topbar({ view, onShare, onOpenCharter, onSearch }: {
+  view: string;
+  onShare: () => void;
+  onOpenCharter: () => void;
+  onSearch: () => void;
+}) {
   const presenceUsers = usePresence();
+  const kinds = useKinds();
   const { canEdit, displayName, avatarUrl, signOut } = useAuth();
   const { isRealDm, viewAsPlayer, setViewAsPlayer } = useViewAsPlayer();
   const [signingIn, setSigningIn] = useState(false);
+  // Breadcrumb tail (Modern Atlas only, via CSS): "campaign / where you are".
+  const viewLabel =
+    view === "board" ? "Notice Board"
+    : view === "arcs" ? "Story Arcs"
+    : view === "events" ? "Events"
+    : view === "campaign" ? "Charter"
+    : kinds.find((k) => k.key === view)?.label ?? "";
   return (
     <header className="topbar">
       <div className="logo">
         <div className="logo-mark"><Icon name="compass" size={18} /></div>
         <div>
-          <div className="logo-title">THE CODEX</div>
+          <div className="logo-title"><ThemedLabel parchment="THE CODEX" atlas="Codex" /></div>
           <div className="logo-sub">a shared journal</div>
         </div>
       </div>
       <div className="topbar-center">
         <CampaignPicker onOpenCharter={onOpenCharter} />
+        {viewLabel && (
+          <>
+            <span className="topbar-crumb-sep" aria-hidden>/</span>
+            <span className="topbar-crumb">{viewLabel}</span>
+          </>
+        )}
+        <div className="topbar-center-gap" aria-hidden />
         <SessionPin />
+        <button className="topbar-search" onClick={onSearch} title="Search the codex (⌘K)">
+          <Icon name="search" size={12} />
+          <span>Search the codex…</span>
+          <kbd>⌘K</kbd>
+        </button>
       </div>
       <div className="topbar-right">
         <Presence users={presenceUsers} />
@@ -817,30 +854,31 @@ export function Topbar({ onShare, onOpenCharter }: { onShare: () => void; onOpen
             <Icon name="eye" size={14} /> View as player
           </button>
         )}
-        <button className="btn" onClick={onShare}><Icon name="share" size={14} /> Share link</button>
+        <button className="btn" onClick={onShare}><Icon name="share" size={14} /> <ThemedLabel parchment="Share link" atlas="Share" /></button>
         {canEdit ? (
           <>
-            {avatarUrl && (
+            {avatarUrl ? (
               <img
                 src={avatarUrl}
                 alt=""
                 referrerPolicy="no-referrer"
-                style={{
-                  width: 20, height: 20, borderRadius: "50%",
-                  border: "1px solid var(--ink-faded)", objectFit: "cover",
-                }}
+                className="avatar-self"
+                title={displayName || undefined}
               />
+            ) : (
+              // Atlas-only fallback (CSS-gated): the design's initial disc, so
+              // the account always has a face even without a Discord avatar.
+              <span className="avatar-self-initial" title={displayName || undefined} aria-hidden>
+                {(displayName || "?").trim().charAt(0).toUpperCase()}
+              </span>
             )}
             {/* Functional micro-text, not flavor — the UI face reads better
                 than 12px italic serif. */}
-            <span style={{
-              fontFamily: "var(--font-ui)",
-              fontSize: 12, color: "var(--ink-secondary)",
-            }}>
+            <span className="topbar-account-name">
               {displayName}
             </span>
             <button
-              className="btn"
+              className="btn topbar-signout"
               onClick={() => { signOut().catch(console.error); }}
               title="Sign out and return to read-only viewing"
             >

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -190,8 +190,6 @@ export function CardBody({ entity, kind }: { entity: any; kind: KindKey }) {
   );
 }
 
-// Decorative ✦ flourishes around small-caps kind tags. A real span (not CSS
-// content) so the Modern Atlas theme can hide them and swap in its own dot.
 // Modern Atlas speaks a terser UI voice than the parchment themes ("Tidy"
 // vs "Tidy board", "S191" vs "Session 191"). Both labels render; the theme
 // CSS shows exactly one — same override-layer pattern as the visual dress.
@@ -204,6 +202,8 @@ export function ThemedLabel({ parchment, atlas }: { parchment: React.ReactNode; 
   );
 }
 
+// Decorative ✦ flourishes around small-caps kind tags. A real span (not CSS
+// content) so the Modern Atlas theme can hide them and swap in its own dot.
 export function Fleurons({ children }: { children: React.ReactNode }) {
   return (
     <>

--- a/src/styles.css
+++ b/src/styles.css
@@ -3090,11 +3090,20 @@ button.session-pin { line-height: 1; }
 /* Topbar buttons drop their engraving icons ("Share", not "⎋ Share link"). */
 [data-theme="modern"] .topbar .btn svg { display: none; }
 [data-theme="modern"] .topbar-right { gap: 10px; }
-[data-theme="modern"] .topbar-account-name { display: none; }
+/* Visually hidden, NOT display:none — the avatar art is aria-hidden/alt="",
+   so this span must stay in the accessibility tree to name the account. */
+[data-theme="modern"] .topbar-account-name {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
 [data-theme="modern"] .topbar-signout {
   background: transparent;
   border-color: transparent;
-  color: var(--ink-ghost);
+  color: var(--ink-secondary);
   padding: 6px 8px;
 }
 [data-theme="modern"] .topbar-signout:hover { color: var(--ink); border-color: transparent; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -384,6 +384,27 @@ body {
   display: flex; align-items: center; gap: 14px;
 }
 
+/* Themed label pairs (see <ThemedLabel/>): the parchment voice is the
+   default; Modern Atlas flips the pair in its override layer. */
+.label-atlas { display: none; }
+
+/* Modern Atlas topbar furniture — breadcrumb tail, flex gap, and the search
+   chip only exist in the Atlas dress; parchment keeps the centered chips. */
+.topbar-crumb-sep, .topbar-crumb, .topbar-center-gap, .topbar-search { display: none; }
+
+/* Signed-in account cluster (topbar right). */
+.avatar-self {
+  width: 20px; height: 20px; border-radius: 50%;
+  border: 1px solid var(--ink-faded);
+  object-fit: cover;
+}
+.avatar-self-initial { display: none; } /* Atlas-only initial disc */
+.topbar-account-name {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  color: var(--ink-secondary);
+}
+
 /* Breadcrumb / campaign */
 .campaign-chip {
   display: flex; align-items: center; gap: 10px;
@@ -407,6 +428,9 @@ body {
   box-shadow: 0 0 0 2px rgba(138,42,31,.25);
   flex-shrink: 0;
 }
+.campaign-chip-kicker { font-family: var(--font-fell-sc); letter-spacing: .1em; font-size: 11px; }
+.campaign-chip-title { font-family: var(--font-display); font-weight: 600; font-size: 15px; }
+.campaign-chip-sub { color: var(--ink-secondary); font-style: italic; font-size: 12px; }
 
 /* Campaign picker (Topbar) — the chip is the trigger, menu drops below it. */
 .campaign-picker { position: relative; max-width: 100%; }
@@ -551,6 +575,8 @@ body {
   cursor: pointer;
 }
 button.session-pin { line-height: 1; }
+.session-pin .pin-kicker { font-family: var(--font-fell-sc); letter-spacing: .1em; font-size: 11px; }
+.session-pin .pin-session { font-family: var(--font-display); font-weight: 600; font-size: 14px; }
 .session-pin .pin-dot {
   width: 8px; height: 8px; border-radius: 50%;
   background: var(--ink-ghost);
@@ -2920,7 +2946,7 @@ button.session-pin { line-height: 1; }
    except the short category kind-tags (.loc-type/.goal-kind/.i-label):
    those are user-typed but render as category labels, and the other themes
    already small-cap them via IM Fell SC — uppercase is the same treatment. */
-[data-theme="modern"] :is(.sidebar-label, .logo-title, .sb-kind, .stat-label,
+[data-theme="modern"] :is(.sidebar-label, .sb-kind, .stat-label,
   .detail-notes h3, .rail-section h4, .cmdk-kind, .live-head, .live-vertical,
   .live-dm-head, .cleanup-group-title, .quest-tag, .loc-type, .goal-kind,
   .i-label, .l-label, .card-poster .wanted, .card-poster .deceased-tag,
@@ -2967,12 +2993,17 @@ button.session-pin { line-height: 1; }
 [data-theme="modern"] .logo-title {
   font-family: var(--font-ui);
   font-weight: 600;
-  font-size: 12.5px;
-  letter-spacing: .08em;
+  font-size: 13.5px;
+  letter-spacing: 0;
   color: var(--ink);
 }
 [data-theme="modern"] .logo-sub { display: none; }
 
+/* Terser Atlas voice: <ThemedLabel/> pairs flip from parchment to atlas. */
+[data-theme="modern"] .label-parchment { display: none; }
+[data-theme="modern"] .label-atlas { display: inline; }
+
+/* Campaign chip collapses to the breadcrumb head: bare title + chevron. */
 [data-theme="modern"] .campaign-chip {
   background: transparent;
   border: none;
@@ -2980,9 +3011,54 @@ button.session-pin { line-height: 1; }
   font-family: var(--font-ui);
   font-size: 13px;
   color: var(--ink);
-  padding: 5px 8px;
+  padding: 5px 6px;
+  gap: 8px;
 }
-[data-theme="modern"] .campaign-chip .dot { width: 7px; height: 7px; box-shadow: none; }
+[data-theme="modern"] .campaign-chip .dot,
+[data-theme="modern"] .campaign-chip-kicker,
+[data-theme="modern"] .campaign-chip-sep,
+[data-theme="modern"] .campaign-chip-sub { display: none; }
+[data-theme="modern"] .campaign-chip-title {
+  font-family: var(--font-ui);
+  font-weight: 500;
+  font-size: 13px;
+}
+
+/* Breadcrumb tail + left-aligned center row: campaign ⌄ / view … live · search */
+[data-theme="modern"] .topbar-center { justify-content: flex-start; gap: 8px; min-width: 0; }
+[data-theme="modern"] .topbar-center-gap { display: block; flex: 1; }
+[data-theme="modern"] .topbar-crumb-sep { display: inline; color: #3d4353; font-size: 13px; }
+[data-theme="modern"] .topbar-crumb {
+  display: inline;
+  font-family: var(--font-ui);
+  font-size: 13px;
+  color: var(--ink-secondary);
+  white-space: nowrap;
+}
+
+/* Search chip — opens the ⌘K palette. Not a .btn, so it keeps its icon. */
+[data-theme="modern"] .topbar-search {
+  display: flex; align-items: center; gap: 7px;
+  width: 210px;
+  padding: 5px 10px;
+  background: var(--vellum-dark);
+  border: 1px solid var(--card-edge);
+  border-radius: 6px;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  color: var(--ink-secondary);
+  cursor: pointer;
+  white-space: nowrap;
+}
+[data-theme="modern"] .topbar-search:hover { border-color: #3d4353; color: var(--ink); }
+[data-theme="modern"] .topbar-search kbd {
+  margin-left: auto;
+  font-family: var(--font-ui);
+  font-size: 10px;
+  border: 1px solid var(--card-edge);
+  border-radius: 3px;
+  padding: 0 4px;
+}
 
 [data-theme="modern"] .session-pin {
   background: var(--vellum-dark);
@@ -2990,9 +3066,19 @@ button.session-pin { line-height: 1; }
   border-radius: 14px;
   box-shadow: none;
   font-family: var(--font-ui);
-  font-size: 12px;
+  font-size: 11px;
   color: var(--ink-body);
+  gap: 7px;
+  padding: 4px 11px;
 }
+[data-theme="modern"] .session-pin .pin-kicker,
+[data-theme="modern"] .session-pin .pin-session {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+[data-theme="modern"] .session-pin .pin-dot { width: 6px; height: 6px; }
 /* Live: the red occupancy pill from the design's topbar. */
 [data-theme="modern"] .session-pin:has(.pin-dot.live) {
   background: rgba(224,90,74,.12);
@@ -3000,6 +3086,29 @@ button.session-pin { line-height: 1; }
   color: var(--bloodred-deep);
 }
 [data-theme="modern"] .session-pin .pin-dot.live { box-shadow: none; animation: none; }
+
+/* Topbar buttons drop their engraving icons ("Share", not "⎋ Share link"). */
+[data-theme="modern"] .topbar .btn svg { display: none; }
+[data-theme="modern"] .topbar-right { gap: 10px; }
+[data-theme="modern"] .topbar-account-name { display: none; }
+[data-theme="modern"] .topbar-signout {
+  background: transparent;
+  border-color: transparent;
+  color: var(--ink-ghost);
+  padding: 6px 8px;
+}
+[data-theme="modern"] .topbar-signout:hover { color: var(--ink); border-color: transparent; }
+[data-theme="modern"] .avatar-self { width: 26px; height: 26px; border: none; }
+[data-theme="modern"] .avatar-self-initial {
+  display: grid; place-items: center;
+  width: 26px; height: 26px;
+  border-radius: 50%;
+  background: #a06a3a;
+  color: #fff;
+  font-family: var(--font-ui);
+  font-size: 10px;
+  font-weight: 600;
+}
 
 [data-theme="modern"] .campaign-picker-menu {
   background: var(--paper-cream);
@@ -3116,7 +3225,19 @@ button.session-pin { line-height: 1; }
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  background: var(--vellum-dark);
+  border: 1px solid var(--card-edge);
+  padding: 4px 10px;
+  color: var(--ink-body);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  border-radius: 6px;
 }
+/* Toolbar buttons speak in words, not engravings — except New card's "+". */
+[data-theme="modern"] .board-toolbar .btn svg { display: none; }
+[data-theme="modern"] .board-toolbar .btn-newcard svg { display: inline-block; }
+[data-theme="modern"] .board-toolbar .btn-ghost { color: var(--ink-secondary); }
+[data-theme="modern"] .board-toolbar .btn-ghost:hover { color: var(--ink); }
 [data-theme="modern"] .filter-pill {
   font-family: var(--font-ui);
   font-size: 11.5px;
@@ -3132,12 +3253,17 @@ button.session-pin { line-height: 1; }
   color: var(--ink);
 }
 [data-theme="modern"] .filter-pill .swatch { width: 7px; height: 7px; border-radius: 50%; }
-[data-theme="modern"] .session-focus { font-family: var(--font-ui); font-size: 12px; color: var(--ink-secondary); border-radius: 6px; }
+/* The session chip is self-boxed in Atlas (always bg + border, like the
+   mock's "S191 ⌄"), so the group's active box would double the chrome —
+   the on-state moves to the chip itself. */
 [data-theme="modern"] .filter-group.active {
-  background: var(--vellum-dark);
-  border-color: var(--card-edge);
-  border-radius: 6px;
+  background: transparent;
+  border-color: transparent;
   box-shadow: none;
+}
+[data-theme="modern"] .filter-group.active .session-focus {
+  color: var(--ink);
+  border-color: #3d4353;
 }
 [data-theme="modern"] .view-menu {
   background: var(--paper-cream);


### PR DESCRIPTION
## Summary

Brings the Codex top bars in line with the "Codex — Modern Atlas" design (claude.ai/design project), continuing the override-layer approach from #101–#104: shared markup gains classed elements, and everything Atlas-specific is CSS-gated to `[data-theme="modern"]` so the parchment themes render exactly as before.

**Topbar**
- Center row becomes the design's left-aligned breadcrumb: bare campaign title + chevron, then `/ Notice Board` (new `view` prop on `Topbar`, mapped to the sidebar labels), a flex gap, the compact red **Live · S191** pill, and a new 210px **Search the codex… ⌘K** chip that opens the command palette (new `onSearch` prop).
- Logo reads **Codex** (13.5px Inter 600) in Atlas; parchment keeps **THE CODEX / a shared journal**.
- Account cluster tightens to the design's 26px avatar — initial-disc fallback for editors without a Discord avatar — with the name text hidden (tooltip carries it) and Sign out quieted to a ghost button.

**Board toolbar**
- Buttons speak the Atlas voice: **Tidy**, **Connect**/**Cancel**, **+ New card**; engraving icons hidden except New card's plus.
- The session select is now a self-boxed `S191 ⌄` chip; the active-state chrome moves onto the chip, retiring the group's double box.

**Mechanism**: a new `<ThemedLabel parchment atlas>` primitive renders both voices of a label; theme CSS shows exactly one. Inline font styles on the campaign chip / session pin spans moved verbatim to classed base rules so the Atlas layer can override them.

## Verification

- `npm run build` (tsc + vite) passes.
- Verified in the dev server: Atlas topbar matches the mock (breadcrumb, search chip opens ⌘K palette, Share label), board toolbar chip styling; flipped `data-theme` to cartographer and confirmed the parchment topbar is unchanged. No console errors.
- Editor/DM-only surfaces (Tidy/Connect/New card, avatar, live pill) couldn't be exercised locally (localhost is off the auth redirect allowlist) but use the same verified `ThemedLabel`/CSS mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)