### PR TITLE
Notice board: hide background people by default

### DIFF
--- a/src/board.tsx
+++ b/src/board.tsx
@@ -300,6 +300,8 @@ export function NoticeBoard({
     if (!(filters as any)[pos.kind]) setFilters((f) => ({ ...f, [pos.kind]: true }));
     const ent = findEntity(id);
     if (ent && (ent as any).archived) setShowArchived(true);
+    if (ent && pos.kind === "people" && personTier(ent as any) === "background")
+      setShowBackground(true);
 
     const rect = canvasRef.current?.getBoundingClientRect();
     const c = centerOf(id);

--- a/src/board.tsx
+++ b/src/board.tsx
@@ -104,6 +104,8 @@ export function NoticeBoard({
   // FK-derived strings (dashed) can be hidden when the board gets busy; manual
   // strings always show. This also scopes Tidy to what's visible (see onTidy).
   const [showDerived, setShowDerived] = useState(true);
+  // Background-tier folk are tucked away by default, same as the People list.
+  const [showBackground, setShowBackground] = useState(false);
   const [scale, setScale] = useState(0.9);
   const [pan, setPan] = useState({ x: 0, y: 0 });
   const [panning, setPanning] = useState(false);
@@ -144,6 +146,8 @@ export function NoticeBoard({
     const ent = findEntity(id);
     if (!ent) return false;
     if (!showArchived && (ent as any).archived) return false;
+    if (!showBackground && pos.kind === "people" && personTier(ent as any) === "background")
+      return false;
     return true;
   };
 
@@ -439,7 +443,7 @@ export function NoticeBoard({
   const allKindsOn = kinds.every((k) => (filters as any)[k.key]);
   // Non-default view toggles get a dot on the View button so a filtered board
   // is never silent about it.
-  const viewNonDefault = showArchived || !showDerived;
+  const viewNonDefault = showArchived || !showDerived || showBackground;
 
   return (
     <>
@@ -488,7 +492,7 @@ export function NoticeBoard({
           <button
             className="btn btn-ghost"
             onClick={() => setViewMenuOpen((o) => !o)}
-            title="View options: archived cards, derived strings"
+            title="View options: archived cards, background people, derived strings"
           >
             <Icon name="eye" size={14} /> View
             {viewNonDefault && <span className="view-dot" title="View options changed from default" />}
@@ -502,6 +506,14 @@ export function NoticeBoard({
                   onChange={(e) => setShowArchived(e.target.checked)}
                 />
                 Show archived cards
+              </label>
+              <label className="view-menu-row" title="Include background-tier folk on the board">
+                <input
+                  type="checkbox"
+                  checked={showBackground}
+                  onChange={(e) => setShowBackground(e.target.checked)}
+                />
+                Show background people
               </label>
               <label className="view-menu-row" title="Show the dashed strings derived from relations (resides at, member of, quest giver)">
                 <input
@@ -631,10 +643,8 @@ export function NoticeBoard({
           </svg>
 
           {Object.entries(positions).map(([id, pos]) => {
-            if (!(filters as any)[pos.kind]) return null;
-            const entity = findEntity(id);
-            if (!entity) return null;
-            if (!showArchived && (entity as any).archived) return null;
+            if (!visible(id)) return null;
+            const entity = findEntity(id)!;
             const anim = tidyAnim?.[id];
             const dpos = anim ? { ...pos, x: anim.x, y: anim.y } : pos;
             return (


### PR DESCRIPTION
## Summary

Ships the "board-card gating by tier" follow-up promised in the `PersonTier` comment (src/data.ts): background-tier people are now hidden on the notice board by default, matching the People list's default reveal behavior.

- New **Show background people** checkbox in the board's View dropdown (next to "Show archived cards" / "Derived strings"), session-only local state like its neighbors.
- The gate lives in `visible()`, the single choke point shared by cards, strings, and Tidy — so strings whose endpoint is a hidden background card disappear automatically, and Tidy clusters only what's visible, with no extra logic.
- The card render loop now calls `visible(id)` instead of duplicating the kind-filter/archive checks inline, so the card gate and the string/Tidy gate can't drift.
- The View button's changed-from-default dot also lights for this toggle.

Tier is read through `personTier()` so null-tier rows still count as major. No DB changes; hiding is render-only and `board_positions` rows stay put.

## Test plan

- `npm run build` passes.
- Verified in the dev server by temporarily injecting `tier: "background"` on a board-positioned person at the mapping layer (reverted): card + its 3 strings (2 manual, 1 derived) hidden by default; toggle reveals them and lights the dot; toggling back re-hides; "Show archived cards" stays independent; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
