### PR TITLE
Fix unreadable native select dropdowns on Windows dark themes

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -213,6 +213,18 @@
   --hairline:      #262a36;
 }
 
+/* Native <select> popups are painted by the OS/browser, not our stylesheet.
+   Without a matching color-scheme, Windows renders the dark themes' light ink
+   onto its default light popup and the options vanish. Pin option colors too
+   for engines that honor them (Chromium on Windows does). */
+:root { color-scheme: light; }
+[data-theme="grimoire"],
+[data-theme="modern"] { color-scheme: dark; }
+select option {
+  background: var(--vellum-light);
+  color: var(--ink);
+}
+
 * { box-sizing: border-box; }
 html, body { margin: 0; padding: 0; height: 100%; }
 body {

--- a/src/styles.css
+++ b/src/styles.css
@@ -216,7 +216,8 @@
 /* Native <select> popups are painted by the OS/browser, not our stylesheet.
    Without a matching color-scheme, Windows renders the dark themes' light ink
    onto its default light popup and the options vanish. Pin option colors too
-   for engines that honor them (Chromium on Windows does). */
+   for engines that honor them (Chromium on Windows does). Any new dark theme
+   must be added to the dark list below or its popups regress to light. */
 :root { color-scheme: light; }
 [data-theme="grimoire"],
 [data-theme="modern"] { color-scheme: dark; }


### PR DESCRIPTION
## Problem

On Windows, opening a native `<select>` (e.g. the TIER dropdown on a person detail sheet) under the dark themes shows near-invisible options: light gray text on the OS default white popup.

Native option popups are painted by the OS/browser, not the app stylesheet. The dark themes set light ink colors on the select, but with no declared `color-scheme` Windows keeps painting the popup light.

## Fix

- `:root` declares `color-scheme: light` (parchment); `grimoire` and `modern` override to `dark`, so Windows paints their popups with the matching dark palette.
- `select option` gets explicit theme-aware `background`/`color` (`--vellum-light` / `--ink`) for engines that honor option styling (Chromium on Windows does).

Covers every native select — EnumSelect on the detail sheet, the sidebar arc picker, facet selects — with no component changes.

## Verified

Computed styles on a live select in the dev preview, per theme:

- parchment: `color-scheme: light`, `#1f160e` on `#f2e6c9`
- grimoire: `color-scheme: dark`, `#f3ecca` on `#24253a`
- modern: `color-scheme: dark`, `#eef0f5` on `#191c25`

`npm run build` typechecks clean. (The open popup itself cannot be screenshotted — an open native select popup blocks Chromium capture, which is itself confirmation that it is OS-rendered and only reachable via `color-scheme`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)