### PR TITLE
DM prep-time creations default to hidden

### DIFF
--- a/src/board.tsx
+++ b/src/board.tsx
@@ -9,7 +9,7 @@ import {
   isArchivableKind,
 } from "./data";
 import { CompassRose, Icon, kindIcon } from "./icons";
-import { useCampaign, useDismiss, useFindEntity, useKinds } from "./hooks";
+import { useCampaign, useDismiss, useFindEntity, useIsDm, useKinds } from "./hooks";
 import { useAuth } from "./auth";
 import { CardBody, PinnedCard, ThemedLabel } from "./components";
 import { entityLabel, sessionLabel } from "./data";
@@ -66,6 +66,7 @@ export function NoticeBoard({
   const findEntity = useFindEntity();
   const kinds = useKinds();
   const { canEdit } = useAuth();
+  const isDm = useIsDm();
 
   const positions = campaign.board;
   // Unified relationship edges: hand-drawn strings (connections table) + the
@@ -216,11 +217,19 @@ export function NoticeBoard({
   useDismiss(addMenuRef, addMenuOpen, () => setAddMenuOpen(false));
   useDismiss(viewMenuRef, viewMenuOpen, () => setViewMenuOpen(false));
 
+  // Creation-only visibility default: the DM's prep-time creations start
+  // hidden — there's no draft state, so a visible insert would broadcast the
+  // half-typed spoiler to every player. While a session is live the entity is
+  // usually "the thing the party just met", so it stays visible (and the
+  // effective isDm is false in view-as-player, where a hidden creation would
+  // vanish from the DM's own projected view).
+  const createHidden = isDm && !campaign.activeSessionId;
+
   const onCreate = async (k: Exclude<KindKey, "sessions" | "arcs" | "events">) => {
     setAddMenuOpen(false);
     const id = crypto.randomUUID();
     try {
-      await createEntity(k, id, NEW_ENTITY_DEFAULTS[k]);
+      await createEntity(k, id, { ...NEW_ENTITY_DEFAULTS[k], ...(createHidden ? { hidden: true } : {}) });
       // Creating a person while live implies they showed up this session —
       // auto-mark them seen (people have no session_id, so this is their
       // creation-only link, mirroring the events/quests default in createEntity).
@@ -690,6 +699,7 @@ export function KindList({ kind, onOpenEntity }: { kind: string; onOpenEntity: (
   const kinds = useKinds();
   const campaign = useCampaign();
   const { canEdit } = useAuth();
+  const isDm = useIsDm();
   const [showArchived, setShowArchived] = useState(false);
   // People facets: view filters, not writes — open to read-only viewers, like
   // the sidebar arc filter. Background folk hide behind a reveal by default so
@@ -763,7 +773,9 @@ export function KindList({ kind, onOpenEntity }: { kind: string; onOpenEntity: (
               title="Add a person to the codex without pinning them to the board"
               onClick={() => {
                 const id = crypto.randomUUID();
-                createEntity("people", id, NEW_ENTITY_DEFAULTS.people)
+                // Same prep-time visibility default as the board's "Pin new".
+                const hide = isDm && !campaign.activeSessionId;
+                createEntity("people", id, { ...NEW_ENTITY_DEFAULTS.people, ...(hide ? { hidden: true } : {}) })
                   .then(() => onOpenEntity(id))
                   .catch(console.error);
               }}


### PR DESCRIPTION
## Summary
- Entities the DM creates while **no session is live** now start `hidden: true` — the app has no draft state, so a visible insert broadcasts the half-typed spoiler to every connected player over realtime the moment the DM starts typing.
- Entities created **during a live session** stay visible (they're usually "the thing the party just met"), mirroring the creation-only session auto-link precedent in `createEntity`.
- The gate is the *effective* `isDm` (`useIsDm()`), so **view-as-player** and **player editors** keep creating visible entities — a hidden creation would instantly vanish from their own projected view and the post-create detail sheet couldn't resolve it.
- Applies to both hideable-kind creation surfaces in `board.tsx`: the board "Pin new" menu and the codex "New person" button. Sessions/arcs/events are untouched (no `hidden` column, per migration 0015). No migration — client-side seed only; the reveal machinery (STAGE / RELEASE / SHOW NOW) picks the entity up from there.

## Verification
`npm run build` passes. Full E2E on the dev server against the prod DB (dev-editor temporarily promoted to DM on `test-campaingn`, role/session/fixtures restored after):
- DM + live session → created visible, pinned, sheet opens
- DM + no session → created `hidden: true`; sheet opens veiled with ◈ UNREVEALED; board card wears the dashed badge; concealed in view-as-player (Known People count drops)
- DM in view-as-player + no session → created visible, sheet opens
- Player-role editor + live session → created visible
- Codex "New person" (DM, no session) → `hidden: true`, no board position

🤖 Generated with [Claude Code](https://claude.com/claude-code)